### PR TITLE
Fix lifetime issue of allocated memory by implicit transformation

### DIFF
--- a/Sources/Yams/Yams.swift
+++ b/Sources/Yams/Yams.swift
@@ -30,7 +30,9 @@ private class Document {
         defer { yaml_parser_delete(&parser) }
 
         yaml_parser_set_encoding(&parser, YAML_UTF8_ENCODING)
-        yaml_parser_set_input_string(&parser, string, string.utf8.count)
+        // `bytes` must be valid while `parser` exists.
+        let bytes = string.utf8.map { UInt8($0) }
+        yaml_parser_set_input_string(&parser, bytes, bytes.count)
         guard yaml_parser_load(&parser, &document) == 1 else {
             throw Error(problem: String(validatingUTF8: parser.problem)!,
                         problemOffset: parser.problem_offset)


### PR DESCRIPTION
On passing `String` as `UnsafePointer<UInt8>` arguments to function,
Swift implicitly creates null terminated UTF8 string buffer and passes the pointer to function.
That memory is released immediately on returning the function.
But, yaml_parser requires that is valid while `yaml_parser_t` exists.
This change extends lifetime of the buffer to end of function.

The issue was introduced by my commit 3125c9a. 🙇 