### PR TITLE
Refactor Errors

### DIFF
--- a/Sources/Yams/Emitter.swift
+++ b/Sources/Yams/Emitter.swift
@@ -24,7 +24,7 @@ import Foundation
 ///   - explicitEnd: explicit document end `...`
 ///   - version: YAML version directive
 /// - Returns: YAML String
-/// - Throws: `RepresenterError` or `YamlError`
+/// - Throws: `YamlError`
 public func dump<Objects>(
     objects: Objects,
     canonical: Bool = false,
@@ -68,7 +68,7 @@ public func dump<Objects>(
 ///   - explicitEnd: explicit document end `...`
 ///   - version: YAML version directive
 /// - Returns: YAML String
-/// - Throws: `RepresenterError` or `YamlError`
+/// - Throws: `YamlError`
 public func dump(
     object: Any?,
     canonical: Bool = false,
@@ -104,7 +104,7 @@ public func dump(
 ///   - explicitEnd: explicit document end `...`
 ///   - version: YAML version directive
 /// - Returns: YAML String
-/// - Throws: `RepresenterError` or `YamlError`
+/// - Throws: `YamlError`
 public func serialize<Nodes>(
     nodes: Nodes,
     canonical: Bool = false,
@@ -148,7 +148,7 @@ public func serialize<Nodes>(
 ///   - explicitEnd: explicit document end `...`
 ///   - version: YAML version directive
 /// - Returns: YAML String
-/// - Throws: `RepresenterError` or `YamlError`
+/// - Throws: `YamlError`
 public func serialize(
     node: Node,
     canonical: Bool = false,

--- a/Sources/Yams/Emitter.swift
+++ b/Sources/Yams/Emitter.swift
@@ -24,7 +24,7 @@ import Foundation
 ///   - explicitEnd: explicit document end `...`
 ///   - version: YAML version directive
 /// - Returns: YAML String
-/// - Throws: `EmitterError` or `YamlError`
+/// - Throws: `RepresenterError` or `YamlError`
 public func dump<Objects>(
     objects: Objects,
     canonical: Bool = false,
@@ -40,7 +40,7 @@ public func dump<Objects>(
             if let representable = object as? NodeRepresentable {
                 return representable
             }
-            throw EmitterError.objectIsNotRepresentable("\(object) does not conform to NodeRepresentable!")
+            throw YamlError.emitter(problem: "\(object) does not conform to NodeRepresentable!")
         }
         let nodes = try objects.map(representable(from:)).map { try $0.represented() }
         return try serialize(
@@ -68,7 +68,7 @@ public func dump<Objects>(
 ///   - explicitEnd: explicit document end `...`
 ///   - version: YAML version directive
 /// - Returns: YAML String
-/// - Throws: `EmitterError` or `YamlError`
+/// - Throws: `RepresenterError` or `YamlError`
 public func dump(
     object: Any?,
     canonical: Bool = false,
@@ -104,7 +104,7 @@ public func dump(
 ///   - explicitEnd: explicit document end `...`
 ///   - version: YAML version directive
 /// - Returns: YAML String
-/// - Throws: `EmitterError` or `YamlError`
+/// - Throws: `RepresenterError` or `YamlError`
 public func serialize<Nodes>(
     nodes: Nodes,
     canonical: Bool = false,
@@ -148,7 +148,7 @@ public func serialize<Nodes>(
 ///   - explicitEnd: explicit document end `...`
 ///   - version: YAML version directive
 /// - Returns: YAML String
-/// - Throws: `EmitterError` or `YamlError`
+/// - Throws: `RepresenterError` or `YamlError`
 public func serialize(
     node: Node,
     canonical: Bool = false,
@@ -169,11 +169,6 @@ public func serialize(
         explicitStart: explicitStart,
         explicitEnd: explicitEnd,
         version: version)
-}
-
-public enum EmitterError: Swift.Error {
-    case invalidState(String)
-    case objectIsNotRepresentable(String)
 }
 
 public final class Emitter {
@@ -248,16 +243,16 @@ public final class Emitter {
             try emit(&event)
             state = .opened
         case .opened:
-            throw EmitterError.invalidState("serializer is already opened")
+            throw YamlError.emitter(problem: "serializer is already opened")
         case .closed:
-            throw EmitterError.invalidState("serializer is closed")
+            throw YamlError.emitter(problem: "serializer is closed")
         }
     }
 
     public func close() throws {
         switch state {
         case .initialized:
-            throw EmitterError.invalidState("serializer is not opened")
+            throw YamlError.emitter(problem: "serializer is not opened")
         case .opened:
             var event = yaml_event_t()
             yaml_stream_end_event_initialize(&event)
@@ -271,11 +266,11 @@ public final class Emitter {
     public func serialize(node: Node) throws {
         switch state {
         case .initialized:
-            throw EmitterError.invalidState("serializer is not opened")
+            throw YamlError.emitter(problem: "serializer is not opened")
         case .opened:
             break
         case .closed:
-            throw EmitterError.invalidState("serializer is closed")
+            throw YamlError.emitter(problem: "serializer is closed")
         }
         var event = yaml_event_t()
         var versionDirective: UnsafeMutablePointer<yaml_version_directive_t>?

--- a/Sources/Yams/Parser.swift
+++ b/Sources/Yams/Parser.swift
@@ -151,10 +151,9 @@ public final class Parser {
         let event = try parse()
         if event.type != YAML_STREAM_END_EVENT {
             throw YamlError.composer(
-                context: "expected a single document in the stream",
-                problem: "but found another document",
-                line: event.event.start_mark.line,
-                column: event.event.start_mark.column,
+                context: YamlError.Context(text: "expected a single document in the stream",
+                                           mark: .init(line: 0, column: 0)),
+                problem: "but found another document", event.startMark,
                 yaml: yaml
             )
         }
@@ -212,11 +211,9 @@ extension Parser {
             fatalError("unreachable")
         }
         guard let node = anchors[alias] else {
-            throw YamlError.composer(
-                context: nil,
-                problem: "found undefined alias",
-                line: event.event.start_mark.line, column: event.event.start_mark.column,
-                yaml: yaml)
+            throw YamlError.composer(context: nil,
+                                     problem: "found undefined alias", event.startMark,
+                                     yaml: yaml)
         }
         return node
     }
@@ -327,6 +324,11 @@ fileprivate class Event {
     var mappingTag: String? {
         return event.data.mapping_start.implicit != 0
             ? nil : string(from: event.data.sequence_start.tag)
+    }
+
+    // start_mark
+    var startMark: YamlError.Mark {
+        return YamlError.Mark(line: event.start_mark.line, column: event.start_mark.column)
     }
 }
 

--- a/Sources/Yams/Parser.swift
+++ b/Sources/Yams/Parser.swift
@@ -154,7 +154,8 @@ public final class Parser {
                 context: "expected a single document in the stream",
                 problem: "but found another document",
                 line: event.event.start_mark.line,
-                column: event.event.start_mark.column
+                column: event.event.start_mark.column,
+                yaml: yaml
             )
         }
         return node
@@ -201,7 +202,7 @@ extension Parser {
     fileprivate func parse() throws -> Event {
         let event = Event()
         guard yaml_parser_parse(&parser, &event.event) == 1 else {
-            throw YamlError(from: parser)
+            throw YamlError(from: parser, with: yaml)
         }
         return event
     }
@@ -214,7 +215,8 @@ extension Parser {
             throw YamlError.composer(
                 context: nil,
                 problem: "found undefined alias",
-                line: event.event.start_mark.line, column: event.event.start_mark.column)
+                line: event.event.start_mark.line, column: event.event.start_mark.column,
+                yaml: yaml)
         }
         return node
     }

--- a/Sources/Yams/Representer.swift
+++ b/Sources/Yams/Representer.swift
@@ -14,14 +14,10 @@ import Foundation
 public extension Node {
     /// initialize `Node` with instance of `NodeRepresentable`
     /// - Parameter representable: instance of `NodeRepresentable`
-    /// - Throws: `RepresenterError`
+    /// - Throws: `YamlError`
     public init<T: NodeRepresentable>(_ representable: T) throws {
         self = try representable.represented()
     }
-}
-
-public enum RepresenterError: Swift.Error {
-    case fail(String)
 }
 
 // MARK: - NodeRepresentable
@@ -142,7 +138,7 @@ private func represent(_ value: Any) throws -> Node {
     } else if let representable = value as? NodeRepresentable {
         return try representable.represented()
     }
-    throw RepresenterError.fail("Fail to represent \(value)")
+    throw YamlError.representer(problem: "Fail to represent \(value)")
 }
 
 extension Optional: NodeRepresentable {

--- a/Sources/Yams/YamlError.swift
+++ b/Sources/Yams/YamlError.swift
@@ -12,15 +12,15 @@ public enum YamlError: Swift.Error {
 
     // Used in `yaml_parser_t`
     /// YAML_READER_ERROR. Cannot read or decode the input stream.
-    case reader(problem: String, byteOffset: Int, value: Int32)
+    case reader(problem: String, byteOffset: Int, value: Int32, yaml: String)
 
     // line and column start from 0, column is counted by unicodeScalars
     /// YAML_SCANNER_ERROR. Cannot scan the input stream.
-    case scanner(context: String, problem: String, line: Int, column: Int)
+    case scanner(context: String, problem: String, line: Int, column: Int, yaml: String)
     /// YAML_PARSER_ERROR. Cannot parse the input stream.
-    case parser(context: String?, problem: String, line: Int, column: Int)
+    case parser(context: String?, problem: String, line: Int, column: Int, yaml: String)
     /// YAML_COMPOSER_ERROR. Cannot compose a YAML document.
-    case composer(context: String?, problem: String, line: Int, column: Int)
+    case composer(context: String?, problem: String, line: Int, column: Int, yaml: String)
 
     // Used in `yaml_emitter_t`
     /// YAML_WRITER_ERROR. Cannot write to the output stream.
@@ -33,29 +33,33 @@ public enum YamlError: Swift.Error {
 }
 
 extension YamlError {
-    init(from parser: yaml_parser_t) {
+    init(from parser: yaml_parser_t, with yaml: String) {
         switch parser.error {
         case YAML_MEMORY_ERROR:
             self = .memory
         case YAML_READER_ERROR:
             self = .reader(problem: String(cString: parser.problem),
                            byteOffset: parser.problem_offset,
-                           value: parser.problem_value)
+                           value: parser.problem_value,
+                           yaml: yaml)
         case YAML_SCANNER_ERROR:
             self = .scanner(context: parser.context != nil ? String(cString: parser.context) : "",
                             problem: String(cString: parser.problem),
                             line: parser.problem_mark.line,
-                            column: parser.problem_mark.column)
+                            column: parser.problem_mark.column,
+                            yaml: yaml)
         case YAML_PARSER_ERROR:
             self = .parser(context: parser.context != nil ? String(cString: parser.context) : nil,
                              problem: String(cString: parser.problem),
                              line: parser.problem_mark.line,
-                             column: parser.problem_mark.column)
+                             column: parser.problem_mark.column,
+                             yaml: yaml)
         case YAML_COMPOSER_ERROR:
             self = .composer(context: parser.context != nil ? String(cString: parser.context) : nil,
                              problem: String(cString: parser.problem),
                              line: parser.problem_mark.line,
-                             column: parser.problem_mark.column)
+                             column: parser.problem_mark.column,
+                             yaml: yaml)
         default:
             fatalError("Parser has unknown error: \(parser.error)!")
         }
@@ -73,14 +77,14 @@ extension YamlError {
     }
 }
 
-extension YamlError {
-    public func describing(with yaml: String) -> String {
+extension YamlError: CustomStringConvertible {
+    public var description: String {
         switch self {
         case .no:
             return "No error is produced"
         case .memory:
             return "Memory error"
-        case let .reader(problem, byteOffset, value):
+        case let .reader(problem, byteOffset, value, yaml):
             #if USE_UTF8
                 guard let (_, column, contents) = yaml.utf8LineNumberColumnAndContents(at: byteOffset)
                     else { return "\(problem) at byte offset: \(byteOffset), value: \(value)" }
@@ -90,22 +94,25 @@ extension YamlError {
             #endif
             return contents.endingWithNewLine
                 + String(repeating: " ", count: column - 1) + "^ " + problem
-        case let .scanner(context, problem, line, column):
+        case let .scanner(context, problem, line, column, yaml):
             return describing(with: yaml, context, problem, line, column)
-        case let .parser(context, problem, line, column):
+        case let .parser(context, problem, line, column, yaml):
             return describing(with: yaml, context ?? "", problem, line, column)
-        case let .composer(context, problem, line, column):
+        case let .composer(context, problem, line, column, yaml):
             return describing(with: yaml, context ?? "", problem, line, column)
         default:
             fatalError("unreachable")
         }
     }
+}
 
-    private func describing(with yaml: String,
-                            _ context: String,
-                            _ problem: String,
-                            _ line: Int,
-                            _ column: Int // libYAML counts column by unicodeScalars.
+extension YamlError {
+    fileprivate func describing(
+        with yaml: String,
+        _ context: String,
+        _ problem: String,
+        _ line: Int,
+        _ column: Int // libYAML counts column by unicodeScalars.
         ) -> String {
         let contents = yaml.substring(at: line)
         let columnIndex = contents.unicodeScalars

--- a/Sources/Yams/YamlError.swift
+++ b/Sources/Yams/YamlError.swift
@@ -100,6 +100,8 @@ extension YamlError: CustomStringConvertible {
             return describing(with: yaml, context ?? "", problem, line, column)
         case let .composer(context, problem, line, column, yaml):
             return describing(with: yaml, context ?? "", problem, line, column)
+        case let .emitter(problem):
+            return problem
         default:
             fatalError("unreachable")
         }

--- a/Sources/Yams/YamlError.swift
+++ b/Sources/Yams/YamlError.swift
@@ -27,6 +27,9 @@ public enum YamlError: Swift.Error {
     case writer(problem: String)
     /// YAML_EMITTER_ERROR. Cannot emit a YAML stream.
     case emitter(problem: String)
+
+    // Used in `NodeRepresentable`
+    case representer(problem: String)
 }
 
 extension YamlError {

--- a/Tests/YamsTests/YamlErrorTests.swift
+++ b/Tests/YamsTests/YamlErrorTests.swift
@@ -101,6 +101,19 @@ class YamlErrorTests: XCTestCase {
             }
         }
     }
+
+    func testUndefinedAliasCausesError() throws {
+        let undefinedAlias = "*undefinedAlias\n"
+        let parser = try Parser(yaml: undefinedAlias)
+        XCTAssertThrowsError(try parser.singleRoot()) {
+            if let error = $0 as? YamlError {
+                XCTAssertEqual(error.describing(with: undefinedAlias),
+                               "*undefinedAlias\n^ found undefined alias ")
+            } else {
+                XCTFail()
+            }
+        }
+    }
 }
 
 extension YamlErrorTests {
@@ -112,7 +125,8 @@ extension YamlErrorTests {
                 ("testYamlErrorParser", testYamlErrorParser),
                 ("testNextRootThrowsOnInvalidYaml", testNextRootThrowsOnInvalidYaml),
                 ("testSingleRootThrowsOnInvalidYaml", testSingleRootThrowsOnInvalidYaml),
-                ("testSingleRootThrowsOnMultipleDocuments", testSingleRootThrowsOnMultipleDocuments)
+                ("testSingleRootThrowsOnMultipleDocuments", testSingleRootThrowsOnMultipleDocuments),
+                ("testUndefinedAliasCausesError", testUndefinedAliasCausesError)
             ]
         #else
             return [] // https://bugs.swift.org/browse/SR-3366

--- a/Tests/YamsTests/YamlErrorTests.swift
+++ b/Tests/YamsTests/YamlErrorTests.swift
@@ -11,6 +11,13 @@ import XCTest
 import Yams
 
 class YamlErrorTests: XCTestCase {
+    func testYamlErrorEmitter() throws {
+        XCTAssertThrowsError(try Yams.serialize(node: "test", version: (1, 2))) { error in
+            XCTAssertTrue(error is YamlError)
+            XCTAssertEqual("\(error)", "incompatible %YAML directive")
+        }
+    }
+
     func testYamlErrorReader() throws {
         // reader
         let yaml = "test: 'テスト\u{12}'"

--- a/Tests/YamsTests/YamlErrorTests.swift
+++ b/Tests/YamsTests/YamlErrorTests.swift
@@ -88,6 +88,19 @@ class YamlErrorTests: XCTestCase {
             }
         }
     }
+
+    func testSingleRootThrowsOnMultipleDocuments() throws {
+        let multipleDocuments = "document 1\n---\ndocument 2\n"
+        let parser = try Parser(yaml: multipleDocuments)
+        XCTAssertThrowsError(try parser.singleRoot()) {
+            if let error = $0 as? YamlError {
+                XCTAssertEqual(error.describing(with: multipleDocuments),
+                               "---\n^ but found another document expected a single document in the stream")
+            } else {
+                XCTFail()
+            }
+        }
+    }
 }
 
 extension YamlErrorTests {
@@ -98,7 +111,8 @@ extension YamlErrorTests {
                 ("testYamlErrorScanner", testYamlErrorScanner),
                 ("testYamlErrorParser", testYamlErrorParser),
                 ("testNextRootThrowsOnInvalidYaml", testNextRootThrowsOnInvalidYaml),
-                ("testSingleRootThrowsOnInvalidYaml", testSingleRootThrowsOnInvalidYaml)
+                ("testSingleRootThrowsOnInvalidYaml", testSingleRootThrowsOnInvalidYaml),
+                ("testSingleRootThrowsOnMultipleDocuments", testSingleRootThrowsOnMultipleDocuments)
             ]
         #else
             return [] // https://bugs.swift.org/browse/SR-3366

--- a/Tests/YamsTests/YamlErrorTests.swift
+++ b/Tests/YamsTests/YamlErrorTests.swift
@@ -22,7 +22,7 @@ class YamlErrorTests: XCTestCase {
                 "test: 'テスト\u{12}'",
                 "          ^ control characters are not allowed"
                 ].joined(separator: "\n")
-            XCTAssertEqual(error.describing(with: yaml), expected)
+            XCTAssertEqual(error.description, expected)
         } catch {
             XCTFail("should not happen")
         }
@@ -38,7 +38,7 @@ class YamlErrorTests: XCTestCase {
                 "test: 'テスト",
                 "          ^ found unexpected end of stream while scanning a quoted scalar"
                 ].joined(separator: "\n")
-            XCTAssertEqual(error.describing(with: yaml), expected)
+            XCTAssertEqual(error.description, expected)
         } catch {
             XCTFail("should not happen")
         }
@@ -54,7 +54,7 @@ class YamlErrorTests: XCTestCase {
                 "- [key1: value1, key2: ,",
                 "^ did not find expected node content while parsing a flow node"
                 ].joined(separator: "\n")
-            XCTAssertEqual(error.describing(with: yaml), expected)
+            XCTAssertEqual(error.description, expected)
         } catch {
             XCTFail("should not happen")
         }
@@ -69,7 +69,7 @@ class YamlErrorTests: XCTestCase {
         // second iteration throws error
         XCTAssertThrowsError(try parser.nextRoot()) {
             if let error = $0 as? YamlError {
-                XCTAssertEqual(error.describing(with: invalidYAML), "a\n^ did not find expected <document start> ")
+                XCTAssertEqual(error.description, "a\n^ did not find expected <document start> ")
             } else {
                 XCTFail()
             }
@@ -82,7 +82,7 @@ class YamlErrorTests: XCTestCase {
         let parser = try Parser(yaml: invalidYAML)
         XCTAssertThrowsError(try parser.singleRoot()) {
             if let error = $0 as? YamlError {
-                XCTAssertEqual(error.describing(with: invalidYAML), "a\n^ did not find expected <document start> ")
+                XCTAssertEqual(error.description, "a\n^ did not find expected <document start> ")
             } else {
                 XCTFail()
             }
@@ -94,7 +94,7 @@ class YamlErrorTests: XCTestCase {
         let parser = try Parser(yaml: multipleDocuments)
         XCTAssertThrowsError(try parser.singleRoot()) {
             if let error = $0 as? YamlError {
-                XCTAssertEqual(error.describing(with: multipleDocuments),
+                XCTAssertEqual(error.description,
                                "---\n^ but found another document expected a single document in the stream")
             } else {
                 XCTFail()
@@ -107,7 +107,7 @@ class YamlErrorTests: XCTestCase {
         let parser = try Parser(yaml: undefinedAlias)
         XCTAssertThrowsError(try parser.singleRoot()) {
             if let error = $0 as? YamlError {
-                XCTAssertEqual(error.describing(with: undefinedAlias),
+                XCTAssertEqual(error.description,
                                "*undefinedAlias\n^ found undefined alias ")
             } else {
                 XCTFail()


### PR DESCRIPTION
Simplify error handling.

- [x] Change `Parser.singleRoot()` to throw if multiple documents in yaml
- [x] Remove `EmitterError` and `RepresenterError`
- [x] Remove `YamlError.describing(with:)` and make `YamlError` to conform `CustomStringConvertible`
- [x] Fix that `description` property of `YamlError` does not use` context` and `problem` in the correct order

I expect to release 0.3.0 once this PR is completed.