### PR TITLE
Fix crash with empty yaml on Swift 3.0.2

### DIFF
--- a/Sources/Yams/Parser.swift
+++ b/Sources/Yams/Parser.swift
@@ -124,7 +124,21 @@ public final class Parser {
             // use native endian
             let isLittleEndian = 1 == 1.littleEndian
             yaml_parser_set_encoding(&parser, isLittleEndian ? YAML_UTF16LE_ENCODING : YAML_UTF16BE_ENCODING)
-            data = yaml.data(using: isLittleEndian ? .utf16LittleEndian : .utf16BigEndian)!
+            let encoding: String.Encoding
+            #if swift(>=3.1)
+                encoding = isLittleEndian ? .utf16LittleEndian : .utf16BigEndian
+            #else
+                /*
+                 ```
+                 "".data(using: .utf16LittleEndian).withUnsafeBytes { (bytes: UnsafePointer<UInt8>) in
+                    bytes == nil // true on Swift 3.0.2, false on Swift 3.1
+                 }
+                 ```
+                 for avoiding above, use `.utf16` if yaml is empty.
+                 */
+                encoding = yaml.isEmpty ? .utf16 : isLittleEndian ? .utf16LittleEndian : .utf16BigEndian
+            #endif
+            data = yaml.data(using: encoding)!
             data.withUnsafeBytes { bytes in
                 yaml_parser_set_input_string(&parser, bytes, data.count)
             }

--- a/Tests/YamsTests/SpecTests.swift
+++ b/Tests/YamsTests/SpecTests.swift
@@ -12,6 +12,10 @@ import Yams
 
 class SpecTests: XCTestCase { // swiftlint:disable:this type_body_length
 
+    func testEmptyString() throws {
+        XCTAssertNil(try Yams.load(yaml: ""))
+    }
+
     func testMultibyteCharacters() throws {
         let example = [
             "Bulbasaur: フシギダネ",
@@ -914,6 +918,7 @@ class SpecTests: XCTestCase { // swiftlint:disable:this type_body_length
 extension SpecTests {
     static var allTests: [(String, (SpecTests) -> () throws -> Void)] {
         return [
+            ("testEmptyString", testEmptyString),
             ("testMultibyteCharacters", testMultibyteCharacters),
             ("testSpecExample2_1_SequenceOfScalars", testSpecExample2_1_SequenceOfScalars),
             ("testSpecExample2_2_MappingScalarsToScalars", testSpecExample2_2_MappingScalarsToScalars),


### PR DESCRIPTION
Assertion failure in `yaml_parser_set_input_string()` was caused by following behavior:
```swift
"".data(using: .utf16LittleEndian)!.withUnsafeBytes { (bytes: UnsafePointer<UInt8>) in
   bytes == nil // true on Swift 3.0.2, false on Swift 3.1
}
```
Change to use `.utf16` if yaml is empty.
