### PR TITLE
Remove unused `LIBRARY_SEARCH_PATHS` 

### DIFF
--- a/Yams.xcodeproj/project.pbxproj
+++ b/Yams.xcodeproj/project.pbxproj
@@ -309,7 +309,6 @@
 				HEADER_SEARCH_PATHS = Sources/CYaml/include;
 				INFOPLIST_FILE = Yams.xcodeproj/Yams_Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
-				LIBRARY_SEARCH_PATHS = "$(PROJECT_TEMP_DIR)/SymlinkLibs/";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = Yams;
@@ -333,7 +332,6 @@
 				HEADER_SEARCH_PATHS = Sources/CYaml/include;
 				INFOPLIST_FILE = Yams.xcodeproj/Yams_Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
-				LIBRARY_SEARCH_PATHS = "$(PROJECT_TEMP_DIR)/SymlinkLibs/";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = Yams;
@@ -356,7 +354,6 @@
 				HEADER_SEARCH_PATHS = Sources/CYaml/include;
 				INFOPLIST_FILE = Yams.xcodeproj/YamsTests_Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "@loader_path/../Frameworks";
-				LIBRARY_SEARCH_PATHS = "$(PROJECT_TEMP_DIR)/SymlinkLibs/";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
 				SUPPORTED_PLATFORMS = macosx;
@@ -374,7 +371,6 @@
 				HEADER_SEARCH_PATHS = Sources/CYaml/include;
 				INFOPLIST_FILE = Yams.xcodeproj/YamsTests_Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "@loader_path/../Frameworks";
-				LIBRARY_SEARCH_PATHS = "$(PROJECT_TEMP_DIR)/SymlinkLibs/";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
 				SUPPORTED_PLATFORMS = macosx;


### PR DESCRIPTION
e.g.
> Showing All Messages
(null): Directory not found for option '-L/Users/norio/Library/Developer/Xcode/DerivedData/SwiftLint-ckusyxhfypwoaeaswpxdhrwypieq/Build/Intermediates/Yams.build/SymlinkLibs'

Fixes https://github.com/realm/SwiftLint/issues/927
