### PR TITLE
Improve Error

### DIFF
--- a/Sources/Yams/String+Yams.swift
+++ b/Sources/Yams/String+Yams.swift
@@ -1,0 +1,68 @@
+//
+//  String+Yams.swift
+//  Yams
+//
+//  Created by Norio Nomura on 12/7/16.
+//  Copyright (c) 2016 Yams. All rights reserved.
+//
+
+import Foundation
+
+extension String {
+    /// line number, column and contents at byteOffset.
+    ///
+    /// - Parameter byteOffset: Int
+    /// - Returns: lineNumber: line number start from 1,
+    ///            column: utf16 column start from 1,
+    ///            contents: substring of line
+    func lineNumberColumnAndContents(at byteOffset: Int) -> (lineNumber: Int, column: Int, contents: String)? {
+        guard let index = utf8
+            .index(utf8.startIndex, offsetBy: byteOffset, limitedBy: utf8.endIndex)?
+            .samePosition(in: self) else { return nil }
+        var number = 0
+        var outStartIndex = startIndex, outEndIndex = startIndex, outContentsEndIndex = startIndex
+        getLineStart(&outStartIndex, end: &outEndIndex, contentsEnd: &outContentsEndIndex,
+                     for: startIndex..<startIndex)
+        while (outEndIndex <= index && outEndIndex < endIndex) {
+            number += 1
+            let range = outEndIndex..<outEndIndex
+            getLineStart(&outStartIndex, end: &outEndIndex, contentsEnd: &outContentsEndIndex,
+                         for: range)
+        }
+        let utf16StartIndex = outStartIndex.samePosition(in: utf16)
+        let utf16Index = index.samePosition(in: utf16)
+        return (
+            number + 1,
+            utf16.distance(from: utf16StartIndex, to: utf16Index) + 1,
+            substring(with: outStartIndex..<outEndIndex)
+        )
+    }
+
+    /// substring indicated by line number.
+    ///
+    /// - Parameter line: line number starts from 0.
+    /// - Returns: substring of line contains line ending characters
+    func substring(at line: Int) -> String {
+        var number = 0
+        var outStartIndex = startIndex, outEndIndex = startIndex, outContentsEndIndex = startIndex
+        getLineStart(&outStartIndex, end: &outEndIndex, contentsEnd: &outContentsEndIndex,
+                     for: startIndex..<startIndex)
+        while (number < line  && outEndIndex < endIndex) {
+            number += 1
+            let range = outEndIndex..<outEndIndex
+            getLineStart(&outStartIndex, end: &outEndIndex, contentsEnd: &outContentsEndIndex,
+                         for: range)
+        }
+        return substring(with: outStartIndex..<outEndIndex)
+    }
+
+    /// String appending newline if is not ending with newline.
+    var endingWithNewLine: String {
+        let isEndsWithNewLines = unicodeScalars.last.map(CharacterSet.newlines.contains) ?? false
+        if isEndsWithNewLines {
+            return self
+        } else {
+            return self + "\n"
+        }
+    }
+}

--- a/Sources/Yams/Yams.swift
+++ b/Sources/Yams/Yams.swift
@@ -3,9 +3,102 @@ import CYaml
 #endif
 import Foundation
 
-public struct Error: Swift.Error {
-    let problem: String
-    let problemOffset: Int
+
+public enum YamsError: Swift.Error {
+    // Used in `yaml_emitter_t` and `yaml_parser_t`
+    /// YAML_NO_ERROR. No error is produced.
+    case no
+    /// YAML_MEMORY_ERROR. Cannot allocate or reallocate a block of memory.
+    case memory
+
+    // Used in `yaml_parser_t`
+    /// YAML_READER_ERROR. Cannot read or decode the input stream.
+    case reader(problem: String, byteOffset: Int, value: Int32)
+
+    // line and column start from 0, column is counted by unicodeScalars
+    /// YAML_SCANNER_ERROR. Cannot scan the input stream.
+    case scanner(context: String, problem: String, line: Int, column: Int)
+    /// YAML_PARSER_ERROR. Cannot parse the input stream.
+    case parser(context: String?, problem: String, line: Int, column: Int)
+    /// YAML_COMPOSER_ERROR. Cannot compose a YAML document.
+    case composer(context: String?, problem: String, line: Int, column: Int)
+
+    // Used in `yaml_emitter_t`
+    /// YAML_WRITER_ERROR. Cannot write to the output stream.
+    case writer(problem: String)
+    /// YAML_EMITTER_ERROR. Cannot emit a YAML stream.
+    case emitter(problem: String)
+}
+
+extension YamsError {
+    init(from parser: yaml_parser_t) {
+        switch parser.error {
+        case YAML_MEMORY_ERROR:
+            self = .memory
+        case YAML_READER_ERROR:
+            self = .reader(problem: String(validatingUTF8: parser.problem)!,
+                           byteOffset: parser.problem_offset,
+                           value: parser.problem_value)
+        case YAML_SCANNER_ERROR:
+            self = .scanner(context: String(validatingUTF8: parser.context)!,
+                            problem: String(validatingUTF8: parser.problem)!,
+                            line: parser.problem_mark.line,
+                            column: parser.problem_mark.column)
+        case YAML_PARSER_ERROR:
+            self = .parser(context: String(validatingUTF8: parser.context),
+                             problem: String(validatingUTF8: parser.problem)!,
+                             line: parser.problem_mark.line,
+                             column: parser.problem_mark.column)
+        case YAML_COMPOSER_ERROR:
+            self = .composer(context: String(validatingUTF8: parser.context),
+                             problem: String(validatingUTF8: parser.problem)!,
+                             line: parser.problem_mark.line,
+                             column: parser.problem_mark.column)
+        default:
+            fatalError("Parser has unknown error: \(parser.error)!")
+        }
+    }
+}
+
+extension YamsError {
+    public func describing(with yaml: String) -> String {
+        switch self {
+        case .no:
+            return "No error is produced"
+        case .memory:
+            return "Memory error"
+        case let .reader(problem, byteOffset, value):
+            guard let (_, column, contents) = yaml.lineNumberColumnAndContents(at: byteOffset)
+                else { return "\(problem) at byte offset: \(byteOffset), value: \(value)" }
+            return contents.endingWithNewLine
+                + String(repeating: " ", count: column - 1) + "^ " + problem
+        case let .scanner(context, problem, line, column):
+            return describing(with: yaml, context, problem, line, column)
+        case let .parser(context, problem, line, column):
+            return describing(with: yaml, context ?? "", problem, line, column)
+        case let .composer(context, problem, line, column):
+            return describing(with: yaml, context ?? "", problem, line, column)
+        default:
+            fatalError()
+        }
+    }
+
+    private func describing(with yaml: String,
+                            _ context: String,
+                            _ problem: String,
+                            _ line: Int,
+                            _ column: Int // libYAML counts column by unicodeScalars.
+        ) -> String {
+        let contents = yaml.substring(at: line)
+        let columnIndex = contents.unicodeScalars
+            .index(contents.unicodeScalars.startIndex,
+                   offsetBy: column,
+                   limitedBy: contents.unicodeScalars.endIndex)?
+            .samePosition(in: contents) ?? contents.endIndex
+        let column = contents.distance(from: contents.startIndex, to: columnIndex)
+        return contents.endingWithNewLine +
+            String(repeating: " ", count: column) + "^ " + problem + " " + context
+    }
 }
 
 public enum Node {
@@ -34,8 +127,7 @@ private class Document {
         let bytes = string.utf8.map { UInt8($0) }
         yaml_parser_set_input_string(&parser, bytes, bytes.count)
         guard yaml_parser_load(&parser, &document) == 1 else {
-            throw Error(problem: String(validatingUTF8: parser.problem)!,
-                        problemOffset: parser.problem_offset)
+            throw YamsError(from: parser)
         }
     }
 

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -3,5 +3,6 @@ import XCTest
 @testable import YamsTests
 
 XCTMain([
+    testCase(StringTests.allTests),
     testCase(YamsTests.allTests),
 ])

--- a/Tests/YamsTests/StringTests.swift
+++ b/Tests/YamsTests/StringTests.swift
@@ -53,9 +53,11 @@ class StringTests: XCTestCase {
 extension StringTests {
     static var allTests: [(String, (StringTests) -> () throws -> Void)] {
         return [
+            /* FIXME: https://bugs.swift.org/browse/SR-3366
             ("testConfirmBehaviorOfStandardLibraryAPI", testConfirmBehaviorOfStandardLibraryAPI),
             ("testLineNumberColumnAndContentsAtByteOffset", testLineNumberColumnAndContentsAtByteOffset),
             ("testSubstringAtLine", testSubstringAtLine),
+             */
         ]
     }
 }

--- a/Tests/YamsTests/StringTests.swift
+++ b/Tests/YamsTests/StringTests.swift
@@ -1,0 +1,61 @@
+//
+//  StringTests.swift
+//  Yams
+//
+//  Created by Norio Nomura on 12/7/16.
+//  Copyright (c) 2016 Yams. All rights reserved.
+//
+
+import XCTest
+@testable import Yams
+
+class StringTests: XCTestCase {
+    // byteoffset 01234567890 12345678901 23456789012
+    // column     12345678901 12345678901 12345678901
+    let string = "LINE1_6789\nLINE2_7890\nLINE3_8901\n"
+
+    // Confirm behavior of Standard Library API
+    func testConfirmBehaviorOfStandardLibraryAPI() {
+        let rangeOfFirstLine = string.lineRange(for: string.startIndex..<string.startIndex)
+        let firstLine = string.substring(with: rangeOfFirstLine)
+        XCTAssertEqual(firstLine, "LINE1_6789\n")
+    }
+
+    // `String.lineNumberColumnAndContents(at:)`
+    func testLineNumberColumnAndContentsAtByteOffset() {
+        do {
+            let (number, column, content) = string.lineNumberColumnAndContents(at: 0)!
+            XCTAssertEqual(number, 1)
+            XCTAssertEqual(column, 1)
+            XCTAssertEqual(content, "LINE1_6789\n")
+        }
+        do {
+            let (number, column, content) = string.lineNumberColumnAndContents(at: 10)!
+            XCTAssertEqual(number, 1)
+            XCTAssertEqual(column, 11)
+            XCTAssertEqual(content, "LINE1_6789\n")
+        }
+        do {
+            let (number, column, content) = string.lineNumberColumnAndContents(at: 11)!
+            XCTAssertEqual(number, 2)
+            XCTAssertEqual(column, 1)
+            XCTAssertEqual(content, "LINE2_7890\n")
+        }
+    }
+
+    // `String.substring(at:)`
+    func testSubstringAtLine() {
+        let scecondLine = string.substring(at: 1)
+        XCTAssertEqual(scecondLine, "LINE2_7890\n")
+    }
+}
+
+extension StringTests {
+    static var allTests: [(String, (StringTests) -> () throws -> Void)] {
+        return [
+            ("testConfirmBehaviorOfStandardLibraryAPI", testConfirmBehaviorOfStandardLibraryAPI),
+            ("testLineNumberColumnAndContentsAtByteOffset", testLineNumberColumnAndContentsAtByteOffset),
+            ("testSubstringAtLine", testSubstringAtLine),
+        ]
+    }
+}

--- a/Tests/YamsTests/YamsTests.swift
+++ b/Tests/YamsTests/YamsTests.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 import XCTest
-@testable import Yams
+import Yams
 
 class YamsTests: XCTestCase {
     func testExample() throws {

--- a/Yams.xcodeproj/project.pbxproj
+++ b/Yams.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		6C4A22071DF8553C002A0206 /* String+Yams.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C4A22061DF8553C002A0206 /* String+Yams.swift */; };
+		6C4A22091DF855BB002A0206 /* StringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C4A22081DF855BB002A0206 /* StringTests.swift */; };
 		E8EDB8851DE2181B0062268D /* api.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_10 /* api.c */; };
 		E8EDB8861DE2181B0062268D /* dumper.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_11 /* dumper.c */; };
 		E8EDB8871DE2181B0062268D /* emitter.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_12 /* emitter.c */; };
@@ -32,6 +34,9 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		6C4A22061DF8553C002A0206 /* String+Yams.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+Yams.swift"; sourceTree = "<group>"; };
+		6C4A22081DF855BB002A0206 /* StringTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StringTests.swift; sourceTree = "<group>"; };
+		6C4A220A1DF85793002A0206 /* LinuxMain.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LinuxMain.swift; sourceTree = "<group>"; };
 		OBJ_10 /* api.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = api.c; sourceTree = "<group>"; };
 		OBJ_11 /* dumper.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = dumper.c; sourceTree = "<group>"; };
 		OBJ_12 /* emitter.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = emitter.c; sourceTree = "<group>"; };
@@ -78,6 +83,7 @@
 		OBJ_21 /* Yams */ = {
 			isa = PBXGroup;
 			children = (
+				6C4A22061DF8553C002A0206 /* String+Yams.swift */,
 				OBJ_22 /* Yams.swift */,
 			);
 			name = Yams;
@@ -87,6 +93,7 @@
 		OBJ_23 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				6C4A220A1DF85793002A0206 /* LinuxMain.swift */,
 				OBJ_24 /* YamsTests */,
 			);
 			path = Tests;
@@ -95,6 +102,7 @@
 		OBJ_24 /* YamsTests */ = {
 			isa = PBXGroup;
 			children = (
+				6C4A22081DF855BB002A0206 /* StringTests.swift */,
 				OBJ_25 /* YamsTests.swift */,
 			);
 			name = YamsTests;
@@ -239,6 +247,7 @@
 				E8EDB8881DE2181B0062268D /* loader.c in Sources */,
 				E8EDB88C1DE2181B0062268D /* writer.c in Sources */,
 				E8EDB88B1DE2181B0062268D /* scanner.c in Sources */,
+				6C4A22071DF8553C002A0206 /* String+Yams.swift in Sources */,
 				E8EDB8891DE2181B0062268D /* parser.c in Sources */,
 				OBJ_50 /* Yams.swift in Sources */,
 				E8EDB88A1DE2181B0062268D /* reader.c in Sources */,
@@ -249,6 +258,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 0;
 			files = (
+				6C4A22091DF855BB002A0206 /* StringTests.swift in Sources */,
 				OBJ_59 /* YamsTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
- Rename `Error` to `YamsError` for avoiding force consumer to using `Swift.Error`
- Change `YamsError` to `enum` that supports `YAML_*_ERROR`
- Add `YamsError.init(from:)` that initializing from `yaml_parser_t`
- Add `YamsError.describing(with:)` that produce `String` describing error with YAML contents:
```
test: 'test
           ^ found unexpected end of stream while scanning a quoted scalar
```

Fixes #3 

This is still in [WIP] because of failing `StringTests` on Linux.