### PR TITLE
Refactor `Node.Scalar`, `Node.Mapping` and `Node.Sequence`

### DIFF
--- a/Sources/Yams/Constructor.swift
+++ b/Sources/Yams/Constructor.swift
@@ -272,7 +272,7 @@ extension Dictionary {
                         merge.append(contentsOf: mapping)
                     }
                 case let .sequence(sequence):
-                    let submerge = sequence.nodes
+                    let submerge = sequence
                         .filter { $0.isMapping } // TODO: Should raise error on other than mapping
                         .flatMap { flatten_mapping($0).mapping }
                         .reversed()
@@ -307,13 +307,13 @@ extension Set {
 extension Array {
     public static func construct_seq(from node: Node) -> [Any] {
         // swiftlint:disable:next force_unwrapping
-        return node.sequence!.nodes.map(node.tag.constructor.any)
+        return node.sequence!.map(node.tag.constructor.any)
     }
 
     public static func construct_omap(from node: Node) -> [(Any, Any)] {
         // Note: we do not check for duplicate keys.
         assert(node.isSequence) // swiftlint:disable:next force_unwrapping
-        return node.sequence!.nodes.flatMap { subnode -> (Any, Any)? in
+        return node.sequence!.flatMap { subnode -> (Any, Any)? in
             // TODO: Should raise error if subnode is not mapping or mapping.count != 1
             guard let (key, value) = subnode.mapping?.first else { return nil }
             return (node.tag.constructor.any(from: key), node.tag.constructor.any(from: value))
@@ -323,7 +323,7 @@ extension Array {
     public static func construct_pairs(from node: Node) -> [(Any, Any)] {
         // Note: we do not check for duplicate keys.
         assert(node.isSequence) // swiftlint:disable:next force_unwrapping
-        return node.sequence!.nodes.flatMap { subnode -> (Any, Any)? in
+        return node.sequence!.flatMap { subnode -> (Any, Any)? in
             // TODO: Should raise error if subnode is not mapping or mapping.count != 1
             guard let (key, value) = subnode.mapping?.first else { return nil }
             return (node.tag.constructor.any(from: key), node.tag.constructor.any(from: value))

--- a/Sources/Yams/Constructor.swift
+++ b/Sources/Yams/Constructor.swift
@@ -216,8 +216,8 @@ extension String: ScalarConstructible {
     fileprivate static func _construct(from node: Node) -> String {
         // This will happen while `Dictionary.flatten_mapping()` if `node.tag.name` was `.value`
         if case let .mapping(mapping) = node {
-            for pair in mapping.pairs where pair.key.tag.name == .value {
-                return _construct(from: pair.value)
+            for (key, value) in mapping where key.tag.name == .value {
+                return _construct(from: value)
             }
         }
         assert(node.isScalar) // swiftlint:disable:next force_unwrapping
@@ -246,9 +246,9 @@ extension Dictionary {
 
     fileprivate static func _construct_mapping(from node: Node) -> [AnyHashable: Any] {
         assert(node.isMapping) // swiftlint:disable:next force_unwrapping
-        let pairs = flatten_mapping(node).mapping!.pairs
-        var dictionary = [AnyHashable: Any](minimumCapacity: pairs.count)
-        pairs.forEach {
+        let mapping = flatten_mapping(node).mapping!
+        var dictionary = [AnyHashable: Any](minimumCapacity: mapping.count)
+        mapping.forEach {
             // TODO: YAML supports keys other than str.
             dictionary[String._construct(from: $0.key)] = node.tag.constructor.any(from: $0.value)
         }
@@ -258,7 +258,7 @@ extension Dictionary {
     private static func flatten_mapping(_ node: Node) -> Node {
         assert(node.isMapping) // swiftlint:disable:next force_unwrapping
         let mapping = node.mapping!
-        var pairs = mapping.pairs.map(Pair.toTuple)
+        var pairs = Array(mapping)
         var merge = [(key: Node, value: Node)]()
         var index = pairs.startIndex
         while index < pairs.count {
@@ -268,13 +268,13 @@ extension Dictionary {
                 switch pair.value {
                 case .mapping:
                     let flattened_node = flatten_mapping(pair.value)
-                    if let pairs = flattened_node.mapping?.pairs.map(Pair.toTuple) {
-                        merge.append(contentsOf: pairs)
+                    if let mapping = flattened_node.mapping {
+                        merge.append(contentsOf: mapping)
                     }
                 case let .sequence(sequence):
                     let submerge = sequence.nodes
                         .filter { $0.isMapping } // TODO: Should raise error on other than mapping
-                        .flatMap { flatten_mapping($0).mapping?.pairs.map(Pair.toTuple) }
+                        .flatMap { flatten_mapping($0).mapping }
                         .reversed()
                     submerge.forEach {
                         merge.append(contentsOf: $0)
@@ -297,7 +297,7 @@ extension Set {
     public static func construct_set(from node: Node) -> Set<AnyHashable>? {
         // TODO: YAML supports Hashable elements other than str.
         assert(node.isMapping) // swiftlint:disable:next force_unwrapping
-        return Set<AnyHashable>(node.mapping!.pairs.map({ String._construct(from: $0.key) as AnyHashable }))
+        return Set<AnyHashable>(node.mapping!.map({ String._construct(from: $0.key) as AnyHashable }))
         // Explicitly declaring the generic parameter as `<AnyHashable>` above is required,
         // because this is inside extension of `Set` and Swift 3.0.2 can't infer the type without that.
     }
@@ -314,9 +314,9 @@ extension Array {
         // Note: we do not check for duplicate keys.
         assert(node.isSequence) // swiftlint:disable:next force_unwrapping
         return node.sequence!.nodes.flatMap { subnode -> (Any, Any)? in
-            // TODO: Should raise error if subnode is not mapping or pairs.count != 1
-            guard let pairs = subnode.mapping?.pairs, let pair = pairs.first else { return nil }
-            return (node.tag.constructor.any(from: pair.key), node.tag.constructor.any(from: pair.value))
+            // TODO: Should raise error if subnode is not mapping or mapping.count != 1
+            guard let (key, value) = subnode.mapping?.first else { return nil }
+            return (node.tag.constructor.any(from: key), node.tag.constructor.any(from: value))
         }
     }
 
@@ -324,9 +324,9 @@ extension Array {
         // Note: we do not check for duplicate keys.
         assert(node.isSequence) // swiftlint:disable:next force_unwrapping
         return node.sequence!.nodes.flatMap { subnode -> (Any, Any)? in
-            // TODO: Should raise error if subnode is not mapping or pairs.count != 1
-            guard let pairs = subnode.mapping?.pairs, let pair = pairs.first else { return nil }
-            return (node.tag.constructor.any(from: pair.key), node.tag.constructor.any(from: pair.value))
+            // TODO: Should raise error if subnode is not mapping or mapping.count != 1
+            guard let (key, value) = subnode.mapping?.first else { return nil }
+            return (node.tag.constructor.any(from: key), node.tag.constructor.any(from: value))
         }
     }
 }

--- a/Sources/Yams/Emitter.swift
+++ b/Sources/Yams/Emitter.swift
@@ -352,7 +352,7 @@ extension Emitter {
                 sequence_style)
         }
         try emit(&event)
-        try sequence.nodes.forEach(self.serializeNode)
+        try sequence.forEach(self.serializeNode)
         yaml_sequence_end_event_initialize(&event)
         try emit(&event)
     }

--- a/Sources/Yams/Emitter.swift
+++ b/Sources/Yams/Emitter.swift
@@ -360,7 +360,7 @@ extension Emitter {
     private func serializeMappingNode(_ node: Node) throws {
         assert(node.isMapping) // swiftlint:disable:next force_unwrapping
         let mapping = node.mapping!
-        var pairs = mapping.pairs, tag = node.tag.name.rawValue.utf8CString
+        var tag = node.tag.name.rawValue.utf8CString
         let implicit: Int32 = node.tag.name == Tag.Name.map ? 1 : 0
         let mapping_style = yaml_mapping_style_t(rawValue: mapping.style.rawValue)
         var event = yaml_event_t()
@@ -373,9 +373,9 @@ extension Emitter {
                 mapping_style)
         }
         try emit(&event)
-        try pairs.forEach { pair in
-            try self.serializeNode(pair.key)
-            try self.serializeNode(pair.value)
+        try mapping.forEach { (key, value) in
+            try self.serializeNode(key)
+            try self.serializeNode(value)
         }
         yaml_mapping_end_event_initialize(&event)
         try emit(&event)

--- a/Sources/Yams/Node.Mapping.swift
+++ b/Sources/Yams/Node.Mapping.swift
@@ -53,7 +53,7 @@ extension Node.Mapping: Comparable {
 
 extension Node.Mapping: Equatable {
     public static func == (lhs: Node.Mapping, rhs: Node.Mapping) -> Bool {
-        return lhs.pairs == rhs.pairs && lhs.tag.resolved(with: lhs) == rhs.tag.resolved(with: rhs)
+        return lhs.pairs == rhs.pairs && lhs.resolvedTag == rhs.resolvedTag
     }
 }
 
@@ -96,6 +96,10 @@ extension Node.Mapping: MutableCollection {
             pairs[index] = Pair(newValue.key, newValue.value)
         }
     }
+}
+
+extension Node.Mapping: TagResolvable {
+    static let defaultTagName = Tag.Name.map
 }
 
 extension Node.Mapping {

--- a/Sources/Yams/Node.Mapping.swift
+++ b/Sources/Yams/Node.Mapping.swift
@@ -1,0 +1,164 @@
+//
+//  Node.Mapping.swift
+//  Yams
+//
+//  Created by Norio Nomura on 2/24/17.
+//  Copyright (c) 2016 Yams. All rights reserved.
+//
+
+import Foundation
+
+extension Node {
+    public struct Mapping {
+        fileprivate var pairs: [Pair<Node>]
+        public var tag: Tag
+        public var style: Style
+
+        public enum Style: UInt32 { // swiftlint:disable:this nesting
+            /// Let the emitter choose the style.
+            case any
+            /// The block mapping style.
+            case block
+            /// The flow mapping style.
+            case flow
+        }
+
+        public init(_ pairs: [(Node, Node)], _ tag: Tag = .implicit, _ style: Style = .any) {
+            self.pairs = pairs.map(Pair.init)
+            self.tag = tag
+            self.style = style
+        }
+    }
+
+    public var mapping: Mapping? {
+        get {
+            if case let .mapping(mapping) = self {
+                return mapping
+            }
+            return nil
+        }
+        set {
+            if let newValue = newValue {
+                self = .mapping(newValue)
+            }
+        }
+    }
+}
+
+extension Node.Mapping: Comparable {
+    public static func < (lhs: Node.Mapping, rhs: Node.Mapping) -> Bool {
+        return lhs.pairs < rhs.pairs
+    }
+}
+
+extension Node.Mapping: Equatable {
+    public static func == (lhs: Node.Mapping, rhs: Node.Mapping) -> Bool {
+        return lhs.pairs == rhs.pairs && lhs.tag.resolved(with: lhs) == rhs.tag.resolved(with: rhs)
+    }
+}
+
+extension Node.Mapping: ExpressibleByDictionaryLiteral {
+    public init(dictionaryLiteral elements: (Node, Node)...) {
+        self.init(elements)
+    }
+}
+
+extension Node.Mapping: MutableCollection {
+    public typealias Element = (key: Node, value: Node)
+
+    // Sequence
+    public func makeIterator() -> Array<Element>.Iterator {
+        let iterator = pairs.map(Pair.toTuple).makeIterator()
+        return iterator
+    }
+
+    // Collection
+    public typealias Index = Array<Element>.Index
+
+    public var startIndex: Int {
+        return pairs.startIndex
+    }
+
+    public var endIndex: Int {
+        return pairs.endIndex
+    }
+
+    public func index(after index: Int) -> Int {
+        return pairs.index(after:index)
+    }
+
+    public subscript(index: Int) -> Element {
+        get {
+            return (key: pairs[index].key, value: pairs[index].value)
+        }
+        // MutableCollection
+        set {
+            pairs[index] = Pair(newValue.key, newValue.value)
+        }
+    }
+}
+
+extension Node.Mapping {
+    public var keys: LazyMapCollection<Node.Mapping, Node> {
+        return lazy.map { $0.key }
+    }
+
+    public var values: LazyMapCollection<Node.Mapping, Node> {
+        return lazy.map { $0.value }
+    }
+
+    public subscript(string: String) -> Node? {
+        get {
+            return self[Node(string)]
+        }
+        set {
+            self[Node(string)] = newValue
+        }
+    }
+
+    public subscript(node: Node) -> Node? {
+        get {
+            let v = pairs.reversed().first(where: { $0.key == node })
+            return v?.value
+        }
+        set {
+            if let newValue = newValue {
+                if let index = index(forKey: node) {
+                    pairs[index] = Pair(pairs[index].key, newValue)
+                } else {
+                    pairs.append(Pair(node, newValue))
+                }
+            } else {
+                if let index = index(forKey: node) {
+                    pairs.remove(at: index)
+                }
+            }
+        }
+    }
+
+    public func index(forKey key: Node) -> Int? {
+        return pairs.reversed().index(where: { $0.key == key }).map({ pairs.index(before: $0.base) })
+    }
+}
+
+private struct Pair<Value: Comparable & Equatable>: Comparable, Equatable {
+    let key: Value
+    let value: Value
+
+    init(_ key: Value, _ value: Value) {
+        self.key = key
+        self.value = value
+    }
+
+    static func == (lhs: Pair, rhs: Pair) -> Bool {
+        return lhs.key == rhs.key && lhs.value == rhs.value
+    }
+
+    static func < (lhs: Pair<Value>, rhs: Pair<Value>) -> Bool {
+        return lhs.key < rhs.key
+    }
+
+    static func toTuple(pair: Pair) -> (key: Value, value: Value) {
+        return (key: pair.key, value: pair.value)
+    }
+}

--- a/Sources/Yams/Node.Scalar.swift
+++ b/Sources/Yams/Node.Scalar.swift
@@ -10,7 +10,11 @@ import Foundation
 
 extension Node {
     public struct Scalar {
-        public var string: String
+        public var string: String {
+            didSet {
+                tag = .implicit
+            }
+        }
         public var tag: Tag
         public var style: Style
 
@@ -61,6 +65,13 @@ extension Node.Scalar: Comparable {
 
 extension Node.Scalar: Equatable {
     public static func == (lhs: Node.Scalar, rhs: Node.Scalar) -> Bool {
-        return lhs.string == rhs.string && lhs.tag.resolved(with: lhs) == rhs.tag.resolved(with: rhs)
+        return lhs.string == rhs.string && lhs.resolvedTag == rhs.resolvedTag
+    }
+}
+
+extension Node.Scalar: TagResolvable {
+    static let defaultTagName = Tag.Name.str
+    func resolveTag(using resolver: Resolver) -> Tag.Name {
+        return tag.name == .implicit ? resolver.resolveTag(from: string) : tag.name
     }
 }

--- a/Sources/Yams/Node.Scalar.swift
+++ b/Sources/Yams/Node.Scalar.swift
@@ -1,0 +1,66 @@
+//
+//  Node.Scalar.swift
+//  Yams
+//
+//  Created by Norio Nomura on 2/24/17.
+//  Copyright (c) 2016 Yams. All rights reserved.
+//
+
+import Foundation
+
+extension Node {
+    public struct Scalar {
+        public var string: String
+        public var tag: Tag
+        public var style: Style
+
+        public enum Style: UInt32 { // swiftlint:disable:this nesting
+            /// Let the emitter choose the style.
+            case any = 0
+            /// The plain scalar style.
+            case plain
+
+            /// The single-quoted scalar style.
+            case singleQuoted
+            /// The double-quoted scalar style.
+            case doubleQuoted
+
+            /// The literal scalar style.
+            case literal
+            /// The folded scalar style.
+            case folded
+        }
+
+        public init(_ string: String, _ tag: Tag = .implicit, _ style: Style = .any) {
+            self.string = string
+            self.tag = tag
+            self.style = style
+        }
+    }
+
+    public var scalar: Scalar? {
+        get {
+            if case let .scalar(scalar) = self {
+                return scalar
+            }
+            return nil
+        }
+        set {
+            if let newValue = newValue {
+                self = .scalar(newValue)
+            }
+        }
+    }
+}
+
+extension Node.Scalar: Comparable {
+    public static func < (lhs: Node.Scalar, rhs: Node.Scalar) -> Bool {
+        return lhs.string < rhs.string
+    }
+}
+
+extension Node.Scalar: Equatable {
+    public static func == (lhs: Node.Scalar, rhs: Node.Scalar) -> Bool {
+        return lhs.string == rhs.string && lhs.tag.resolved(with: lhs) == rhs.tag.resolved(with: rhs)
+    }
+}

--- a/Sources/Yams/Node.Sequence.swift
+++ b/Sources/Yams/Node.Sequence.swift
@@ -1,0 +1,139 @@
+//
+//  Node.Sequence.swift
+//  Yams
+//
+//  Created by Norio Nomura on 2/24/17.
+//  Copyright (c) 2016 Yams. All rights reserved.
+//
+
+import Foundation
+
+extension Node {
+    public struct Sequence {
+        fileprivate var nodes: [Node]
+        public var tag: Tag
+        public var style: Style
+
+        public enum Style: UInt32 { // swiftlint:disable:this nesting
+            /// Let the emitter choose the style.
+            case any
+            /// The block sequence style.
+            case block
+            /// The flow sequence style.
+            case flow
+        }
+
+        public init(_ nodes: [Node], _ tag: Tag = .implicit, _ style: Style = .any) {
+            self.nodes = nodes
+            self.tag = tag
+            self.style = style
+        }
+    }
+
+    public var sequence: Sequence? {
+        get {
+            if case let .sequence(sequence) = self {
+                return sequence
+            }
+            return nil
+        }
+        set {
+            if let newValue = newValue {
+                self = .sequence(newValue)
+            }
+        }
+    }
+}
+
+// MARK: - Node.Sequence
+
+extension Node.Sequence: Comparable {
+    public static func < (lhs: Node.Sequence, rhs: Node.Sequence) -> Bool {
+        return lhs.nodes < rhs.nodes
+    }
+}
+
+extension Node.Sequence: Equatable {
+    public static func == (lhs: Node.Sequence, rhs: Node.Sequence) -> Bool {
+        return lhs.nodes == rhs.nodes && lhs.tag.resolved(with: lhs) == rhs.tag.resolved(with: rhs)
+    }
+}
+
+extension Node.Sequence: ExpressibleByArrayLiteral {
+    public init(arrayLiteral elements: Node...) {
+        self.init(elements)
+    }
+}
+
+extension Node.Sequence: MutableCollection {
+    // Sequence
+    public func makeIterator() -> Array<Node>.Iterator {
+        return nodes.makeIterator()
+    }
+
+    // Collection
+    public typealias Index = Array<Node>.Index
+
+    public var startIndex: Index {
+        return nodes.startIndex
+    }
+
+    public var endIndex: Index {
+        return nodes.endIndex
+    }
+
+    public func index(after index: Index) -> Index {
+        return nodes.index(after: index)
+    }
+
+    public subscript(index: Index) -> Node {
+        get {
+            return nodes[index]
+        }
+        // MutableCollection
+        set {
+            nodes[index] = newValue
+        }
+    }
+
+    public subscript(bounds: Range<Index>) -> Array<Node>.SubSequence {
+        get {
+            return nodes[bounds]
+        }
+        // MutableCollection
+        set {
+            nodes[bounds] = newValue
+        }
+    }
+
+    public var indices: Array<Node>.Indices {
+        return nodes.indices
+    }
+}
+
+extension Node.Sequence: RandomAccessCollection {
+    // BidirectionalCollection
+    public func index(before index: Index) -> Index {
+        return nodes.index(before: index)
+    }
+
+    // RandomAccessCollection
+    public func index(_ index: Index, offsetBy num: Int) -> Index {
+        return nodes.index(index, offsetBy: num)
+    }
+
+    public func distance(from start: Index, to end: Int) -> Index {
+        return nodes.distance(from: start, to: end)
+    }
+}
+
+extension Node.Sequence: RangeReplaceableCollection {
+    public init() {
+        self.init([])
+    }
+
+    public mutating func replaceSubrange<C>(_ subrange: Range<Int>, with newElements: C)
+        where C : Collection, C.Iterator.Element == Node {
+            nodes.replaceSubrange(subrange, with: newElements)
+    }
+}

--- a/Sources/Yams/Node.Sequence.swift
+++ b/Sources/Yams/Node.Sequence.swift
@@ -55,7 +55,7 @@ extension Node.Sequence: Comparable {
 
 extension Node.Sequence: Equatable {
     public static func == (lhs: Node.Sequence, rhs: Node.Sequence) -> Bool {
-        return lhs.nodes == rhs.nodes && lhs.tag.resolved(with: lhs) == rhs.tag.resolved(with: rhs)
+        return lhs.nodes == rhs.nodes && lhs.resolvedTag == rhs.resolvedTag
     }
 }
 
@@ -136,4 +136,8 @@ extension Node.Sequence: RangeReplaceableCollection {
         where C : Collection, C.Iterator.Element == Node {
             nodes.replaceSubrange(subrange, with: newElements)
     }
+}
+
+extension Node.Sequence: TagResolvable {
+    static let defaultTagName = Tag.Name.seq
 }

--- a/Sources/Yams/Node.swift
+++ b/Sources/Yams/Node.swift
@@ -29,51 +29,6 @@ extension Node {
 }
 
 extension Node {
-    public struct Scalar {
-        public var string: String
-        public var tag: Tag
-        public var style: Style
-
-        public enum Style: UInt32 { // swiftlint:disable:this nesting
-            /// Let the emitter choose the style.
-            case any = 0
-            /// The plain scalar style.
-            case plain
-
-            /// The single-quoted scalar style.
-            case singleQuoted
-            /// The double-quoted scalar style.
-            case doubleQuoted
-
-            /// The literal scalar style.
-            case literal
-            /// The folded scalar style.
-            case folded
-        }
-
-        public init(_ string: String, _ tag: Tag = .implicit, _ style: Style = .any) {
-            self.string = string
-            self.tag = tag
-            self.style = style
-        }
-    }
-
-    public var scalar: Scalar? {
-        get {
-            if case let .scalar(scalar) = self {
-                return scalar
-            }
-            return nil
-        }
-        set {
-            if let newValue = newValue {
-                self = .scalar(newValue)
-            }
-        }
-    }
-}
-
-extension Node {
     /// Accessing this property causes the tag to be resolved by tag.resolver.
     public var tag: Tag {
         switch self {
@@ -216,7 +171,7 @@ extension Node: Comparable {
     public static func < (lhs: Node, rhs: Node) -> Bool {
         switch (lhs, rhs) {
         case let (.scalar(lhs), .scalar(rhs)):
-            return lhs.string < rhs.string
+            return lhs < rhs
         case let (.mapping(lhs), .mapping(rhs)):
             return lhs < rhs
         case let (.sequence(lhs), .sequence(rhs)):
@@ -276,14 +231,6 @@ extension Node: ExpressibleByStringLiteral {
 
     public init(unicodeScalarLiteral value: String) {
         self.init(value)
-    }
-}
-
-// MARK: - Node.Scalar
-
-extension Node.Scalar: Equatable {
-    public static func == (lhs: Node.Scalar, rhs: Node.Scalar) -> Bool {
-        return lhs.string == rhs.string && lhs.tag.resolved(with: lhs) == rhs.tag.resolved(with: rhs)
     }
 }
 

--- a/Sources/Yams/Node.swift
+++ b/Sources/Yams/Node.swift
@@ -304,15 +304,12 @@ extension Node: Hashable {
 
     public static func == (lhs: Node, rhs: Node) -> Bool {
         switch (lhs, rhs) {
-        case let (.scalar(lhsValue), .scalar(rhsValue)):
-            return lhsValue.string == rhsValue.string &&
-                lhsValue.tag.resolved(with: lhs) == rhsValue.tag.resolved(with: rhs)
-        case let (.mapping(lhsValue), .mapping(rhsValue)):
-            return lhsValue.pairs == rhsValue.pairs &&
-                lhsValue.tag.resolved(with: lhs) == rhsValue.tag.resolved(with: rhs)
-        case let (.sequence(lhsValue), .sequence(rhsValue)):
-            return lhsValue.nodes == rhsValue.nodes &&
-                lhsValue.tag.resolved(with: lhs) == rhsValue.tag.resolved(with: rhs)
+        case let (.scalar(lhs), .scalar(rhs)):
+            return lhs == rhs
+        case let (.mapping(lhs), .mapping(rhs)):
+            return lhs == rhs
+        case let (.sequence(lhs), .sequence(rhs)):
+            return lhs == rhs
         default:
             return false
         }
@@ -386,11 +383,19 @@ extension Node: ExpressibleByStringLiteral {
     }
 }
 
+// MARK: - Node.Scalar
+
+extension Node.Scalar: Equatable {
+    public static func == (lhs: Node.Scalar, rhs: Node.Scalar) -> Bool {
+        return lhs.string == rhs.string && lhs.tag.resolved(with: lhs) == rhs.tag.resolved(with: rhs)
+    }
+}
+
 // MARK: - Node.Mapping
 
 extension Node.Mapping: Equatable {
     public static func == (lhs: Node.Mapping, rhs: Node.Mapping) -> Bool {
-        return lhs.pairs == rhs.pairs
+        return lhs.pairs == rhs.pairs && lhs.tag.resolved(with: lhs) == rhs.tag.resolved(with: rhs)
     }
 }
 
@@ -480,7 +485,7 @@ extension Node.Mapping {
 
 extension Node.Sequence: Equatable {
     public static func == (lhs: Node.Sequence, rhs: Node.Sequence) -> Bool {
-        return lhs.nodes == rhs.nodes
+        return lhs.nodes == rhs.nodes && lhs.tag.resolved(with: lhs) == rhs.tag.resolved(with: rhs)
     }
 }
 

--- a/Sources/Yams/Node.swift
+++ b/Sources/Yams/Node.swift
@@ -72,41 +72,6 @@ extension Node {
         }
     }
 
-    public struct Mapping {
-        internal var pairs: [Pair<Node>]
-        public var tag: Tag
-        public var style: Style
-
-        public enum Style: UInt32 { // swiftlint:disable:this nesting
-            /// Let the emitter choose the style.
-            case any
-            /// The block mapping style.
-            case block
-            /// The flow mapping style.
-            case flow
-        }
-
-        public init(_ pairs: [(Node, Node)], _ tag: Tag = .implicit, _ style: Style = .any) {
-            self.pairs = pairs.map(Pair.init)
-            self.tag = tag
-            self.style = style
-        }
-    }
-
-    public var mapping: Mapping? {
-        get {
-            if case let .mapping(mapping) = self {
-                return mapping
-            }
-            return nil
-        }
-        set {
-            if let newValue = newValue {
-                self = .mapping(newValue)
-            }
-        }
-    }
-
     public struct Sequence {
         internal var nodes: [Node]
         public var tag: Tag
@@ -142,28 +107,6 @@ extension Node {
         }
     }
 
-}
-
-struct Pair<Value: Comparable & Equatable>: Comparable, Equatable {
-    let key: Value
-    let value: Value
-
-    init(_ key: Value, _ value: Value) {
-        self.key = key
-        self.value = value
-    }
-
-    static func == (lhs: Pair, rhs: Pair) -> Bool {
-        return lhs.key == rhs.key && lhs.value == rhs.value
-    }
-
-    static func < (lhs: Pair<Value>, rhs: Pair<Value>) -> Bool {
-        return lhs.key < rhs.key
-    }
-
-    static func toTuple(pair: Pair) -> (key: Value, value: Value) {
-        return (key: pair.key, value: pair.value)
-    }
 }
 
 extension Node {
@@ -245,7 +188,7 @@ extension Node {
             switch self {
             case .scalar: return nil
             case let .mapping(mapping):
-                return mapping.pairs.reversed().first(where: { $0.key == node })?.value
+                return mapping[node]
             case let .sequence(sequence):
                 guard let index = node.int, 0 <= index, index < sequence.nodes.count else { return nil }
                 return sequence.nodes[index]
@@ -256,10 +199,8 @@ extension Node {
             switch self {
             case .scalar: return
             case .mapping(var mapping):
-                if let index = mapping.pairs.index(where: { $0.key == node }) {
-                    mapping.pairs[index] = Pair(mapping.pairs[index].key, newValue)
-                    self = .mapping(mapping)
-                }
+                mapping[node] = newValue
+                self = .mapping(mapping)
             case .sequence(var sequence):
                 guard let index = node.int, 0 <= index, index < sequence.nodes.count else { return}
                 sequence.nodes[index] = newValue
@@ -296,7 +237,7 @@ extension Node: Hashable {
         case let .scalar(scalar):
             return scalar.string.hashValue
         case let .mapping(mapping):
-            return mapping.pairs.count
+            return mapping.count
         case let .sequence(sequence):
             return sequence.nodes.count
         }
@@ -322,7 +263,7 @@ extension Node: Comparable {
         case let (.scalar(lhs), .scalar(rhs)):
             return lhs.string < rhs.string
         case let (.mapping(lhs), .mapping(rhs)):
-            return lhs.pairs < rhs.pairs
+            return lhs < rhs
         case let (.sequence(lhs), .sequence(rhs)):
             return lhs.nodes < rhs.nodes
         default:
@@ -388,96 +329,6 @@ extension Node: ExpressibleByStringLiteral {
 extension Node.Scalar: Equatable {
     public static func == (lhs: Node.Scalar, rhs: Node.Scalar) -> Bool {
         return lhs.string == rhs.string && lhs.tag.resolved(with: lhs) == rhs.tag.resolved(with: rhs)
-    }
-}
-
-// MARK: - Node.Mapping
-
-extension Node.Mapping: Equatable {
-    public static func == (lhs: Node.Mapping, rhs: Node.Mapping) -> Bool {
-        return lhs.pairs == rhs.pairs && lhs.tag.resolved(with: lhs) == rhs.tag.resolved(with: rhs)
-    }
-}
-
-extension Node.Mapping: ExpressibleByDictionaryLiteral {
-    public init(dictionaryLiteral elements: (Node, Node)...) {
-        self.init(elements)
-    }
-}
-
-extension Node.Mapping: MutableCollection {
-    public typealias Element = (key: Node, value: Node)
-
-    // Sequence
-    public func makeIterator() -> Array<Element>.Iterator {
-        let iterator = pairs.map(Pair.toTuple).makeIterator()
-        return iterator
-    }
-
-    // Collection
-    public typealias Index = Array<Element>.Index
-
-    public var startIndex: Int {
-        return pairs.startIndex
-    }
-
-    public var endIndex: Int {
-        return pairs.endIndex
-    }
-
-    public func index(after index: Int) -> Int {
-        return pairs.index(after:index)
-    }
-
-    public subscript(index: Int) -> Element {
-        get {
-            return (key: pairs[index].key, value: pairs[index].value)
-        }
-        // MutableCollection
-        set {
-            pairs[index] = Pair(newValue.key, newValue.value)
-        }
-    }
-}
-
-extension Node.Mapping {
-    public var keys: LazyMapCollection<Node.Mapping, Node> {
-        return lazy.map { $0.key }
-    }
-
-    public var values: LazyMapCollection<Node.Mapping, Node> {
-        return lazy.map { $0.value }
-    }
-
-    public subscript(string: String) -> Node? {
-        get {
-            return self[Node(string)]
-        }
-        set {
-            self[Node(string)] = newValue
-        }
-    }
-
-    public subscript(node: Node) -> Node? {
-        get {
-            let v = pairs.reversed().first(where: { $0.key == node })
-            return v?.value
-        }
-        set {
-            if let newValue = newValue {
-                if let index = pairs.reversed().index(where: { $0.key == node }) {
-                    let actualIndex = pairs.index(before: index.base)
-                    pairs[actualIndex] = Pair(pairs[actualIndex].key, newValue)
-                } else {
-                    pairs.append(Pair(node, newValue))
-                }
-            } else {
-                if let index = pairs.reversed().index(where: { $0.key == node }) {
-                    let actualIndex = pairs.index(before: index.base)
-                    pairs.remove(at: actualIndex)
-                }
-            }
-        }
     }
 }
 

--- a/Sources/Yams/Node.swift
+++ b/Sources/Yams/Node.swift
@@ -32,9 +32,9 @@ extension Node {
     /// Accessing this property causes the tag to be resolved by tag.resolver.
     public var tag: Tag {
         switch self {
-        case let .scalar(scalar): return scalar.tag.resolved(with: self)
-        case let .mapping(mapping): return mapping.tag.resolved(with: self)
-        case let .sequence(sequence): return sequence.tag.resolved(with: self)
+        case let .scalar(scalar): return scalar.resolvedTag
+        case let .mapping(mapping): return mapping.resolvedTag
+        case let .sequence(sequence): return sequence.resolvedTag
         }
     }
 

--- a/Sources/Yams/Resolver.swift
+++ b/Sources/Yams/Resolver.swift
@@ -17,12 +17,26 @@ public final class Resolver {
     public func resolveTag(of node: Node) -> Tag.Name {
         switch node {
         case let .scalar(scalar):
-            return scalar.tag.name == .implicit ? resolveTag(from: scalar.string) : scalar.tag.name
+            return resolveTag(of: scalar)
         case let .mapping(mapping):
-            return mapping.tag.name == .implicit ? .map : mapping.tag.name
+            return resolveTag(of: mapping)
         case let .sequence(sequence):
-            return sequence.tag.name == .implicit ? .seq : sequence.tag.name
+            return resolveTag(of: sequence)
         }
+    }
+
+    // MARK: - internal
+    
+    func resolveTag(of scalar: Node.Scalar) -> Tag.Name {
+        return scalar.tag.name == .implicit ? resolveTag(from: scalar.string) : scalar.tag.name
+    }
+
+    func resolveTag(of mapping: Node.Mapping) -> Tag.Name {
+        return mapping.tag.name == .implicit ? .map : mapping.tag.name
+    }
+
+    func resolveTag(of sequence: Node.Sequence) -> Tag.Name {
+        return sequence.tag.name == .implicit ? .seq : sequence.tag.name
     }
 
     private func resolveTag(from string: String) -> Tag.Name {

--- a/Sources/Yams/Resolver.swift
+++ b/Sources/Yams/Resolver.swift
@@ -27,19 +27,11 @@ public final class Resolver {
 
     // MARK: - internal
 
-    func resolveTag(of scalar: Node.Scalar) -> Tag.Name {
-        return scalar.tag.name == .implicit ? resolveTag(from: scalar.string) : scalar.tag.name
+    func resolveTag<T>(of value: T) -> Tag.Name where T: TagResolvable {
+        return value.resolveTag(using: self)
     }
 
-    func resolveTag(of mapping: Node.Mapping) -> Tag.Name {
-        return mapping.tag.name == .implicit ? .map : mapping.tag.name
-    }
-
-    func resolveTag(of sequence: Node.Sequence) -> Tag.Name {
-        return sequence.tag.name == .implicit ? .seq : sequence.tag.name
-    }
-
-    private func resolveTag(from string: String) -> Tag.Name {
+    func resolveTag(from string: String) -> Tag.Name {
         for (tag, regexp) in tagNamePatternPairs where regexp.matches(in: string) {
             return tag
         }

--- a/Sources/Yams/Resolver.swift
+++ b/Sources/Yams/Resolver.swift
@@ -26,7 +26,7 @@ public final class Resolver {
     }
 
     // MARK: - internal
-    
+
     func resolveTag(of scalar: Node.Scalar) -> Tag.Name {
         return scalar.tag.name == .implicit ? resolveTag(from: scalar.string) : scalar.tag.name
     }

--- a/Sources/Yams/Tag.swift
+++ b/Sources/Yams/Tag.swift
@@ -31,37 +31,11 @@ public final class Tag {
         self.name = name
     }
 
-    func resolved(with node: Node) -> Tag {
-        switch node {
-        case let .scalar(scalar): return resolved(with: scalar)
-        case let .mapping(mapping): return resolved(with: mapping)
-        case let .sequence(sequence):  return resolved(with: sequence)
-        }
-    }
-
-    func resolved(with scalar: Node.Scalar) -> Tag {
+    func resolved<T>(with value: T) -> Tag where T: TagResolvable {
         if name == .implicit {
-            name = resolver.resolveTag(of: scalar)
+            name = resolver.resolveTag(of: value)
         } else if name == .nonSpecific {
-            name = .str
-        }
-        return self
-    }
-
-    func resolved(with mapping: Node.Mapping) -> Tag {
-        if name == .implicit {
-            name = resolver.resolveTag(of: mapping)
-        } else if name == .nonSpecific {
-            name = .map
-        }
-        return self
-    }
-
-    func resolved(with sequence: Node.Sequence) -> Tag {
-        if name == .implicit {
-            name = resolver.resolveTag(of: sequence)
-        } else if name == .nonSpecific {
-            name = .seq
+            name = T.defaultTagName
         }
         return self
     }
@@ -72,6 +46,12 @@ public final class Tag {
 
     // fileprivate
     fileprivate let resolver: Resolver
+}
+
+extension Tag: CustomStringConvertible {
+    public var description: String {
+        return name.rawValue
+    }
 }
 
 extension Tag: Hashable {
@@ -149,4 +129,20 @@ extension Tag.Name {
     public static let value: Tag.Name  = "tag:yaml.org,2002:value"
     /// "tag:yaml.org,2002:yaml" <http://yaml.org/type/yaml.html> We don't support this.
     public static let yaml: Tag.Name  = "tag:yaml.org,2002:yaml"
+}
+
+protocol TagResolvable {
+    var tag: Tag { get }
+    static var defaultTagName: Tag.Name { get }
+    func resolveTag(using resolver: Resolver) -> Tag.Name
+}
+
+extension TagResolvable {
+    var resolvedTag: Tag {
+        return tag.resolved(with: self)
+    }
+
+    func resolveTag(using resolver: Resolver) -> Tag.Name {
+        return tag.name == .implicit ? Self.defaultTagName : tag.name
+    }
 }

--- a/Sources/Yams/Tag.swift
+++ b/Sources/Yams/Tag.swift
@@ -24,8 +24,8 @@ public final class Tag {
     var name: Name
 
     public init(_ name: Name,
-         _ resolver: Resolver = .default,
-         _ constructor: Constructor = .default) {
+                _ resolver: Resolver = .default,
+                _ constructor: Constructor = .default) {
         self.resolver = resolver
         self.constructor = constructor
         self.name = name

--- a/Sources/Yams/Tag.swift
+++ b/Sources/Yams/Tag.swift
@@ -32,14 +32,36 @@ public final class Tag {
     }
 
     func resolved(with node: Node) -> Tag {
+        switch node {
+        case let .scalar(scalar): return resolved(with: scalar)
+        case let .mapping(mapping): return resolved(with: mapping)
+        case let .sequence(sequence):  return resolved(with: sequence)
+        }
+    }
+
+    func resolved(with scalar: Node.Scalar) -> Tag {
         if name == .implicit {
-            name = resolver.resolveTag(of: node)
+            name = resolver.resolveTag(of: scalar)
         } else if name == .nonSpecific {
-            switch node {
-            case .scalar: name = .str
-            case .mapping: name = .map
-            case .sequence: name = .seq
-            }
+            name = .str
+        }
+        return self
+    }
+
+    func resolved(with mapping: Node.Mapping) -> Tag {
+        if name == .implicit {
+            name = resolver.resolveTag(of: mapping)
+        } else if name == .nonSpecific {
+            name = .map
+        }
+        return self
+    }
+
+    func resolved(with sequence: Node.Sequence) -> Tag {
+        if name == .implicit {
+            name = resolver.resolveTag(of: sequence)
+        } else if name == .nonSpecific {
+            name = .seq
         }
         return self
     }

--- a/Tests/YamsTests/NodeTests.swift
+++ b/Tests/YamsTests/NodeTests.swift
@@ -186,6 +186,13 @@ class NodeTests: XCTestCase {
         // ExpressibleByArrayLiteral
         XCTAssertEqual(sequence, ["value1", "value2", "value3"])
     }
+
+    func testScalar() {
+        var node = Node("1")
+        XCTAssertEqual(node.tag, Tag(.int))
+        node.scalar?.string = "test"
+        XCTAssertEqual(node.tag, Tag(.str))
+    }
 }
 
 extension NodeTests {
@@ -201,7 +208,8 @@ extension NodeTests {
             ("testSubscriptMapping", testSubscriptMapping),
             ("testSubscriptSequence", testSubscriptSequence),
             ("testMappingBehavesLikeADictionary", testMappingBehavesLikeADictionary),
-            ("testSequenceBehavesLikeAnArray", testSequenceBehavesLikeAnArray)
+            ("testSequenceBehavesLikeAnArray", testSequenceBehavesLikeAnArray),
+            ("testScalar", testScalar)
         ]
     }
 }

--- a/Yams.xcodeproj/project.pbxproj
+++ b/Yams.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		6C0409A81E602E9A00C95D83 /* Node.Mapping.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C0409A71E602E9A00C95D83 /* Node.Mapping.swift */; };
 		6C0488EC1E0BE113006F9F80 /* TestHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C0488EB1E0BE113006F9F80 /* TestHelper.swift */; };
 		6C0488EE1E0CBD56006F9F80 /* ConstructorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C0488ED1E0CBD56006F9F80 /* ConstructorTests.swift */; };
 		6C0A00D51E152D6200222704 /* EmitterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C0A00D41E152D6200222704 /* EmitterTests.swift */; };
@@ -50,6 +51,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		6C0409A71E602E9A00C95D83 /* Node.Mapping.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Node.Mapping.swift; sourceTree = "<group>"; };
 		6C0488EB1E0BE113006F9F80 /* TestHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestHelper.swift; sourceTree = "<group>"; };
 		6C0488ED1E0CBD56006F9F80 /* ConstructorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConstructorTests.swift; sourceTree = "<group>"; };
 		6C0A00D41E152D6200222704 /* EmitterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EmitterTests.swift; sourceTree = "<group>"; };
@@ -119,6 +121,7 @@
 				6C0D2A351E0A934B00C45545 /* Constructor.swift */,
 				6CE603971E13502E00A13D8D /* Emitter.swift */,
 				6C6834C71E0281880047B4D1 /* Node.swift */,
+				6C0409A71E602E9A00C95D83 /* Node.Mapping.swift */,
 				6C6834CB1E0283980047B4D1 /* Parser.swift */,
 				6CC2E33E1E22347B00F62269 /* Representer.swift */,
 				6C6834D21E02B9760047B4D1 /* Resolver.swift */,
@@ -319,6 +322,7 @@
 				6C6834C81E0281880047B4D1 /* Node.swift in Sources */,
 				6C0D2A361E0A934B00C45545 /* Constructor.swift in Sources */,
 				6C6834D31E02B9760047B4D1 /* Resolver.swift in Sources */,
+				6C0409A81E602E9A00C95D83 /* Node.Mapping.swift in Sources */,
 				E8EDB8881DE2181B0062268D /* loader.c in Sources */,
 				E8EDB88C1DE2181B0062268D /* writer.c in Sources */,
 				E8EDB88B1DE2181B0062268D /* scanner.c in Sources */,

--- a/Yams.xcodeproj/project.pbxproj
+++ b/Yams.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		6C0409A81E602E9A00C95D83 /* Node.Mapping.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C0409A71E602E9A00C95D83 /* Node.Mapping.swift */; };
 		6C0409AA1E6033DF00C95D83 /* Node.Sequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C0409A91E6033DF00C95D83 /* Node.Sequence.swift */; };
+		6C0409AC1E607E9900C95D83 /* Node.Scalar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C0409AB1E607E9900C95D83 /* Node.Scalar.swift */; };
 		6C0488EC1E0BE113006F9F80 /* TestHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C0488EB1E0BE113006F9F80 /* TestHelper.swift */; };
 		6C0488EE1E0CBD56006F9F80 /* ConstructorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C0488ED1E0CBD56006F9F80 /* ConstructorTests.swift */; };
 		6C0A00D51E152D6200222704 /* EmitterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C0A00D41E152D6200222704 /* EmitterTests.swift */; };
@@ -54,6 +55,7 @@
 /* Begin PBXFileReference section */
 		6C0409A71E602E9A00C95D83 /* Node.Mapping.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Node.Mapping.swift; sourceTree = "<group>"; };
 		6C0409A91E6033DF00C95D83 /* Node.Sequence.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Node.Sequence.swift; sourceTree = "<group>"; };
+		6C0409AB1E607E9900C95D83 /* Node.Scalar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Node.Scalar.swift; sourceTree = "<group>"; };
 		6C0488EB1E0BE113006F9F80 /* TestHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestHelper.swift; sourceTree = "<group>"; };
 		6C0488ED1E0CBD56006F9F80 /* ConstructorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConstructorTests.swift; sourceTree = "<group>"; };
 		6C0A00D41E152D6200222704 /* EmitterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EmitterTests.swift; sourceTree = "<group>"; };
@@ -123,6 +125,7 @@
 				6C0D2A351E0A934B00C45545 /* Constructor.swift */,
 				6CE603971E13502E00A13D8D /* Emitter.swift */,
 				6C6834C71E0281880047B4D1 /* Node.swift */,
+				6C0409AB1E607E9900C95D83 /* Node.Scalar.swift */,
 				6C0409A71E602E9A00C95D83 /* Node.Mapping.swift */,
 				6C0409A91E6033DF00C95D83 /* Node.Sequence.swift */,
 				6C6834CB1E0283980047B4D1 /* Parser.swift */,
@@ -330,6 +333,7 @@
 				E8EDB8881DE2181B0062268D /* loader.c in Sources */,
 				E8EDB88C1DE2181B0062268D /* writer.c in Sources */,
 				E8EDB88B1DE2181B0062268D /* scanner.c in Sources */,
+				6C0409AC1E607E9900C95D83 /* Node.Scalar.swift in Sources */,
 				6C4A22071DF8553C002A0206 /* String+Yams.swift in Sources */,
 				E8EDB8891DE2181B0062268D /* parser.c in Sources */,
 				OBJ_50 /* YamlError.swift in Sources */,

--- a/Yams.xcodeproj/project.pbxproj
+++ b/Yams.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		6C0409A81E602E9A00C95D83 /* Node.Mapping.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C0409A71E602E9A00C95D83 /* Node.Mapping.swift */; };
+		6C0409AA1E6033DF00C95D83 /* Node.Sequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C0409A91E6033DF00C95D83 /* Node.Sequence.swift */; };
 		6C0488EC1E0BE113006F9F80 /* TestHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C0488EB1E0BE113006F9F80 /* TestHelper.swift */; };
 		6C0488EE1E0CBD56006F9F80 /* ConstructorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C0488ED1E0CBD56006F9F80 /* ConstructorTests.swift */; };
 		6C0A00D51E152D6200222704 /* EmitterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C0A00D41E152D6200222704 /* EmitterTests.swift */; };
@@ -52,6 +53,7 @@
 
 /* Begin PBXFileReference section */
 		6C0409A71E602E9A00C95D83 /* Node.Mapping.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Node.Mapping.swift; sourceTree = "<group>"; };
+		6C0409A91E6033DF00C95D83 /* Node.Sequence.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Node.Sequence.swift; sourceTree = "<group>"; };
 		6C0488EB1E0BE113006F9F80 /* TestHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestHelper.swift; sourceTree = "<group>"; };
 		6C0488ED1E0CBD56006F9F80 /* ConstructorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConstructorTests.swift; sourceTree = "<group>"; };
 		6C0A00D41E152D6200222704 /* EmitterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EmitterTests.swift; sourceTree = "<group>"; };
@@ -122,6 +124,7 @@
 				6CE603971E13502E00A13D8D /* Emitter.swift */,
 				6C6834C71E0281880047B4D1 /* Node.swift */,
 				6C0409A71E602E9A00C95D83 /* Node.Mapping.swift */,
+				6C0409A91E6033DF00C95D83 /* Node.Sequence.swift */,
 				6C6834CB1E0283980047B4D1 /* Parser.swift */,
 				6CC2E33E1E22347B00F62269 /* Representer.swift */,
 				6C6834D21E02B9760047B4D1 /* Resolver.swift */,
@@ -322,6 +325,7 @@
 				6C6834C81E0281880047B4D1 /* Node.swift in Sources */,
 				6C0D2A361E0A934B00C45545 /* Constructor.swift in Sources */,
 				6C6834D31E02B9760047B4D1 /* Resolver.swift in Sources */,
+				6C0409AA1E6033DF00C95D83 /* Node.Sequence.swift in Sources */,
 				6C0409A81E602E9A00C95D83 /* Node.Mapping.swift in Sources */,
 				E8EDB8881DE2181B0062268D /* loader.c in Sources */,
 				E8EDB88C1DE2181B0062268D /* writer.c in Sources */,


### PR DESCRIPTION
Depends on #22. 
In order to make the difference from #22 easier to see, it is a PR for #22 branch.

- Move `Node.Scalar`, `Node.Mapping` and `Node.Sequence` into each own files
- Make use of `Node.Mapping` and` Node.Sequence` collection compliance for internal implementation.
- Simplify code of resolving Tag
- Fix tag was not updated when `Node.scalar.string` is updated