### PR TITLE
Change associated value of `Node`

### DIFF
--- a/Sources/Yams/Constructor.swift
+++ b/Sources/Yams/Constructor.swift
@@ -258,8 +258,8 @@ extension Dictionary {
     private static func flatten_mapping(_ node: Node) -> Node {
         assert(node.isMapping) // swiftlint:disable:next force_unwrapping
         let mapping = node.mapping!
-        var pairs = mapping.pairs
-        var merge = [Pair<Node>]()
+        var pairs = mapping.pairs.map(Pair.toTuple)
+        var merge = [(key: Node, value: Node)]()
         var index = pairs.startIndex
         while index < pairs.count {
             let pair = pairs[index]
@@ -268,13 +268,13 @@ extension Dictionary {
                 switch pair.value {
                 case .mapping:
                     let flattened_node = flatten_mapping(pair.value)
-                    if let pairs = flattened_node.mapping?.pairs {
+                    if let pairs = flattened_node.mapping?.pairs.map(Pair.toTuple) {
                         merge.append(contentsOf: pairs)
                     }
                 case let .sequence(sequence):
                     let submerge = sequence.nodes
                         .filter { $0.isMapping } // TODO: Should raise error on other than mapping
-                        .flatMap { flatten_mapping($0).mapping?.pairs }
+                        .flatMap { flatten_mapping($0).mapping?.pairs.map(Pair.toTuple) }
                         .reversed()
                     submerge.forEach {
                         merge.append(contentsOf: $0)
@@ -289,7 +289,7 @@ extension Dictionary {
                 index += 1
             }
         }
-        return .mapping(.init(merge + pairs, node.tag, mapping.style))
+        return Node(merge + pairs, node.tag, mapping.style)
     }
 }
 

--- a/Sources/Yams/Constructor.swift
+++ b/Sources/Yams/Constructor.swift
@@ -215,8 +215,8 @@ extension String: ScalarConstructible {
 
     fileprivate static func _construct(from node: Node) -> String {
         // This will happen while `Dictionary.flatten_mapping()` if `node.tag.name` was `.value`
-        if case let .mapping(pairs, _, _) = node {
-            for pair in pairs where pair.key.tag.name == .value {
+        if case let .mapping(mapping) = node {
+            for pair in mapping.pairs where pair.key.tag.name == .value {
                 return _construct(from: pair.value)
             }
         }
@@ -289,7 +289,7 @@ extension Dictionary {
                 index += 1
             }
         }
-        return .mapping(merge + pairs, node.tag, mapping.style)
+        return .mapping(.init(merge + pairs, node.tag, mapping.style))
     }
 }
 

--- a/Sources/Yams/Constructor.swift
+++ b/Sources/Yams/Constructor.swift
@@ -271,8 +271,8 @@ extension Dictionary {
                     if let pairs = flattened_node.mapping?.pairs {
                         merge.append(contentsOf: pairs)
                     }
-                case let .sequence(array, _, _):
-                    let submerge = array
+                case let .sequence(sequence):
+                    let submerge = sequence.nodes
                         .filter { $0.isMapping } // TODO: Should raise error on other than mapping
                         .flatMap { flatten_mapping($0).mapping?.pairs }
                         .reversed()

--- a/Sources/Yams/Node.swift
+++ b/Sources/Yams/Node.swift
@@ -15,8 +15,8 @@ public enum Node {
 }
 
 extension Node {
-    public init(_ string: String, _ tag: Tag.Name = .implicit, _ style: Scalar.Style = .any) {
-        self = .scalar(.init(string, Tag(tag), style))
+    public init(_ string: String, _ tag: Tag = .implicit, _ style: Scalar.Style = .any) {
+        self = .scalar(.init(string, tag, style))
     }
 }
 

--- a/Sources/Yams/Node.swift
+++ b/Sources/Yams/Node.swift
@@ -350,27 +350,27 @@ extension Node: ExpressibleByDictionaryLiteral {
 
 extension Node: ExpressibleByFloatLiteral {
     public init(floatLiteral value: Double) {
-        self = .scalar(.init(String(value), Tag(.float)))
+        self.init(String(value), Tag(.float))
     }
 }
 
 extension Node: ExpressibleByIntegerLiteral {
     public init(integerLiteral value: Int) {
-        self = .scalar(.init(String(value), Tag(.int)))
+        self.init(String(value), Tag(.int))
     }
 }
 
 extension Node: ExpressibleByStringLiteral {
     public init(stringLiteral value: String) {
-        self = .scalar(.init(value))
+        self.init(value)
     }
 
     public init(extendedGraphemeClusterLiteral value: String) {
-        self = .scalar(.init(value))
+        self.init(value)
     }
 
     public init(unicodeScalarLiteral value: String) {
-        self = .scalar(.init(value))
+        self.init(value)
     }
 }
 

--- a/Sources/Yams/Node.swift
+++ b/Sources/Yams/Node.swift
@@ -18,6 +18,10 @@ extension Node {
     public init(_ string: String, _ tag: Tag = .implicit, _ style: Scalar.Style = .any) {
         self = .scalar(.init(string, tag, style))
     }
+
+    public init(_ pairs: [(Node, Node)], _ tag: Tag = .implicit, _ style: Mapping.Style = .any) {
+            self = .mapping(.init(pairs.map(Pair.init), tag, style))
+    }
 }
 
 extension Node {
@@ -151,6 +155,10 @@ public struct Pair<Value: Comparable & Equatable>: Comparable, Equatable {
 
     public static func < (lhs: Pair<Value>, rhs: Pair<Value>) -> Bool {
         return lhs.key < rhs.key
+    }
+
+    static func toTuple(pair: Pair) -> (key: Value, value: Value) {
+        return (key: pair.key, value: pair.value)
     }
 }
 
@@ -344,7 +352,7 @@ extension Node: ExpressibleByArrayLiteral {
 
 extension Node: ExpressibleByDictionaryLiteral {
     public init(dictionaryLiteral elements: (Node, Node)...) {
-        self = .mapping(.init(elements.map(Pair.init)))
+        self = Node(elements)
     }
 }
 
@@ -393,7 +401,7 @@ extension Node.Mapping: MutableCollection {
 
     // Sequence
     public func makeIterator() -> Array<Element>.Iterator {
-        let iterator = pairs.map({ (key: $0.key, value: $0.value) }).makeIterator()
+        let iterator = pairs.map(Pair.toTuple).makeIterator()
         return iterator
     }
 

--- a/Sources/Yams/Node.swift
+++ b/Sources/Yams/Node.swift
@@ -22,6 +22,10 @@ extension Node {
     public init(_ pairs: [(Node, Node)], _ tag: Tag = .implicit, _ style: Mapping.Style = .any) {
             self = .mapping(.init(pairs, tag, style))
     }
+
+    public init(_ nodes: [Node], _ tag: Tag = .implicit, _ style: Sequence.Style = .any) {
+        self = .sequence(.init(nodes, tag, style))
+    }
 }
 
 extension Node {

--- a/Sources/Yams/Node.swift
+++ b/Sources/Yams/Node.swift
@@ -20,7 +20,7 @@ extension Node {
     }
 
     public init(_ pairs: [(Node, Node)], _ tag: Tag = .implicit, _ style: Mapping.Style = .any) {
-            self = .mapping(.init(pairs.map(Pair.init), tag, style))
+            self = .mapping(.init(pairs, tag, style))
     }
 }
 
@@ -82,8 +82,8 @@ extension Node {
             case flow
         }
 
-        public init(_ pairs: [Pair<Node>], _ tag: Tag = .implicit, _ style: Style = .any) {
-            self.pairs = pairs
+        public init(_ pairs: [(Node, Node)], _ tag: Tag = .implicit, _ style: Style = .any) {
+            self.pairs = pairs.map(Pair.init)
             self.tag = tag
             self.style = style
         }
@@ -140,7 +140,7 @@ extension Node {
 
 }
 
-public struct Pair<Value: Comparable & Equatable>: Comparable, Equatable {
+struct Pair<Value: Comparable & Equatable>: Comparable, Equatable {
     let key: Value
     let value: Value
 
@@ -149,11 +149,11 @@ public struct Pair<Value: Comparable & Equatable>: Comparable, Equatable {
         self.value = value
     }
 
-    public static func == (lhs: Pair, rhs: Pair) -> Bool {
+    static func == (lhs: Pair, rhs: Pair) -> Bool {
         return lhs.key == rhs.key && lhs.value == rhs.value
     }
 
-    public static func < (lhs: Pair<Value>, rhs: Pair<Value>) -> Bool {
+    static func < (lhs: Pair<Value>, rhs: Pair<Value>) -> Bool {
         return lhs.key < rhs.key
     }
 
@@ -392,7 +392,7 @@ extension Node.Mapping: Equatable {
 
 extension Node.Mapping: ExpressibleByDictionaryLiteral {
     public init(dictionaryLiteral elements: (Node, Node)...) {
-        self.init(elements.map(Pair.init))
+        self.init(elements)
     }
 }
 

--- a/Sources/Yams/Parser.swift
+++ b/Sources/Yams/Parser.swift
@@ -223,7 +223,7 @@ extension Parser {
     }
 
     private func loadScalar(from event: Event) throws -> Node {
-        let node = Node.scalar(.init(event.scalarValue, tag(event.scalarTag), event.scalarStyle))
+        let node = Node(event.scalarValue, tag(event.scalarTag), event.scalarStyle)
         if let anchor = event.scalarAnchor {
             anchors[anchor] = node
         }

--- a/Sources/Yams/Parser.swift
+++ b/Sources/Yams/Parser.swift
@@ -254,7 +254,7 @@ extension Parser {
             pairs.append(Pair(key, value))
             event = try parse()
         }
-        let node = Node.mapping(pairs, tag(firstEvent.mappingTag), event.mappingStyle)
+        let node = Node.mapping(.init(pairs, tag(firstEvent.mappingTag), event.mappingStyle))
         if let anchor = firstEvent.mappingAnchor {
             anchors[anchor] = node
         }

--- a/Sources/Yams/Parser.swift
+++ b/Sources/Yams/Parser.swift
@@ -223,7 +223,7 @@ extension Parser {
     }
 
     private func loadScalar(from event: Event) throws -> Node {
-        let node = Node.scalar(event.scalarValue, tag(event.scalarTag), event.scalarStyle)
+        let node = Node.scalar(.init(event.scalarValue, tag(event.scalarTag), event.scalarStyle))
         if let anchor = event.scalarAnchor {
             anchors[anchor] = node
         }

--- a/Sources/Yams/Parser.swift
+++ b/Sources/Yams/Parser.swift
@@ -237,7 +237,7 @@ extension Parser {
             array.append(try loadNode(from: event))
             event = try parse()
         }
-        let node = Node.sequence(array, tag(firstEvent.sequenceTag), event.sequenceStyle)
+        let node = Node.sequence(.init(array, tag(firstEvent.sequenceTag), event.sequenceStyle))
         if let anchor = firstEvent.sequenceAnchor {
             anchors[anchor] = node
         }

--- a/Sources/Yams/Parser.swift
+++ b/Sources/Yams/Parser.swift
@@ -237,7 +237,7 @@ extension Parser {
             array.append(try loadNode(from: event))
             event = try parse()
         }
-        let node = Node.sequence(.init(array, tag(firstEvent.sequenceTag), event.sequenceStyle))
+        let node = Node(array, tag(firstEvent.sequenceTag), event.sequenceStyle)
         if let anchor = firstEvent.sequenceAnchor {
             anchors[anchor] = node
         }

--- a/Sources/Yams/Parser.swift
+++ b/Sources/Yams/Parser.swift
@@ -245,16 +245,16 @@ extension Parser {
     }
 
     private func loadMapping(from firstEvent: Event) throws -> Node {
-        var pairs = [Pair<Node>]()
+        var pairs = [(Node, Node)]()
         var event = try parse()
         while event.type != YAML_MAPPING_END_EVENT {
             let key = try loadNode(from: event)
             event = try parse()
             let value = try loadNode(from: event)
-            pairs.append(Pair(key, value))
+            pairs.append((key, value))
             event = try parse()
         }
-        let node = Node.mapping(.init(pairs, tag(firstEvent.mappingTag), event.mappingStyle))
+        let node = Node(pairs, tag(firstEvent.mappingTag), event.mappingStyle)
         if let anchor = firstEvent.mappingAnchor {
             anchors[anchor] = node
         }

--- a/Sources/Yams/Representer.swift
+++ b/Sources/Yams/Representer.swift
@@ -165,7 +165,7 @@ extension Array: NodeRepresentable {
 
 extension Dictionary: NodeRepresentable {
     public func represented() throws -> Node {
-        let pairs = try map { Pair<Node>(try represent($0), try represent($1)) }
-        return .mapping(.init(pairs.sorted(), Tag(.map)))
+        let pairs = try map { (key: try represent($0), value: try represent($1)) }
+        return Node(pairs.sorted { $0.key < $1.key }, Tag(.map))
     }
 }

--- a/Sources/Yams/Representer.swift
+++ b/Sources/Yams/Representer.swift
@@ -166,6 +166,6 @@ extension Array: NodeRepresentable {
 extension Dictionary: NodeRepresentable {
     public func represented() throws -> Node {
         let pairs = try map { Pair<Node>(try represent($0), try represent($1)) }
-        return .mapping(pairs.sorted(), Tag(.map), .any)
+        return .mapping(.init(pairs.sorted(), Tag(.map)))
     }
 }

--- a/Sources/Yams/Representer.swift
+++ b/Sources/Yams/Representer.swift
@@ -37,19 +37,19 @@ extension Node: NodeRepresentable {
 
 extension Bool: NodeRepresentable {
     public func represented() throws -> Node {
-        return Node(self ? "true" : "false", .bool)
+        return Node(self ? "true" : "false", Tag(.bool))
     }
 }
 
 extension Data: NodeRepresentable {
     public func represented() throws -> Node {
-        return Node(base64EncodedString(), .binary)
+        return Node(base64EncodedString(), Tag(.binary))
     }
 }
 
 extension Date: NodeRepresentable {
     public func represented() throws -> Node {
-        return Node(iso8601string, .timestamp)
+        return Node(iso8601string, Tag(.timestamp))
     }
 
     private var iso8601string: String {
@@ -90,13 +90,13 @@ private let iso8601FormatterWithNanoseconds: DateFormatter = {
 
 extension Double: NodeRepresentable {
     public func represented() throws -> Node {
-        return Node(doubleFormatter.string(for: self)!.replacingOccurrences(of: "+-", with: "-"), .float)
+        return Node(doubleFormatter.string(for: self)!.replacingOccurrences(of: "+-", with: "-"), Tag(.float))
     }
 }
 
 extension Float: NodeRepresentable {
     public func represented() throws -> Node {
-        return Node(floatFormatter.string(for: self)!.replacingOccurrences(of: "+-", with: "-"), .float)
+        return Node(floatFormatter.string(for: self)!.replacingOccurrences(of: "+-", with: "-"), Tag(.float))
     }
 }
 
@@ -121,7 +121,7 @@ private let floatFormatter = numberFormatter(with: 7)
 
 extension Integer {
     public func represented() throws -> Node {
-        return Node(String(describing: self), .int)
+        return Node(String(describing: self), Tag(.int))
     }
 }
 
@@ -151,7 +151,7 @@ extension Optional: NodeRepresentable {
         case let .some(wrapped):
             return try represent(wrapped)
         case .none:
-            return Node("null", .null)
+            return Node("null", Tag(.null))
         }
     }
 }

--- a/Sources/Yams/Representer.swift
+++ b/Sources/Yams/Representer.swift
@@ -159,7 +159,7 @@ extension Optional: NodeRepresentable {
 extension Array: NodeRepresentable {
     public func represented() throws -> Node {
         let nodes = try flatMap(represent)
-        return .sequence(nodes, Tag(.seq), .any)
+        return .sequence(.init(nodes, Tag(.seq)))
     }
 }
 

--- a/Sources/Yams/Representer.swift
+++ b/Sources/Yams/Representer.swift
@@ -159,7 +159,7 @@ extension Optional: NodeRepresentable {
 extension Array: NodeRepresentable {
     public func represented() throws -> Node {
         let nodes = try flatMap(represent)
-        return .sequence(.init(nodes, Tag(.seq)))
+        return Node(nodes, Tag(.seq))
     }
 }
 

--- a/Sources/Yams/Resolver.swift
+++ b/Sources/Yams/Resolver.swift
@@ -20,8 +20,8 @@ public final class Resolver {
             return scalar.tag.name == .implicit ? resolveTag(from: scalar.string) : scalar.tag.name
         case let .mapping(mapping):
             return mapping.tag.name == .implicit ? .map : mapping.tag.name
-        case let .sequence(_, tag, _):
-            return tag.name == .implicit ? .seq : tag.name
+        case let .sequence(sequence):
+            return sequence.tag.name == .implicit ? .seq : sequence.tag.name
         }
     }
 

--- a/Sources/Yams/Resolver.swift
+++ b/Sources/Yams/Resolver.swift
@@ -16,8 +16,8 @@ public final class Resolver {
 
     public func resolveTag(of node: Node) -> Tag.Name {
         switch node {
-        case let .scalar(string, tag, _):
-            return tag.name == .implicit ? resolveTag(from: string) : tag.name
+        case let .scalar(scalar):
+            return scalar.tag.name == .implicit ? resolveTag(from: scalar.string) : scalar.tag.name
         case let .mapping(_, tag, _):
             return tag.name == .implicit ? .map : tag.name
         case let .sequence(_, tag, _):

--- a/Sources/Yams/Resolver.swift
+++ b/Sources/Yams/Resolver.swift
@@ -18,8 +18,8 @@ public final class Resolver {
         switch node {
         case let .scalar(scalar):
             return scalar.tag.name == .implicit ? resolveTag(from: scalar.string) : scalar.tag.name
-        case let .mapping(_, tag, _):
-            return tag.name == .implicit ? .map : tag.name
+        case let .mapping(mapping):
+            return mapping.tag.name == .implicit ? .map : mapping.tag.name
         case let .sequence(_, tag, _):
             return tag.name == .implicit ? .seq : tag.name
         }

--- a/Sources/Yams/Tag.swift
+++ b/Sources/Yams/Tag.swift
@@ -23,7 +23,7 @@ public final class Tag {
     let constructor: Constructor
     var name: Name
 
-    init(_ name: Name,
+    public init(_ name: Name,
          _ resolver: Resolver = .default,
          _ constructor: Constructor = .default) {
         self.resolver = resolver

--- a/Tests/YamsTests/NodeTests.swift
+++ b/Tests/YamsTests/NodeTests.swift
@@ -14,41 +14,41 @@ class NodeTests: XCTestCase {
 
     func testExpressibleByArrayLiteral() {
         let sequence: Node = [
-            .scalar(.init("1")),
-            .scalar(.init("2")),
-            .scalar(.init("3"))
+            Node("1"),
+            Node("2"),
+            Node("3")
         ]
         let expected: Node = .sequence(.init([
-            .scalar(.init("1")),
-            .scalar(.init("2")),
-            .scalar(.init("3"))
+            Node("1"),
+            Node("2"),
+            Node("3")
             ]))
         XCTAssertEqual(sequence, expected)
     }
 
     func testExpressibleByDictionaryLiteral() {
-        let sequence: Node = [.scalar(.init("key")): .scalar(.init("value"))]
+        let sequence: Node = [Node("key"): Node("value")]
         let expected: Node = .mapping(.init([
-            Pair(.scalar(.init("key")), .scalar(.init("value")))
+            Pair(Node("key"), Node("value"))
             ]))
         XCTAssertEqual(sequence, expected)
     }
 
     func testExpressibleByFloatLiteral() {
         let sequence: Node = 0.0
-        let expected: Node = .scalar(.init(String(0.0)))
+        let expected: Node = Node(String(0.0))
         XCTAssertEqual(sequence, expected)
     }
 
     func testExpressibleByIntegerLiteral() {
         let sequence: Node = 0
-        let expected: Node = .scalar(.init(String(0)))
+        let expected: Node = Node(String(0))
         XCTAssertEqual(sequence, expected)
     }
 
     func testExpressibleByStringLiteral() {
         let sequence: Node = "string"
-        let expected: Node = .scalar(.init("string"))
+        let expected: Node = Node("string")
         XCTAssertEqual(sequence, expected)
     }
 
@@ -71,7 +71,7 @@ class NodeTests: XCTestCase {
             " +f/++f/++f/++f/++f/++SH+Dk1hZGUgd2l0aCBHSU1QACwAAAAADAAMAAAFLC",
             " AgjoEwnuNAFOhpEMTRiggcz4BNJHrv/zCFcLiwMWYNG84BwwEeECcgggoBADs="
             ].joined()
-        let scalarBinary: Node = .scalar(.init(base64String))
+        let scalarBinary: Node = Node(base64String)
         XCTAssertEqual(scalarBinary.binary, Data(base64Encoded: base64String, options: .ignoreUnknownCharacters)!)
 
         let scalarTimestamp: Node = "2001-12-15T02:59:43.1Z"
@@ -89,9 +89,9 @@ class NodeTests: XCTestCase {
             "true",
             "1.0",
             "1",
-            .scalar(.init(base64String))
+            Node(base64String)
         ]
-        XCTAssertEqual(sequence.array(), ["true", "1.0", "1", .scalar(.init(base64String))] as [Node])
+        XCTAssertEqual(sequence.array(), ["true", "1.0", "1", Node(base64String)] as [Node])
         XCTAssertEqual(sequence.array(of: String.self), ["true", "1.0", "1", base64String])
         XCTAssertEqual(sequence.array() as [String], ["true", "1.0", "1", base64String])
         XCTAssertEqual(sequence.array(of: Bool.self), [true])

--- a/Tests/YamsTests/NodeTests.swift
+++ b/Tests/YamsTests/NodeTests.swift
@@ -28,9 +28,9 @@ class NodeTests: XCTestCase {
 
     func testExpressibleByDictionaryLiteral() {
         let sequence: Node = [.scalar(.init("key")): .scalar(.init("value"))]
-        let expected: Node = .mapping([
+        let expected: Node = .mapping(.init([
             Pair(.scalar(.init("key")), .scalar(.init("value")))
-            ], .implicit, .any)
+            ]))
         XCTAssertEqual(sequence, expected)
     }
 

--- a/Tests/YamsTests/NodeTests.swift
+++ b/Tests/YamsTests/NodeTests.swift
@@ -14,41 +14,41 @@ class NodeTests: XCTestCase {
 
     func testExpressibleByArrayLiteral() {
         let sequence: Node = [
-            .scalar("1", .implicit, .any),
-            .scalar("2", .implicit, .any),
-            .scalar("3", .implicit, .any)
+            .scalar(.init("1")),
+            .scalar(.init("2")),
+            .scalar(.init("3"))
         ]
         let expected: Node = .sequence([
-            .scalar("1", .implicit, .any),
-            .scalar("2", .implicit, .any),
-            .scalar("3", .implicit, .any)
+            .scalar(.init("1")),
+            .scalar(.init("2")),
+            .scalar(.init("3"))
             ], .implicit, .any)
         XCTAssertEqual(sequence, expected)
     }
 
     func testExpressibleByDictionaryLiteral() {
-        let sequence: Node = [.scalar("key", .implicit, .any): .scalar("value", .implicit, .any)]
+        let sequence: Node = [.scalar(.init("key")): .scalar(.init("value"))]
         let expected: Node = .mapping([
-            Pair(.scalar("key", .implicit, .any), .scalar("value", .implicit, .any))
+            Pair(.scalar(.init("key")), .scalar(.init("value")))
             ], .implicit, .any)
         XCTAssertEqual(sequence, expected)
     }
 
     func testExpressibleByFloatLiteral() {
         let sequence: Node = 0.0
-        let expected: Node = .scalar(String(0.0), .implicit, .any)
+        let expected: Node = .scalar(.init(String(0.0)))
         XCTAssertEqual(sequence, expected)
     }
 
     func testExpressibleByIntegerLiteral() {
         let sequence: Node = 0
-        let expected: Node = .scalar(String(0), .implicit, .any)
+        let expected: Node = .scalar(.init(String(0)))
         XCTAssertEqual(sequence, expected)
     }
 
     func testExpressibleByStringLiteral() {
         let sequence: Node = "string"
-        let expected: Node = .scalar("string", .implicit, .any)
+        let expected: Node = .scalar(.init("string"))
         XCTAssertEqual(sequence, expected)
     }
 
@@ -71,7 +71,7 @@ class NodeTests: XCTestCase {
             " +f/++f/++f/++f/++f/++SH+Dk1hZGUgd2l0aCBHSU1QACwAAAAADAAMAAAFLC",
             " AgjoEwnuNAFOhpEMTRiggcz4BNJHrv/zCFcLiwMWYNG84BwwEeECcgggoBADs="
             ].joined()
-        let scalarBinary: Node = .scalar(base64String, .implicit, .any)
+        let scalarBinary: Node = .scalar(.init(base64String))
         XCTAssertEqual(scalarBinary.binary, Data(base64Encoded: base64String, options: .ignoreUnknownCharacters)!)
 
         let scalarTimestamp: Node = "2001-12-15T02:59:43.1Z"
@@ -89,9 +89,9 @@ class NodeTests: XCTestCase {
             "true",
             "1.0",
             "1",
-            .scalar(base64String, .implicit, .any)
+            .scalar(.init(base64String))
         ]
-        XCTAssertEqual(sequence.array(), ["true", "1.0", "1", .scalar(base64String, .implicit, .any)] as [Node])
+        XCTAssertEqual(sequence.array(), ["true", "1.0", "1", .scalar(.init(base64String))] as [Node])
         XCTAssertEqual(sequence.array(of: String.self), ["true", "1.0", "1", base64String])
         XCTAssertEqual(sequence.array() as [String], ["true", "1.0", "1", base64String])
         XCTAssertEqual(sequence.array(of: Bool.self), [true])

--- a/Tests/YamsTests/NodeTests.swift
+++ b/Tests/YamsTests/NodeTests.swift
@@ -28,9 +28,9 @@ class NodeTests: XCTestCase {
 
     func testExpressibleByDictionaryLiteral() {
         let sequence: Node = [Node("key"): Node("value")]
-        let expected: Node = .mapping(.init([
-            Pair(Node("key"), Node("value"))
-            ]))
+        let expected: Node = Node([
+            (Node("key"), Node("value"))
+            ])
         XCTAssertEqual(sequence, expected)
     }
 

--- a/Tests/YamsTests/NodeTests.swift
+++ b/Tests/YamsTests/NodeTests.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 import XCTest
-@testable import Yams
+import Yams
 
 class NodeTests: XCTestCase {
 

--- a/Tests/YamsTests/NodeTests.swift
+++ b/Tests/YamsTests/NodeTests.swift
@@ -18,11 +18,11 @@ class NodeTests: XCTestCase {
             Node("2"),
             Node("3")
         ]
-        let expected: Node = .sequence(.init([
+        let expected: Node = Node([
             Node("1"),
             Node("2"),
             Node("3")
-            ]))
+            ])
         XCTAssertEqual(sequence, expected)
     }
 

--- a/Tests/YamsTests/NodeTests.swift
+++ b/Tests/YamsTests/NodeTests.swift
@@ -18,11 +18,11 @@ class NodeTests: XCTestCase {
             .scalar(.init("2")),
             .scalar(.init("3"))
         ]
-        let expected: Node = .sequence([
+        let expected: Node = .sequence(.init([
             .scalar(.init("1")),
             .scalar(.init("2")),
             .scalar(.init("3"))
-            ], .implicit, .any)
+            ]))
         XCTAssertEqual(sequence, expected)
     }
 

--- a/Tests/YamsTests/RepresenterTests.swift
+++ b/Tests/YamsTests/RepresenterTests.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 import XCTest
-@testable import Yams
+import Yams
 
 class RepresenterTests: XCTestCase {
     func testBool() throws {

--- a/Tests/YamsTests/RepresenterTests.swift
+++ b/Tests/YamsTests/RepresenterTests.swift
@@ -24,7 +24,7 @@ class RepresenterTests: XCTestCase {
             "AgjoEwnuNAFOhpEMTRiggcz4BNJHrv/zCFcLiwMWYNG84BwwEeECcgggoBADs="
             ].joined()
         let data = Data(base64Encoded: base64EncodedString, options: .ignoreUnknownCharacters)!
-        XCTAssertEqual(try Node(data), .scalar(base64EncodedString, Tag(.binary), .any))
+        XCTAssertEqual(try Node(data), .scalar(.init(base64EncodedString, Tag(.binary))))
     }
 
     func testDate() throws {

--- a/Tests/YamsTests/RepresenterTests.swift
+++ b/Tests/YamsTests/RepresenterTests.swift
@@ -24,7 +24,7 @@ class RepresenterTests: XCTestCase {
             "AgjoEwnuNAFOhpEMTRiggcz4BNJHrv/zCFcLiwMWYNG84BwwEeECcgggoBADs="
             ].joined()
         let data = Data(base64Encoded: base64EncodedString, options: .ignoreUnknownCharacters)!
-        XCTAssertEqual(try Node(data), .scalar(.init(base64EncodedString, Tag(.binary))))
+        XCTAssertEqual(try Node(data), Node(base64EncodedString, Tag(.binary)))
     }
 
     func testDate() throws {


### PR DESCRIPTION
- Changes associated value of `Node`:
  - `Node.scalar(String, Tag, Scalar.Style)` to `Node.scalar(Scalar)`
  - `Node.mapping([Pair<Node>], Tag, Mapping.Style)` to `Node.mapping(Mapping)`
  - `Node.sequence([Node], Tag, Sequence.Style)` to `Node.sequence(Sequence)`

- Add initializers to `Node`:
  - `Node.init(_ pairs: [(Node, Node)], _ tag: Tag = .implicit, _ style: Mapping.Style = .any)`
  - `Node.init(_ nodes: [Node], _ tag: Tag = .implicit, _ style: Sequence.Style = .any)`

- Access level of `Pair` is changed to `internal`

I expect this would be an answer to #20.