### PR TITLE
Fix misused `flatMap`

### DIFF
--- a/Sources/Yams/Representer.swift
+++ b/Sources/Yams/Representer.swift
@@ -154,7 +154,7 @@ extension Optional: NodeRepresentable {
 
 extension Array: NodeRepresentable {
     public func represented() throws -> Node {
-        let nodes = try flatMap(represent)
+        let nodes = try map(represent)
         return Node(nodes, Tag(.seq))
     }
 }


### PR DESCRIPTION
Now, Swift warns `warning: 'flatMap' is deprecated: This call uses implicit promotion to optional. Please use map instead.`