### PR TITLE
Importing C modules with umbrella directories prevents debugging

### DIFF
--- a/Sources/CYaml/include/CYaml.h
+++ b/Sources/CYaml/include/CYaml.h
@@ -1,0 +1,1 @@
+#include "yaml.h"


### PR DESCRIPTION
This is similar to a pull request I made against the https://github.com/norio-nomura/Clang_C/pull/1 repository.

The difference is that since you do not already provide an explicit module map (I assume you do not want one) by providing this file SwiftPM will auto generate one.

This work-around was originally suggested by @aciidb0mb3r on the SwiftPM Slack channel.