### PR TITLE
Make Node locatable in YAML

### DIFF
--- a/Sources/Yams/Emitter.swift
+++ b/Sources/Yams/Emitter.swift
@@ -174,9 +174,9 @@ public func serialize(
 public final class Emitter {
     public enum LineBreak {
         /// Use CR for line breaks (Mac style).
-        case cr
+        case cr // swiftlint:disable:this identifier_name
         /// Use LN for line breaks (Unix style).
-        case ln
+        case ln // swiftlint:disable:this identifier_name
         /// Use CR LN for line breaks (DOS style).
         case crln
     }

--- a/Sources/Yams/Mark.swift
+++ b/Sources/Yams/Mark.swift
@@ -1,0 +1,34 @@
+//
+//  Mark.swift
+//  Yams
+//
+//  Created by Norio Nomura on 4/11/17.
+//  Copyright (c) 2017 Yams. All rights reserved.
+//
+
+import Foundation
+
+public struct Mark {
+    /// line start from 1
+    public let line: Int
+    /// column start from 1. libYAML counts column by unicodeScalars.
+    public let column: Int
+}
+
+extension Mark: CustomStringConvertible {
+    public var description: String { return "\(line):\(column)" }
+}
+
+extension Mark {
+    public func snippet(from yaml: String) -> String {
+        let contents = yaml.substring(at: line - 1)
+        let columnIndex = contents.unicodeScalars
+            .index(contents.unicodeScalars.startIndex,
+                   offsetBy: column - 1,
+                   limitedBy: contents.unicodeScalars.endIndex)?
+            .samePosition(in: contents.utf16) ?? contents.utf16.endIndex
+        let columnInUTF16 = contents.utf16.distance(from: contents.utf16.startIndex, to: columnIndex)
+        return contents.endingWithNewLine +
+            String(repeating: " ", count: columnInUTF16) + "^"
+    }
+}

--- a/Sources/Yams/Node.Mapping.swift
+++ b/Sources/Yams/Node.Mapping.swift
@@ -13,6 +13,7 @@ extension Node {
         fileprivate var pairs: [Pair<Node>]
         public var tag: Tag
         public var style: Style
+        public var mark: Mark?
 
         public enum Style: UInt32 { // swiftlint:disable:this nesting
             /// Let the emitter choose the style.
@@ -23,10 +24,11 @@ extension Node {
             case flow
         }
 
-        public init(_ pairs: [(Node, Node)], _ tag: Tag = .implicit, _ style: Style = .any) {
+        public init(_ pairs: [(Node, Node)], _ tag: Tag = .implicit, _ style: Style = .any, _ mark: Mark? = nil) {
             self.pairs = pairs.map(Pair.init)
             self.tag = tag
             self.style = style
+            self.mark = mark
         }
     }
 

--- a/Sources/Yams/Node.Scalar.swift
+++ b/Sources/Yams/Node.Scalar.swift
@@ -17,6 +17,7 @@ extension Node {
         }
         public var tag: Tag
         public var style: Style
+        public var mark: Mark?
 
         public enum Style: UInt32 { // swiftlint:disable:this nesting
             /// Let the emitter choose the style.
@@ -35,10 +36,11 @@ extension Node {
             case folded
         }
 
-        public init(_ string: String, _ tag: Tag = .implicit, _ style: Style = .any) {
+        public init(_ string: String, _ tag: Tag = .implicit, _ style: Style = .any, _ mark: Mark? = nil) {
             self.string = string
             self.tag = tag
             self.style = style
+            self.mark = mark
         }
     }
 

--- a/Sources/Yams/Node.Sequence.swift
+++ b/Sources/Yams/Node.Sequence.swift
@@ -13,6 +13,7 @@ extension Node {
         fileprivate var nodes: [Node]
         public var tag: Tag
         public var style: Style
+        public var mark: Mark?
 
         public enum Style: UInt32 { // swiftlint:disable:this nesting
             /// Let the emitter choose the style.
@@ -23,10 +24,11 @@ extension Node {
             case flow
         }
 
-        public init(_ nodes: [Node], _ tag: Tag = .implicit, _ style: Style = .any) {
+        public init(_ nodes: [Node], _ tag: Tag = .implicit, _ style: Style = .any, _ mark: Mark? = nil) {
             self.nodes = nodes
             self.tag = tag
             self.style = style
+            self.mark = mark
         }
     }
 

--- a/Sources/Yams/Node.swift
+++ b/Sources/Yams/Node.swift
@@ -20,7 +20,7 @@ extension Node {
     }
 
     public init(_ pairs: [(Node, Node)], _ tag: Tag = .implicit, _ style: Mapping.Style = .any) {
-            self = .mapping(.init(pairs, tag, style))
+        self = .mapping(.init(pairs, tag, style))
     }
 
     public init(_ nodes: [Node], _ tag: Tag = .implicit, _ style: Sequence.Style = .any) {
@@ -35,6 +35,14 @@ extension Node {
         case let .scalar(scalar): return scalar.resolvedTag
         case let .mapping(mapping): return mapping.resolvedTag
         case let .sequence(sequence): return sequence.resolvedTag
+        }
+    }
+
+    public var mark: Mark? {
+        switch self {
+        case let .scalar(scalar): return scalar.mark
+        case let .mapping(mapping): return mapping.mark
+        case let .sequence(sequence): return sequence.mark
         }
     }
 

--- a/Sources/Yams/Parser.swift
+++ b/Sources/Yams/Parser.swift
@@ -166,7 +166,7 @@ public final class Parser {
         if event.type != YAML_STREAM_END_EVENT {
             throw YamlError.composer(
                 context: YamlError.Context(text: "expected a single document in the stream",
-                                           mark: YamlError.Mark(line: 1, column: 1)),
+                                           mark: Mark(line: 1, column: 1)),
                 problem: "but found another document", event.startMark,
                 yaml: yaml
             )
@@ -341,8 +341,8 @@ fileprivate class Event {
     }
 
     // start_mark
-    var startMark: YamlError.Mark {
-        return YamlError.Mark(line: event.start_mark.line + 1, column: event.start_mark.column + 1)
+    var startMark: Mark {
+        return Mark(line: event.start_mark.line + 1, column: event.start_mark.column + 1)
     }
 }
 

--- a/Sources/Yams/Parser.swift
+++ b/Sources/Yams/Parser.swift
@@ -233,7 +233,7 @@ extension Parser {
     }
 
     private func loadScalar(from event: Event) throws -> Node {
-        let node = Node(event.scalarValue, tag(event.scalarTag), event.scalarStyle)
+        let node = Node.scalar(.init(event.scalarValue, tag(event.scalarTag), event.scalarStyle, event.startMark))
         if let anchor = event.scalarAnchor {
             anchors[anchor] = node
         }
@@ -247,7 +247,7 @@ extension Parser {
             array.append(try loadNode(from: event))
             event = try parse()
         }
-        let node = Node(array, tag(firstEvent.sequenceTag), event.sequenceStyle)
+        let node = Node.sequence(.init(array, tag(firstEvent.sequenceTag), event.sequenceStyle, event.startMark))
         if let anchor = firstEvent.sequenceAnchor {
             anchors[anchor] = node
         }
@@ -264,7 +264,7 @@ extension Parser {
             pairs.append((key, value))
             event = try parse()
         }
-        let node = Node(pairs, tag(firstEvent.mappingTag), event.mappingStyle)
+        let node = Node.mapping(.init(pairs, tag(firstEvent.mappingTag), event.mappingStyle, event.startMark))
         if let anchor = firstEvent.mappingAnchor {
             anchors[anchor] = node
         }

--- a/Sources/Yams/Parser.swift
+++ b/Sources/Yams/Parser.swift
@@ -166,7 +166,7 @@ public final class Parser {
         if event.type != YAML_STREAM_END_EVENT {
             throw YamlError.composer(
                 context: YamlError.Context(text: "expected a single document in the stream",
-                                           mark: .init(line: 0, column: 0)),
+                                           mark: YamlError.Mark(line: 1, column: 1)),
                 problem: "but found another document", event.startMark,
                 yaml: yaml
             )
@@ -342,7 +342,7 @@ fileprivate class Event {
 
     // start_mark
     var startMark: YamlError.Mark {
-        return YamlError.Mark(line: event.start_mark.line, column: event.start_mark.column)
+        return YamlError.Mark(line: event.start_mark.line + 1, column: event.start_mark.column + 1)
     }
 }
 

--- a/Sources/Yams/YamlError.swift
+++ b/Sources/Yams/YamlError.swift
@@ -14,7 +14,7 @@ import Foundation
 public enum YamlError: Swift.Error {
     // Used in `yaml_emitter_t` and `yaml_parser_t`
     /// YAML_NO_ERROR. No error is produced.
-    case no
+    case no // swiftlint:disable:this identifier_name
     /// YAML_MEMORY_ERROR. Cannot allocate or reallocate a block of memory.
     case memory
 

--- a/Sources/Yams/YamlError.swift
+++ b/Sources/Yams/YamlError.swift
@@ -1,3 +1,11 @@
+//
+//  YamlError.swift
+//  Yams
+//
+//  Created by JP Simard on 2016-11-19.
+//  Copyright (c) 2016 Yams. All rights reserved.
+//
+
 #if SWIFT_PACKAGE
 import CYaml
 #endif

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -5,6 +5,7 @@ import XCTest
 XCTMain([
     testCase(ConstructorTests.allTests),
     testCase(EmitterTests.allTests),
+    testCase(MarkTests.allTests),
     testCase(NodeTests.allTests),
     testCase(PerformanceTests.allTests),
     testCase(RepresenterTests.allTests),

--- a/Tests/YamsTests/MarkTests.swift
+++ b/Tests/YamsTests/MarkTests.swift
@@ -1,0 +1,50 @@
+//
+//  MarkTests.swift
+//  Yams
+//
+//  Created by Norio Nomura on 4/11/17.
+//  Copyright (c) 2017 Yams. All rights reserved.
+//
+
+import XCTest
+import Yams
+
+class MarkTests: XCTestCase {
+    func testLocatableDeprecationMessageForSwiftLint() throws {
+        let deprecatedRulesIdentifiers = [("variable_name", "identifier_name")].map { (Node($0), $1) }
+        func deprecatedMessage(from rule: Node) -> String? {
+            guard let index = deprecatedRulesIdentifiers.index(where: { $0.0 == rule }) else {
+                return nil
+            }
+            let changed = deprecatedRulesIdentifiers[index].1
+            return "\(rule.mark?.description ?? ""): warning: '\(rule.string ?? "")' has been renamed to " +
+                "'\(changed)' and will be completely removed in a future release."
+        }
+
+        let yaml = [
+            "disabled_rules:",
+            "  - variable_name",
+            "  - line_length",
+            "variable_name:",
+            "  min_length: 2"
+            ].joined(separator: "\n")
+        let configuration = try Yams.compose(yaml: yaml)
+        let disabled_rules = configuration?.mapping?["disabled_rules"]?.array() ?? []
+        let configured_rules = configuration?.mapping?.keys.filter({ $0 != "disabled_rules" }) ?? []
+        let deprecatedMessages = (disabled_rules + configured_rules).flatMap(deprecatedMessage(from:))
+        XCTAssertEqual(deprecatedMessages, [
+            "2:5: warning: 'variable_name' has been renamed to " +
+                "'identifier_name' and will be completely removed in a future release.",
+            "4:1: warning: 'variable_name' has been renamed to " +
+                "'identifier_name' and will be completely removed in a future release."
+            ])
+    }
+}
+
+extension MarkTests {
+    static var allTests: [(String, (MarkTests) -> () throws -> Void)] {
+        return [
+            ("testLocatableDeprecationMessageForSwiftLint", testLocatableDeprecationMessageForSwiftLint)
+        ]
+    }
+}

--- a/Tests/YamsTests/StringTests.swift
+++ b/Tests/YamsTests/StringTests.swift
@@ -89,7 +89,7 @@ extension StringTests {
                 ("testConfirmBehaviorOfStandardLibraryAPI", testConfirmBehaviorOfStandardLibraryAPI),
                 ("testUTF8LineNumberColumnAndContentsAtOffset", testUTF8LineNumberColumnAndContentsAtOffset),
                 ("testUTF16LineNumberColumnAndContentsAtOffset", testUTF16LineNumberColumnAndContentsAtOffset),
-                ("testSubstringAtLine", testSubstringAtLine),
+                ("testSubstringAtLine", testSubstringAtLine)
             ]
         #else
             return [] // https://bugs.swift.org/browse/SR-3366

--- a/Yams.xcodeproj/project.pbxproj
+++ b/Yams.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		6CC2E33F1E22347B00F62269 /* Representer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CC2E33E1E22347B00F62269 /* Representer.swift */; };
 		6CE603981E13502E00A13D8D /* Emitter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CE603971E13502E00A13D8D /* Emitter.swift */; };
 		6CF025381E9CF4380061FB47 /* Mark.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CF025371E9CF4380061FB47 /* Mark.swift */; };
+		6CF0253A1E9D12680061FB47 /* MarkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CF025391E9D12680061FB47 /* MarkTests.swift */; };
 		6CF6CE091E0E3B1000CB87D4 /* PerformanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CF6CE081E0E3B1000CB87D4 /* PerformanceTests.swift */; };
 		E8EDB8851DE2181B0062268D /* api.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_10 /* api.c */; };
 		E8EDB8861DE2181B0062268D /* dumper.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_11 /* dumper.c */; };
@@ -76,6 +77,7 @@
 		6CC2E33E1E22347B00F62269 /* Representer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Representer.swift; sourceTree = "<group>"; };
 		6CE603971E13502E00A13D8D /* Emitter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Emitter.swift; sourceTree = "<group>"; };
 		6CF025371E9CF4380061FB47 /* Mark.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Mark.swift; sourceTree = "<group>"; };
+		6CF025391E9D12680061FB47 /* MarkTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MarkTests.swift; sourceTree = "<group>"; };
 		6CF6CE071E0E3A5900CB87D4 /* Fixtures */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Fixtures; sourceTree = "<group>"; };
 		6CF6CE081E0E3B1000CB87D4 /* PerformanceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PerformanceTests.swift; sourceTree = "<group>"; };
 		OBJ_10 /* api.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = api.c; sourceTree = "<group>"; };
@@ -158,6 +160,7 @@
 				6CF6CE071E0E3A5900CB87D4 /* Fixtures */,
 				6C0488ED1E0CBD56006F9F80 /* ConstructorTests.swift */,
 				6C0A00D41E152D6200222704 /* EmitterTests.swift */,
+				6CF025391E9D12680061FB47 /* MarkTests.swift */,
 				6C3C90B81E0FFB6B009DEFE8 /* NodeTests.swift */,
 				6CF6CE081E0E3B1000CB87D4 /* PerformanceTests.swift */,
 				6C78C5631E29B1CE0096215F /* RepresenterTests.swift */,
@@ -356,6 +359,7 @@
 				6C78C5651E29B27D0096215F /* RepresenterTests.swift in Sources */,
 				6C3C90B91E0FFB6B009DEFE8 /* NodeTests.swift in Sources */,
 				6C0A00D51E152D6200222704 /* EmitterTests.swift in Sources */,
+				6CF0253A1E9D12680061FB47 /* MarkTests.swift in Sources */,
 				6C0488EE1E0CBD56006F9F80 /* ConstructorTests.swift in Sources */,
 				OBJ_59 /* YamlErrorTests.swift in Sources */,
 				6C6834D11E0297390047B4D1 /* SpecTests.swift in Sources */,

--- a/Yams.xcodeproj/project.pbxproj
+++ b/Yams.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		6CBAEE1A1E3839500021BF87 /* Yams.h in Headers */ = {isa = PBXBuildFile; fileRef = 6CBAEE191E3839500021BF87 /* Yams.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		6CC2E33F1E22347B00F62269 /* Representer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CC2E33E1E22347B00F62269 /* Representer.swift */; };
 		6CE603981E13502E00A13D8D /* Emitter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CE603971E13502E00A13D8D /* Emitter.swift */; };
+		6CF025381E9CF4380061FB47 /* Mark.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CF025371E9CF4380061FB47 /* Mark.swift */; };
 		6CF6CE091E0E3B1000CB87D4 /* PerformanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CF6CE081E0E3B1000CB87D4 /* PerformanceTests.swift */; };
 		E8EDB8851DE2181B0062268D /* api.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_10 /* api.c */; };
 		E8EDB8861DE2181B0062268D /* dumper.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_11 /* dumper.c */; };
@@ -74,6 +75,7 @@
 		6CBAEE191E3839500021BF87 /* Yams.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Yams.h; sourceTree = "<group>"; };
 		6CC2E33E1E22347B00F62269 /* Representer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Representer.swift; sourceTree = "<group>"; };
 		6CE603971E13502E00A13D8D /* Emitter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Emitter.swift; sourceTree = "<group>"; };
+		6CF025371E9CF4380061FB47 /* Mark.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Mark.swift; sourceTree = "<group>"; };
 		6CF6CE071E0E3A5900CB87D4 /* Fixtures */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Fixtures; sourceTree = "<group>"; };
 		6CF6CE081E0E3B1000CB87D4 /* PerformanceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PerformanceTests.swift; sourceTree = "<group>"; };
 		OBJ_10 /* api.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = api.c; sourceTree = "<group>"; };
@@ -124,6 +126,7 @@
 			children = (
 				6C0D2A351E0A934B00C45545 /* Constructor.swift */,
 				6CE603971E13502E00A13D8D /* Emitter.swift */,
+				6CF025371E9CF4380061FB47 /* Mark.swift */,
 				6C6834C71E0281880047B4D1 /* Node.swift */,
 				6C0409AB1E607E9900C95D83 /* Node.Scalar.swift */,
 				6C0409A71E602E9A00C95D83 /* Node.Mapping.swift */,
@@ -336,6 +339,7 @@
 				6C0409AC1E607E9900C95D83 /* Node.Scalar.swift in Sources */,
 				6C4A22071DF8553C002A0206 /* String+Yams.swift in Sources */,
 				E8EDB8891DE2181B0062268D /* parser.c in Sources */,
+				6CF025381E9CF4380061FB47 /* Mark.swift in Sources */,
 				OBJ_50 /* YamlError.swift in Sources */,
 				E8EDB88A1DE2181B0062268D /* reader.c in Sources */,
 				6C6834CD1E02847D0047B4D1 /* Tag.swift in Sources */,


### PR DESCRIPTION
This change provides the location information of the Node in YAML to the consumer.
Consumers can use the location information of Node to display detailed messages for the contents of YAML. (e.g. locatable deprecation warning in `.swiftlint.yml` for Xcode)

- Change `YamlError.Mark` to `Mark`
- Add `Mark` to `Node`

Can we treat this as patch level changes?