### PR TITLE
Add `Parser.singleRoot()`

### DIFF
--- a/Sources/Yams/Parser.swift
+++ b/Sources/Yams/Parser.swift
@@ -39,7 +39,7 @@ public func load_all(yaml: String,
 public func load(yaml: String,
                  _ resolver: Resolver = .default,
                  _ constructor: Constructor = .default) throws -> Any? {
-    return try Parser(yaml: yaml, resolver: resolver, constructor: constructor).nextRoot()?.any
+    return try Parser(yaml: yaml, resolver: resolver, constructor: constructor).singleRoot()?.any
 }
 
 /// Parse all YAML documents in a String
@@ -70,7 +70,7 @@ public func compose_all(yaml: String,
 public func compose(yaml: String,
                     _ resolver: Resolver = .default,
                     _ constructor: Constructor = .default) throws -> Node? {
-    return try Parser(yaml: yaml, resolver: resolver, constructor: constructor).nextRoot()
+    return try Parser(yaml: yaml, resolver: resolver, constructor: constructor).singleRoot()
 }
 
 /// Sequence that holds error
@@ -153,6 +153,17 @@ public final class Parser {
         default: // YAML_STREAM_END_EVENT
             return nil
         }
+    }
+
+    public func singleRoot() throws -> Node? {
+        if streamEndProduced { return nil }
+        var node: Node?
+        if try expectNextEvent(oneOf: [YAML_DOCUMENT_START_EVENT, YAML_STREAM_END_EVENT]) != YAML_STREAM_END_EVENT {
+            node = try loadNode(from: parse())
+            try expectNextEvent(oneOf: [YAML_DOCUMENT_END_EVENT])
+            try expectNextEvent(oneOf: [YAML_STREAM_END_EVENT])
+        }
+        return node
     }
 
     // MARK: private

--- a/Sources/Yams/YamlError.swift
+++ b/Sources/Yams/YamlError.swift
@@ -35,7 +35,7 @@ extension YamlError {
         case YAML_MEMORY_ERROR:
             self = .memory
         case YAML_READER_ERROR:
-            self = .reader(problem: String(cString:parser.problem),
+            self = .reader(problem: String(cString: parser.problem),
                            byteOffset: parser.problem_offset,
                            value: parser.problem_value)
         case YAML_SCANNER_ERROR:

--- a/Sources/Yams/YamlError.swift
+++ b/Sources/Yams/YamlError.swift
@@ -35,22 +35,22 @@ extension YamlError {
         case YAML_MEMORY_ERROR:
             self = .memory
         case YAML_READER_ERROR:
-            self = .reader(problem: String(validatingUTF8: parser.problem)!,
+            self = .reader(problem: String(cString:parser.problem),
                            byteOffset: parser.problem_offset,
                            value: parser.problem_value)
         case YAML_SCANNER_ERROR:
-            self = .scanner(context: String(validatingUTF8: parser.context)!,
-                            problem: String(validatingUTF8: parser.problem)!,
+            self = .scanner(context: parser.context != nil ? String(cString: parser.context) : "",
+                            problem: String(cString: parser.problem),
                             line: parser.problem_mark.line,
                             column: parser.problem_mark.column)
         case YAML_PARSER_ERROR:
-            self = .parser(context: String(validatingUTF8: parser.context),
-                             problem: String(validatingUTF8: parser.problem)!,
+            self = .parser(context: parser.context != nil ? String(cString: parser.context) : nil,
+                             problem: String(cString: parser.problem),
                              line: parser.problem_mark.line,
                              column: parser.problem_mark.column)
         case YAML_COMPOSER_ERROR:
-            self = .composer(context: String(validatingUTF8: parser.context),
-                             problem: String(validatingUTF8: parser.problem)!,
+            self = .composer(context: parser.context != nil ? String(cString: parser.context) : nil,
+                             problem: String(cString: parser.problem),
                              line: parser.problem_mark.line,
                              column: parser.problem_mark.column)
         default:
@@ -63,7 +63,7 @@ extension YamlError {
         case YAML_MEMORY_ERROR:
             self = .memory
         case YAML_EMITTER_ERROR:
-            self = .emitter(problem: String(validatingUTF8: emitter.problem)!)
+            self = .emitter(problem: String(cString: emitter.problem))
         default:
             fatalError("Emitter has unknown error: \(emitter.error)!")
         }

--- a/Tests/YamsTests/YamlErrorTests.swift
+++ b/Tests/YamsTests/YamlErrorTests.swift
@@ -75,6 +75,19 @@ class YamlErrorTests: XCTestCase {
             }
         }
     }
+
+    func testSingleRootThrowsOnInvalidYaml() throws {
+        let invalidYAML = "|\na"
+
+        let parser = try Parser(yaml: invalidYAML)
+        XCTAssertThrowsError(try parser.singleRoot()) {
+            if let error = $0 as? YamlError {
+                XCTAssertEqual(error.describing(with: invalidYAML), "a\n^ did not find expected <document start> ")
+            } else {
+                XCTFail()
+            }
+        }
+    }
 }
 
 extension YamlErrorTests {
@@ -84,7 +97,8 @@ extension YamlErrorTests {
                 ("testYamlErrorReader", testYamlErrorReader),
                 ("testYamlErrorScanner", testYamlErrorScanner),
                 ("testYamlErrorParser", testYamlErrorParser),
-                ("testNextRootThrowsOnInvalidYaml", testNextRootThrowsOnInvalidYaml)
+                ("testNextRootThrowsOnInvalidYaml", testNextRootThrowsOnInvalidYaml),
+                ("testSingleRootThrowsOnInvalidYaml", testSingleRootThrowsOnInvalidYaml)
             ]
         #else
             return [] // https://bugs.swift.org/browse/SR-3366

--- a/Tests/YamsTests/YamlErrorTests.swift
+++ b/Tests/YamsTests/YamlErrorTests.swift
@@ -59,6 +59,22 @@ class YamlErrorTests: XCTestCase {
             XCTFail("should not happen")
         }
     }
+
+    func testNextRootThrowsOnInvalidYaml() throws {
+        let invalidYAML = "|\na"
+
+        let parser = try Parser(yaml: invalidYAML)
+        // first iteration returns scalar
+        XCTAssertEqual(try parser.nextRoot(), Node("", Tag(.null), .literal))
+        // second iteration throws error
+        XCTAssertThrowsError(try parser.nextRoot()) {
+            if let error = $0 as? YamlError {
+                XCTAssertEqual(error.describing(with: invalidYAML), "a\n^ did not find expected <document start> ")
+            } else {
+                XCTFail()
+            }
+        }
+    }
 }
 
 extension YamlErrorTests {
@@ -67,7 +83,8 @@ extension YamlErrorTests {
             return [
                 ("testYamlErrorReader", testYamlErrorReader),
                 ("testYamlErrorScanner", testYamlErrorScanner),
-                ("testYamlErrorParser", testYamlErrorParser)
+                ("testYamlErrorParser", testYamlErrorParser),
+                ("testNextRootThrowsOnInvalidYaml", testNextRootThrowsOnInvalidYaml)
             ]
         #else
             return [] // https://bugs.swift.org/browse/SR-3366


### PR DESCRIPTION
This is needed to support passing `YamlParserTests.testParseInvalidStringThrows` in SwiftLint.
This depends on #23.
In order to make the difference from #23 easier to see, it is a PR agains #23's branch.
