### PR TITLE
Change to use UTF16 by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ matrix:
   include:
     - script:
         - xcodebuild -scheme Yams build-for-testing test-without-building # -sdk macosx -destination arch=x86_64
-        - xcodebuild -scheme Yams build-for-testing test-without-building OTHER_SWIFT_FLAGS=-DUSE_UTF16
+        - xcodebuild -scheme Yams build-for-testing test-without-building OTHER_SWIFT_FLAGS=-DUSE_UTF8
         - xcodebuild -scheme Yams build-for-testing test-without-building -sdk iphonesimulator -destination "name=iPhone 6s"
         - xcodebuild -scheme Yams build-for-testing test-without-building -sdk appletvsimulator -destination "name=Apple TV 1080p"
         - xcodebuild -scheme Yams build -sdk watchsimulator -destination "name=Apple Watch - 38mm"
@@ -22,13 +22,13 @@ matrix:
       osx_image: xcode8.2
     - script:
         - docker run -v `pwd`:`pwd` -w `pwd` --rm swift:3.0.2 swift test
-        - docker run -v `pwd`:`pwd` -w `pwd` --rm swift:3.0.2 swift test -Xswiftc -DUSE_UTF16
+        - docker run -v `pwd`:`pwd` -w `pwd` --rm swift:3.0.2 swift test -Xswiftc -DUSE_UTF8
       env: JOB=Linux
       sudo: required
       services: docker
     - script:
         - docker run -v `pwd`:`pwd` -w `pwd` --rm norionomura/swift:3120170222a swift test
-        - docker run -v `pwd`:`pwd` -w `pwd` --rm norionomura/swift:3120170222a swift test -Xswiftc -DUSE_UTF16
+        - docker run -v `pwd`:`pwd` -w `pwd` --rm norionomura/swift:3120170222a swift test -Xswiftc -DUSE_UTF8
       env: JOB=Linux-Swift3.1
       sudo: required
       services: docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,14 +21,14 @@ matrix:
       os: osx
       osx_image: xcode8.2
     - script:
-        - docker run -v `pwd`:/Yams norionomura/sourcekit:301 bash -c "cd /Yams && swift test"
-        - docker run -v `pwd`:/Yams norionomura/sourcekit:301 bash -c "cd /Yams && swift test -Xswiftc -DUSE_UTF16"
+        - docker run -v `pwd`:`pwd` -w `pwd` --rm swift:3.0.2 swift test
+        - docker run -v `pwd`:`pwd` -w `pwd` --rm swift:3.0.2 swift test -Xswiftc -DUSE_UTF16
       env: JOB=Linux
       sudo: required
       services: docker
     - script:
-        - docker run -v `pwd`:/Yams norionomura/sourcekit:3120170131a bash -c "cd /Yams && swift test"
-        - docker run -v `pwd`:/Yams norionomura/sourcekit:3120170131a bash -c "cd /Yams && swift test -Xswiftc -DUSE_UTF16"
+        - docker run -v `pwd`:`pwd` -w `pwd` --rm norionomura/swift:3120170222a swift test
+        - docker run -v `pwd`:`pwd` -w `pwd` --rm norionomura/swift:3120170222a swift test -Xswiftc -DUSE_UTF16
       env: JOB=Linux-Swift3.1
       sudo: required
       services: docker

--- a/Sources/Yams/Emitter.swift
+++ b/Sources/Yams/Emitter.swift
@@ -242,7 +242,8 @@ public final class Emitter {
             #if USE_UTF8
                 yaml_stream_start_event_initialize(&event, YAML_UTF8_ENCODING)
             #else
-                yaml_stream_start_event_initialize(&event, isLittleEndian ? YAML_UTF16LE_ENCODING : YAML_UTF16BE_ENCODING)
+                let encoding = isLittleEndian ? YAML_UTF16LE_ENCODING : YAML_UTF16BE_ENCODING
+                yaml_stream_start_event_initialize(&event, encoding)
             #endif
             try emit(&event)
             state = .opened

--- a/Sources/Yams/Emitter.swift
+++ b/Sources/Yams/Emitter.swift
@@ -225,7 +225,7 @@ public final class Emitter {
         }
 
         #if USE_UTF16
-            yaml_emitter_set_encoding(&emitter, YAML_UTF16BE_ENCODING)
+            yaml_emitter_set_encoding(&emitter, isLittleEndian ? YAML_UTF16LE_ENCODING : YAML_UTF16BE_ENCODING)
         #else
             yaml_emitter_set_encoding(&emitter, YAML_UTF8_ENCODING)
         #endif
@@ -240,7 +240,7 @@ public final class Emitter {
         case .initialized:
             var event = yaml_event_t()
             #if USE_UTF16
-                yaml_stream_start_event_initialize(&event, YAML_UTF16BE_ENCODING)
+                yaml_stream_start_event_initialize(&event, isLittleEndian ? YAML_UTF16LE_ENCODING : YAML_UTF16BE_ENCODING)
             #else
                 yaml_stream_start_event_initialize(&event, YAML_UTF8_ENCODING)
             #endif
@@ -381,3 +381,6 @@ extension Emitter {
         try emit(&event)
     }
 }
+
+private let isLittleEndian = 1 == 1.littleEndian
+

--- a/Sources/Yams/Emitter.swift
+++ b/Sources/Yams/Emitter.swift
@@ -128,10 +128,10 @@ public func serialize<Nodes>(
         try emitter.open()
         try nodes.forEach(emitter.serialize)
         try emitter.close()
-        #if USE_UTF16
-            return String(data: emitter.data, encoding: .utf16)!
-        #else
+        #if USE_UTF8
             return String(data: emitter.data, encoding: .utf8)!
+        #else
+            return String(data: emitter.data, encoding: .utf16)!
         #endif
 }
 
@@ -224,10 +224,10 @@ public final class Emitter {
         case .crln: yaml_emitter_set_break(&emitter, YAML_CRLN_BREAK)
         }
 
-        #if USE_UTF16
-            yaml_emitter_set_encoding(&emitter, isLittleEndian ? YAML_UTF16LE_ENCODING : YAML_UTF16BE_ENCODING)
-        #else
+        #if USE_UTF8
             yaml_emitter_set_encoding(&emitter, YAML_UTF8_ENCODING)
+        #else
+            yaml_emitter_set_encoding(&emitter, isLittleEndian ? YAML_UTF16LE_ENCODING : YAML_UTF16BE_ENCODING)
         #endif
     }
 
@@ -239,10 +239,10 @@ public final class Emitter {
         switch state {
         case .initialized:
             var event = yaml_event_t()
-            #if USE_UTF16
-                yaml_stream_start_event_initialize(&event, isLittleEndian ? YAML_UTF16LE_ENCODING : YAML_UTF16BE_ENCODING)
-            #else
+            #if USE_UTF8
                 yaml_stream_start_event_initialize(&event, YAML_UTF8_ENCODING)
+            #else
+                yaml_stream_start_event_initialize(&event, isLittleEndian ? YAML_UTF16LE_ENCODING : YAML_UTF16BE_ENCODING)
             #endif
             try emit(&event)
             state = .opened
@@ -383,4 +383,3 @@ extension Emitter {
 }
 
 private let isLittleEndian = 1 == 1.littleEndian
-

--- a/Sources/Yams/Parser.swift
+++ b/Sources/Yams/Parser.swift
@@ -119,8 +119,10 @@ public final class Parser {
 
         yaml_parser_initialize(&parser)
 #if USE_UTF16
-        yaml_parser_set_encoding(&parser, YAML_UTF16BE_ENCODING)
-        data = yaml.data(using: .utf16BigEndian)!
+        // use native endian
+        let isLittleEndian = 1 == 1.littleEndian
+        yaml_parser_set_encoding(&parser, isLittleEndian ? YAML_UTF16LE_ENCODING : YAML_UTF16BE_ENCODING)
+        data = yaml.data(using: isLittleEndian ? .utf16LittleEndian : .utf16BigEndian)!
         data.withUnsafeBytes { bytes in
             yaml_parser_set_input_string(&parser, bytes, data.count)
         }

--- a/Sources/Yams/Parser.swift
+++ b/Sources/Yams/Parser.swift
@@ -118,20 +118,20 @@ public final class Parser {
         self.constructor = constructor
 
         yaml_parser_initialize(&parser)
-#if USE_UTF16
+#if USE_UTF8
+        yaml_parser_set_encoding(&parser, YAML_UTF8_ENCODING)
+        utf8CString = string.utf8CString
+        utf8CString.withUnsafeBytes { bytes in
+            let input = bytes.baseAddress?.assumingMemoryBound(to: UInt8.self)
+            yaml_parser_set_input_string(&parser, input, bytes.count - 1)
+        }
+#else
         // use native endian
         let isLittleEndian = 1 == 1.littleEndian
         yaml_parser_set_encoding(&parser, isLittleEndian ? YAML_UTF16LE_ENCODING : YAML_UTF16BE_ENCODING)
         data = yaml.data(using: isLittleEndian ? .utf16LittleEndian : .utf16BigEndian)!
         data.withUnsafeBytes { bytes in
             yaml_parser_set_input_string(&parser, bytes, data.count)
-        }
-#else
-        yaml_parser_set_encoding(&parser, YAML_UTF8_ENCODING)
-        utf8CString = string.utf8CString
-        utf8CString.withUnsafeBytes { bytes in
-            let input = bytes.baseAddress?.assumingMemoryBound(to: UInt8.self)
-            yaml_parser_set_input_string(&parser, input, bytes.count - 1)
         }
 #endif
         try expectNextEvent(oneOf: [YAML_STREAM_START_EVENT])
@@ -160,10 +160,10 @@ public final class Parser {
     // MARK: private
     fileprivate var anchors = [String: Node]()
     fileprivate var parser = yaml_parser_t()
-#if USE_UTF16
-    private let data: Data
-#else
+#if USE_UTF8
     private let utf8CString: ContiguousArray<CChar>
+#else
+    private let data: Data
 #endif
 }
 

--- a/Sources/Yams/Parser.swift
+++ b/Sources/Yams/Parser.swift
@@ -118,22 +118,22 @@ public final class Parser {
         self.constructor = constructor
 
         yaml_parser_initialize(&parser)
-#if USE_UTF8
-        yaml_parser_set_encoding(&parser, YAML_UTF8_ENCODING)
-        utf8CString = string.utf8CString
-        utf8CString.withUnsafeBytes { bytes in
-            let input = bytes.baseAddress?.assumingMemoryBound(to: UInt8.self)
-            yaml_parser_set_input_string(&parser, input, bytes.count - 1)
-        }
-#else
-        // use native endian
-        let isLittleEndian = 1 == 1.littleEndian
-        yaml_parser_set_encoding(&parser, isLittleEndian ? YAML_UTF16LE_ENCODING : YAML_UTF16BE_ENCODING)
-        data = yaml.data(using: isLittleEndian ? .utf16LittleEndian : .utf16BigEndian)!
-        data.withUnsafeBytes { bytes in
-            yaml_parser_set_input_string(&parser, bytes, data.count)
-        }
-#endif
+        #if USE_UTF8
+            yaml_parser_set_encoding(&parser, YAML_UTF8_ENCODING)
+            utf8CString = string.utf8CString
+            utf8CString.withUnsafeBytes { bytes in
+                let input = bytes.baseAddress?.assumingMemoryBound(to: UInt8.self)
+                yaml_parser_set_input_string(&parser, input, bytes.count - 1)
+            }
+        #else
+            // use native endian
+            let isLittleEndian = 1 == 1.littleEndian
+            yaml_parser_set_encoding(&parser, isLittleEndian ? YAML_UTF16LE_ENCODING : YAML_UTF16BE_ENCODING)
+            data = yaml.data(using: isLittleEndian ? .utf16LittleEndian : .utf16BigEndian)!
+            data.withUnsafeBytes { bytes in
+                yaml_parser_set_input_string(&parser, bytes, data.count)
+            }
+        #endif
         try expectNextEvent(oneOf: [YAML_STREAM_START_EVENT])
     }
 

--- a/Sources/Yams/YamlError.swift
+++ b/Sources/Yams/YamlError.swift
@@ -78,11 +78,11 @@ extension YamlError {
         case .memory:
             return "Memory error"
         case let .reader(problem, byteOffset, value):
-            #if USE_UTF16
-                guard let (_, column, contents) = yaml.utf16LineNumberColumnAndContents(at: byteOffset / 2)
+            #if USE_UTF8
+                guard let (_, column, contents) = yaml.utf8LineNumberColumnAndContents(at: byteOffset)
                     else { return "\(problem) at byte offset: \(byteOffset), value: \(value)" }
             #else
-                guard let (_, column, contents) = yaml.utf8LineNumberColumnAndContents(at: byteOffset)
+                guard let (_, column, contents) = yaml.utf16LineNumberColumnAndContents(at: byteOffset / 2)
                     else { return "\(problem) at byte offset: \(byteOffset), value: \(value)" }
             #endif
             return contents.endingWithNewLine


### PR DESCRIPTION
Because using UTF16 is faster than using UTF8 on macOS:

|                                      |UTF8 |UTF16|
|--------------------------------------|-----|-----|
|`testSourceKittenIssue289UsingCompose`|0.026|0.007|
|`testSourceKittenIssue289UsingLoad`   |0.038|0.017|

The `USE_UTF8` option using UTF8 will remain.