### PR TITLE
Support SE-0166 Swift Archival & Serialization

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -87,7 +87,7 @@ matrix:
         - docker run -v `pwd`:`pwd` -w `pwd` --rm $DOCKER_IMAGE swift test -Xswiftc -DUSE_UTF8
       env:
         - JOB=Docker
-        - DOCKER_IMAGE=norionomura/swift:4020170908a
+        - DOCKER_IMAGE=norionomura/swift:40
       sudo: required
       services: docker
 notifications:

--- a/Sources/Yams/Constructor.swift
+++ b/Sources/Yams/Constructor.swift
@@ -242,8 +242,8 @@ extension String: ScalarConstructible {
 // MARK: - Types that can't conform to ScalarConstructible
 extension NSNull/*: ScalarConstructible*/ {
     public static func construct(from node: Node) -> NSNull? {
-        assert(node.isScalar) // swiftlint:disable:next force_unwrapping
-        switch node.scalar!.string {
+        guard let string = node.scalar?.string else { return nil }
+        switch string {
         case "", "~", "null", "Null", "NULL":
             return NSNull()
         default:

--- a/Sources/Yams/Constructor.swift
+++ b/Sources/Yams/Constructor.swift
@@ -193,30 +193,25 @@ extension ScalarConstructible where Self: FloatingPoint & SexagesimalConvertible
 extension Int: ScalarConstructible {
     public static func construct(from node: Node) -> Int? {
         assert(node.isScalar) // swiftlint:disable:next force_unwrapping
-        var scalarWithSign = node.scalar!.string
-        scalarWithSign = scalarWithSign.replacingOccurrences(of: "_", with: "")
+        let scalarWithSign = node.scalar!.string.replacingOccurrences(of: "_", with: "")
         if scalarWithSign == "0" {
             return 0
         }
-        let negative = scalarWithSign.hasPrefix("-")
 
-        let scalar = negative || scalarWithSign.hasPrefix("+") ?
-            scalarWithSign.substring(from: 1) : scalarWithSign.substring(from: 0)
-        if scalar.hasPrefix("0x") {
-            let hexadecimal = negative ? "-" + scalar.substring(from: 2) : scalar.substring(from: 2)
-            return Int(hexadecimal, radix: 16)
-        }
-        if scalar.hasPrefix("0b") {
-            let octal = negative ? "-" + scalar.substring(from: 2) : scalar.substring(from: 2)
-            return Int(octal, radix: 2)
-        }
-        if scalar.hasPrefix("0o") {
-            let octal = negative ? "-" + scalar.substring(from: 2) : scalar.substring(from: 2)
-            return Int(octal, radix: 8)
-        }
-        if scalar.hasPrefix("0") {
-            let octal = negative ? "-" + scalar.substring(from: 1) : scalar.substring(from: 1)
-            return Int(octal, radix: 8)
+        let negative = scalarWithSign.hasPrefix("-")
+        let signPrefix = negative ? "-" : ""
+        let hasSign = negative || scalarWithSign.hasPrefix("+")
+
+        let prefixToRadix: [(String, Int)] = [
+            ("0x", 16),
+            ("0b", 2),
+            ("0o", 8),
+            ("0", 8)
+        ]
+
+        let scalar = scalarWithSign.substring(from: hasSign ? 1 : 0)
+        for (prefix, radix) in prefixToRadix where scalar.hasPrefix(prefix) {
+            return Int(signPrefix + scalar.substring(from: prefix.count), radix: radix)
         }
         if scalar.contains(":") {
             return Int(sexagesimal: scalarWithSign)
@@ -228,30 +223,22 @@ extension Int: ScalarConstructible {
 extension UInt: ScalarConstructible {
     public static func construct(from node: Node) -> UInt? {
         assert(node.isScalar) // swiftlint:disable:next force_unwrapping
-        var scalarWithSign = node.scalar!.string
-        scalarWithSign = scalarWithSign.replacingOccurrences(of: "_", with: "")
+        let scalarWithSign = node.scalar!.string.replacingOccurrences(of: "_", with: "")
         if scalarWithSign == "0" {
             return 0
         }
         guard !scalarWithSign.hasPrefix("-") else { return nil }
 
-        let scalar = scalarWithSign.hasPrefix("+") ?
-            scalarWithSign.substring(from: 1) : scalarWithSign.substring(from: 0)
-        if scalar.hasPrefix("0x") {
-            let hexadecimal = scalar.substring(from: 2)
-            return UInt(hexadecimal, radix: 16)
-        }
-        if scalar.hasPrefix("0b") {
-            let octal = scalar.substring(from: 2)
-            return UInt(octal, radix: 2)
-        }
-        if scalar.hasPrefix("0o") {
-            let octal = scalar.substring(from: 2)
-            return UInt(octal, radix: 8)
-        }
-        if scalar.hasPrefix("0") {
-            let octal = scalar.substring(from: 1)
-            return UInt(octal, radix: 8)
+        let prefixToRadix: [(String, Int)] = [
+            ("0x", 16),
+            ("0b", 2),
+            ("0o", 8),
+            ("0", 8)
+        ]
+
+        let scalar = scalarWithSign.substring(from: scalarWithSign.hasPrefix("+") ? 1 : 0)
+        for (prefix, radix) in prefixToRadix where scalar.hasPrefix(prefix) {
+            return UInt(scalar.substring(from: prefix.count), radix: radix)
         }
         if scalar.contains(":") {
             return UInt(sexagesimal: scalarWithSign)

--- a/Sources/Yams/Constructor.swift
+++ b/Sources/Yams/Constructor.swift
@@ -187,6 +187,27 @@ extension Double: ScalarConstructible {
     }
 }
 
+extension Float: ScalarConstructible {
+    public static func construct(from node: Node) -> Float? {
+        assert(node.isScalar) // swiftlint:disable:next force_unwrapping
+        var scalar = node.scalar!.string
+        switch scalar {
+        case ".inf", ".Inf", ".INF", "+.inf", "+.Inf", "+.INF":
+            return Float.infinity
+        case "-.inf", "-.Inf", "-.INF":
+            return -Float.infinity
+        case ".nan", ".NaN", ".NAN":
+            return Float.nan
+        default:
+            scalar = scalar.replacingOccurrences(of: "_", with: "")
+            if scalar.contains(":") {
+                return Float(sexagesimal: scalar)
+            }
+            return Float(scalar)
+        }
+    }
+}
+
 extension Int: ScalarConstructible {
     public static func construct(from node: Node) -> Int? {
         assert(node.isScalar) // swiftlint:disable:next force_unwrapping
@@ -443,6 +464,7 @@ extension SexagesimalConvertible {
 }
 
 extension Double: SexagesimalConvertible {}
+extension Float: SexagesimalConvertible {}
 extension Int: SexagesimalConvertible {
 #if swift(>=4.0)
     fileprivate init?(_ value: Substring) {

--- a/Sources/Yams/Constructor.swift
+++ b/Sources/Yams/Constructor.swift
@@ -222,6 +222,41 @@ extension Int: ScalarConstructible {
     }
 }
 
+extension UInt: ScalarConstructible {
+    public static func construct(from node: Node) -> UInt? {
+        assert(node.isScalar) // swiftlint:disable:next force_unwrapping
+        var scalarWithSign = node.scalar!.string
+        scalarWithSign = scalarWithSign.replacingOccurrences(of: "_", with: "")
+        if scalarWithSign == "0" {
+            return 0
+        }
+        guard !scalarWithSign.hasPrefix("-") else { return nil }
+
+        let scalar = scalarWithSign.hasPrefix("+") ?
+            scalarWithSign.substring(from: 1) : scalarWithSign.substring(from: 0)
+        if scalar.hasPrefix("0x") {
+            let hexadecimal = scalar.substring(from: 2)
+            return UInt(hexadecimal, radix: 16)
+        }
+        if scalar.hasPrefix("0b") {
+            let octal = scalar.substring(from: 2)
+            return UInt(octal, radix: 2)
+        }
+        if scalar.hasPrefix("0o") {
+            let octal = scalar.substring(from: 2)
+            return UInt(octal, radix: 8)
+        }
+        if scalar.hasPrefix("0") {
+            let octal = scalar.substring(from: 1)
+            return UInt(octal, radix: 8)
+        }
+        if scalar.contains(":") {
+            return UInt(sexagesimal: scalarWithSign)
+        }
+        return UInt(scalarWithSign)
+    }
+}
+
 extension String: ScalarConstructible {
     public static func construct(from node: Node) -> String? {
         return _construct(from: node)
@@ -416,6 +451,18 @@ extension Int: SexagesimalConvertible {
 #else
     fileprivate init?(_ value: String) {
         self.init(value, radix: 10)
+    }
+#endif
+}
+
+extension UInt: SexagesimalConvertible {
+#if swift(>=4.0)
+    fileprivate init?(_ value: Substring) {
+        self.init(value, radix: 10)
+    }
+#else
+    fileprivate init?(_ value: String) {
+    self.init(value, radix: 10)
     }
 #endif
 }

--- a/Sources/Yams/Constructor.swift
+++ b/Sources/Yams/Constructor.swift
@@ -6,8 +6,6 @@
 //  Copyright (c) 2016 Yams. All rights reserved.
 //
 
-// swiftlint:disable file_length
-
 import Foundation
 
 public final class Constructor {
@@ -505,4 +503,4 @@ fileprivate extension String {
             return self[index...]
         }
     }
-#endif
+#endif // swiftlint:disable:this file_length

--- a/Sources/Yams/Constructor.swift
+++ b/Sources/Yams/Constructor.swift
@@ -426,9 +426,6 @@ fileprivate extension String {
 // MARK: - SexagesimalConvertible
 public protocol SexagesimalConvertible: ExpressibleByIntegerLiteral {
     static func create(from string: String) -> Self?
-#if swift(>=4.0)
-    static func create(from substring: Substring) -> Self?
-#endif
     static func * (lhs: Self, rhs: Self) -> Self
     static func *= (lhs: inout Self, rhs: Self)
     static func += (lhs: inout Self, rhs: Self)
@@ -438,31 +435,18 @@ extension SexagesimalConvertible {
     fileprivate init(sexagesimal value: String) {
         self = value.sexagesimal()
     }
-    #if swift(>=4.0)
-    fileprivate init(sexagesimal value: Substring) {
-    self = value.sexagesimal()
-    }
-    #endif
 }
 
 extension SexagesimalConvertible where Self: LosslessStringConvertible {
     public static func create(from string: String) -> Self? {
         return Self.init(string)
     }
-#if swift(>=4.0)
-    public static func create(from substring: Substring) -> Self? {
-        return Self.init(String(substring))
-    }
-#endif
 }
 
 #if swift(>=3.2)
     extension SexagesimalConvertible where Self: FixedWidthInteger {
         public static func create(from string: String) -> Self? {
             return Self.init(string, radix: 10)
-        }
-        public static func create(from substring: Substring) -> Self? {
-            return Self.init(String(substring), radix: 10)
         }
     }
 #else
@@ -520,28 +504,6 @@ fileprivate extension String {
             return String(self).components(separatedBy: separator)
         }
     #endif
-
-        func sexagesimal<T>() -> T where T: SexagesimalConvertible {
-            assert(contains(":"))
-            var scalar = self
-
-            var sign: T = 1
-            if scalar.hasPrefix("-") {
-                sign = -1
-                scalar = scalar.substring(from: 1)
-            } else if scalar.hasPrefix("+") {
-                scalar = scalar.substring(from: 1)
-            }
-            let digits = scalar.components(separatedBy: ":").flatMap({ T.create(from: $0) }).reversed()
-            var base: T = 1
-            var value: T = 0
-            digits.forEach {
-                value += $0 * base
-                base *= 60
-            }
-            return sign * value
-        }
-
         func substring(from offset: Int) -> Substring {
             if offset == 0 { return self }
             let index = self.index(startIndex, offsetBy: offset)

--- a/Sources/Yams/Constructor.swift
+++ b/Sources/Yams/Constructor.swift
@@ -211,7 +211,11 @@ extension Int: ScalarConstructible {
 
         let scalar = scalarWithSign.substring(from: hasSign ? 1 : 0)
         for (prefix, radix) in prefixToRadix where scalar.hasPrefix(prefix) {
+#if swift(>=3.2)
             return Int(signPrefix + scalar.substring(from: prefix.count), radix: radix)
+#else
+            return Int(signPrefix + scalar.substring(from: prefix.characters.count), radix: radix)
+#endif
         }
         if scalar.contains(":") {
             return Int(sexagesimal: scalarWithSign)
@@ -238,7 +242,11 @@ extension UInt: ScalarConstructible {
 
         let scalar = scalarWithSign.substring(from: scalarWithSign.hasPrefix("+") ? 1 : 0)
         for (prefix, radix) in prefixToRadix where scalar.hasPrefix(prefix) {
+#if swift(>=3.2)
             return UInt(scalar.substring(from: prefix.count), radix: radix)
+#else
+            return UInt(scalar.substring(from: prefix.characters.count), radix: radix)
+#endif
         }
         if scalar.contains(":") {
             return UInt(sexagesimal: scalarWithSign)

--- a/Sources/Yams/Decoder.swift
+++ b/Sources/Yams/Decoder.swift
@@ -333,12 +333,6 @@
     extension UInt64: ScalarConstructible {}
     extension UInt8: ScalarConstructible {}
 
-    extension Float: ScalarConstructible {
-        public static func construct(from node: Node) -> Float? {
-            return Double.construct(from: node).flatMap(Float.init(exactly:))
-        }
-    }
-
     extension Decimal: ScalarConstructible {
         public static func construct(from node: Node) -> Decimal? {
             assert(node.isScalar) // swiftlint:disable:next force_unwrapping

--- a/Sources/Yams/Decoder.swift
+++ b/Sources/Yams/Decoder.swift
@@ -310,9 +310,17 @@
         return .typeMismatch(expectation, context)
     }
 
-    extension BinaryInteger {
+    extension FixedWidthInteger where Self: SignedInteger {
         public static func construct(from node: Node) -> Self? {
-            return Int.construct(from: node) as? Self
+            guard let int = Int.construct(from: node) else { return nil }
+            return Self.init(exactly: int)
+        }
+    }
+
+    extension FixedWidthInteger where Self: UnsignedInteger {
+        public static func construct(from node: Node) -> Self? {
+            guard let int = UInt.construct(from: node) else { return nil }
+            return Self.init(exactly: int)
         }
     }
 
@@ -320,7 +328,6 @@
     extension Int32: ScalarConstructible {}
     extension Int64: ScalarConstructible {}
     extension Int8: ScalarConstructible {}
-    extension UInt: ScalarConstructible {}
     extension UInt16: ScalarConstructible {}
     extension UInt32: ScalarConstructible {}
     extension UInt64: ScalarConstructible {}

--- a/Sources/Yams/Decoder.swift
+++ b/Sources/Yams/Decoder.swift
@@ -451,7 +451,7 @@
 
     extension Float: ScalarConstructible {
         public static func construct(from node: Node) -> Float? {
-            return Double.construct(from: node) as? Float
+            return Double.construct(from: node).flatMap(Float.init(exactly:))
         }
     }
 

--- a/Sources/Yams/Decoder.swift
+++ b/Sources/Yams/Decoder.swift
@@ -12,20 +12,19 @@
 
     public class YAMLDecoder {
         public init() {}
-        public func decode<T: Swift.Decodable>(_ type: T.Type, from data: Data) throws -> T {
-            // TODO: Detect string encoding
-            let yaml = String(data: data, encoding: .utf8)! // swiftlint:disable:this force_unwrapping
-            let node: Node
+        public func decode<T: Swift.Decodable>(_ type: T.Type, from yaml: String) throws -> T {
             do {
-                node = try Yams.compose(yaml: yaml) ?? ""
+                let node = try Yams.compose(yaml: yaml) ?? ""
+                let decoder = _YAMLDecoder(referencing: node)
+                let container = try decoder.singleValueContainer()
+                return try container.decode(T.self)
+            } catch let error as DecodingError {
+                throw error
             } catch {
                 throw DecodingError.dataCorrupted(.init(codingPath: [],
                                                         debugDescription: "The given data was not valid YAML.",
                                                         underlyingError: error))
             }
-            let decoder = _YAMLDecoder(referencing: node)
-            let container = try decoder.singleValueContainer()
-            return try container.decode(T.self)
         }
     }
 

--- a/Sources/Yams/Decoder.swift
+++ b/Sources/Yams/Decoder.swift
@@ -133,10 +133,8 @@
         func decodeIfPresent<T>(_ type: T.Type, forKey key: Key) throws -> T? where T : Decodable {
             return try decoder.with(pushedKey: key) {
                 guard let node = mapping[key.stringValue] else { return nil }
-                if T.self == Data.self {
-                    return Data.construct(from: node) as? T
-                } else if T.self == Date.self {
-                    return Date.construct(from: node) as? T
+                if let constructibleType = type.self as? ScalarConstructible.Type {
+                    return constructibleType.construct(from: node) as? T
                 }
 
                 let decoder = _YAMLDecoder(referencing: node, codingPath: self.decoder.codingPath)
@@ -279,10 +277,8 @@
 
             let decoded: T? = try decoder.with(pushedKey: nil) {
                 let node = sequence[currentIndex]
-                if T.self == Data.self {
-                    return Data.construct(from: node) as? T
-                } else if T.self == Date.self {
-                    return Date.construct(from: node) as? T
+                if let scalarConstructibleType = type.self as? ScalarConstructible.Type {
+                    return scalarConstructibleType.construct(from: node) as? T
                 }
 
                 let decoder = _YAMLDecoder(referencing: node, codingPath: self.decoder.codingPath)
@@ -403,10 +399,8 @@
         func decode(_ type: Data.Type)   throws -> Data { return try construct() }
 
         func decode<T>(_ type: T.Type) throws -> T where T : Decodable {
-            if T.self == Data.self {
-                return Data.construct(from: node) as! T // swiftlint:disable:this force_cast
-            } else if T.self == Date.self {
-                return Date.construct(from: node) as! T // swiftlint:disable:this force_cast
+            if let scalarConstructibleType = type.self as? ScalarConstructible.Type {
+                return scalarConstructibleType.construct(from: node) as! T // swiftlint:disable:this force_cast
             }
 
             let decoder = _YAMLDecoder(referencing: node)

--- a/Sources/Yams/Decoder.swift
+++ b/Sources/Yams/Decoder.swift
@@ -395,8 +395,6 @@
         func decode(_ type: Data.Type)   throws -> Data { return try construct() }
 
         func decode<T>(_ type: T.Type) throws -> T where T : Decodable {
-            try expectNonNull(T.self)
-
             if let scalarConstructibleType = type.self as? ScalarConstructible.Type {
                 guard let value = scalarConstructibleType.construct(from: node) else {
                     throw _valueNotFound(at: codingPath, T.self, "Expected \(T.self) value but found null instead.")
@@ -412,19 +410,11 @@
 
         /// Decode ScalarConstructible
         private func construct<T: ScalarConstructible>() throws -> T {
-            try expectNonNull(T.self)
             guard let decoded = T.construct(from: node) else {
                 throw _typeMismatch(at: codingPath, expectation: T.self, reality: node)
             }
             return decoded
         }
-
-        private func expectNonNull<T>(_ type: T.Type) throws {
-            guard !self.decodeNil() else {
-                throw _valueNotFound(at: codingPath, type, "Expected \(type) but found null value instead.")
-            }
-        }
-
     }
 
     private func _keyNotFound(at codingPath: [CodingKey], _ key: CodingKey, _ description: String) -> DecodingError {

--- a/Sources/Yams/Decoder.swift
+++ b/Sources/Yams/Decoder.swift
@@ -12,7 +12,7 @@
 
     public class YAMLDecoder {
         public init() {}
-        public func decode<T>(_ type: T.Type,
+        public func decode<T>(_ type: T.Type = T.self,
                               from yaml: String,
                               userInfo: [CodingUserInfoKey: Any] = [:]) throws -> T where T: Swift.Decodable {
             do {

--- a/Sources/Yams/Decoder.swift
+++ b/Sources/Yams/Decoder.swift
@@ -1,0 +1,454 @@
+//
+//  Decoder.swift
+//  Yams
+//
+//  Created by Norio Nomura on 5/6/17.
+//  Copyright (c) 2017 Yams. All rights reserved.
+//
+
+#if swift(>=4.0)
+
+    import Foundation
+
+    public class YAMLDecoder {
+        public init() {}
+        public func decode<T: Swift.Decodable>(_ type: T.Type, from data: Data) throws -> T {
+            // TODO: Detect string encoding
+            let yaml = String(data: data, encoding: .utf8)! // swiftlint:disable:this force_unwrapping
+            let node = try Yams.compose(yaml: yaml) ?? ""
+            let decoder = _YAMLDecoder(referencing: node)
+            return try T(from: decoder)
+        }
+    }
+
+    fileprivate class _YAMLDecoder: Decoder {
+
+        let node: Node
+
+        init(referencing node: Node, codingPath: [CodingKey?] = []) {
+            self.node = node
+            self.codingPath = codingPath
+        }
+
+        // MARK: - Swift.Decoder Methods
+
+        /// The path to the current point in encoding.
+        var codingPath: [CodingKey?]
+
+        /// Contextual user-provided information for use during encoding.
+        var userInfo: [CodingUserInfoKey : Any] = [:]
+
+        func container<Key>(keyedBy type: Key.Type) throws -> KeyedDecodingContainer<Key> {
+            guard let mapping = node.mapping else {
+                // FIXME: Should throw type mismatch error
+                throw DecodingError.valueNotFound(
+                    KeyedDecodingContainer<Key>.self,
+                    DecodingError.Context(
+                        codingPath: self.codingPath,
+                        debugDescription: "Cannot get keyed decoding container -- found null value instead."
+                    )
+                )
+            }
+            let wrapper = _YAMLKeyedDecodingContainer<Key>(decoder: self, wrapping: mapping)
+            return KeyedDecodingContainer(wrapper)
+        }
+
+        func unkeyedContainer() throws -> UnkeyedDecodingContainer {
+            guard let sequence = node.sequence else {
+                // FIXME: Should throw type mismatch error
+                throw DecodingError.valueNotFound(
+                    UnkeyedDecodingContainer.self,
+                    DecodingError.Context(
+                        codingPath: self.codingPath,
+                        debugDescription: "Cannot get unkeyed decoding container -- found null value instead."
+                    )
+                )
+            }
+            return _YAMLUnkeyedDecodingContainer(decoder: self, wrapping: sequence)
+        }
+
+        func singleValueContainer() throws -> SingleValueDecodingContainer {
+            guard node.isScalar else {
+                // FIXME: Should throw type mismatch error
+                throw DecodingError.valueNotFound(
+                    UnkeyedDecodingContainer.self,
+                    DecodingError.Context(
+                        codingPath: self.codingPath,
+                        debugDescription: "Cannot get unkeyed decoding container -- found null value instead."
+                    )
+                )
+            }
+            return self
+        }
+
+        // MARK: Utility
+
+        /// Performs the given closure with the given key pushed onto the end of the current coding path.
+        ///
+        /// - parameter key: The key to push. May be nil for unkeyed containers.
+        /// - parameter work: The work to perform with the key in the path.
+        func with<T>(pushedKey key: CodingKey?, _ work: () throws -> T) rethrows -> T {
+            self.codingPath.append(key)
+            let ret: T = try work()
+            self.codingPath.removeLast()
+            return ret
+        }
+    }
+
+    fileprivate struct _YAMLKeyedDecodingContainer<K: CodingKey> : KeyedDecodingContainerProtocol {
+
+        typealias Key = K
+
+        let decoder: _YAMLDecoder
+        let mapping: Node.Mapping
+
+        init(decoder: _YAMLDecoder, wrapping mapping: Node.Mapping) {
+            self.decoder = decoder
+            self.mapping = mapping
+        }
+
+        // MARK: - KeyedDecodingContainerProtocol
+
+        var codingPath: [CodingKey?] {
+            return decoder.codingPath
+        }
+
+        var allKeys: [Key] {
+            return mapping.keys.flatMap { $0.string.flatMap(Key.init(stringValue:)) }
+        }
+
+        func contains(_ key: K) -> Bool {
+            if mapping[key.stringValue] != nil {
+                return true
+            }
+            return false
+        }
+
+        func decodeIfPresent(_ type: Bool.Type, forKey key: Key) throws -> Bool? { return try construct(for: key) }
+        func decodeIfPresent(_ type: Int.Type, forKey key: Key) throws -> Int? { return try construct(for: key) }
+        func decodeIfPresent(_ type: Int8.Type, forKey key: Key) throws -> Int8? { return try construct(for: key) }
+        func decodeIfPresent(_ type: Int16.Type, forKey key: Key) throws -> Int16? { return try construct(for: key) }
+        func decodeIfPresent(_ type: Int32.Type, forKey key: Key) throws -> Int32? { return try construct(for: key) }
+        func decodeIfPresent(_ type: Int64.Type, forKey key: Key) throws -> Int64? { return try construct(for: key) }
+        func decodeIfPresent(_ type: UInt.Type, forKey key: Key) throws -> UInt? { return try construct(for: key) }
+        func decodeIfPresent(_ type: UInt8.Type, forKey key: Key) throws -> UInt8? { return try construct(for: key) }
+        func decodeIfPresent(_ type: UInt16.Type, forKey key: Key) throws -> UInt16? { return try construct(for: key) }
+        func decodeIfPresent(_ type: UInt32.Type, forKey key: Key) throws -> UInt32? { return try construct(for: key) }
+        func decodeIfPresent(_ type: UInt64.Type, forKey key: Key) throws -> UInt64? { return try construct(for: key) }
+        func decodeIfPresent(_ type: Float.Type, forKey key: Key) throws -> Float? { return try construct(for: key) }
+        func decodeIfPresent(_ type: Double.Type, forKey key: Key) throws -> Double? { return try construct(for: key) }
+        func decodeIfPresent(_ type: String.Type, forKey key: Key) throws -> String? { return try construct(for: key) }
+
+        func decodeIfPresent<T>(_ type: T.Type, forKey key: Key) throws -> T? where T : Decodable {
+            return try decoder.with(pushedKey: key) {
+                guard let node = mapping[key.stringValue] else { return nil }
+                if T.self == Data.self {
+                    return Data.construct(from: node) as? T
+                } else if T.self == Date.self {
+                    return Date.construct(from: node) as? T
+                }
+
+                let decoder = _YAMLDecoder(referencing: node, codingPath: self.decoder.codingPath)
+                return try T(from: decoder)
+            }
+        }
+
+        func nestedContainer<NestedKey>(keyedBy type: NestedKey.Type,
+                                        forKey key: Key) throws -> KeyedDecodingContainer<NestedKey> {
+            return try decoder.with(pushedKey: key) {
+                guard let node = mapping[key.stringValue] else {
+                    // FIXME: Should throw type mismatch error
+                    throw DecodingError.keyNotFound(
+                        key,
+                        DecodingError.Context(
+                            codingPath: self.codingPath,
+                            debugDescription: "Cannot get \(KeyedDecodingContainer<NestedKey>.self) -- no value found for key \"\(key.stringValue)\""
+                        )
+                    )
+                }
+                guard let mapping = node.mapping else {
+                    fatalError("should throw type mismatch error")
+                }
+                let decoder = _YAMLDecoder(referencing: node, codingPath: self.decoder.codingPath)
+                let wrapping =  _YAMLKeyedDecodingContainer<NestedKey>(decoder: decoder, wrapping: mapping)
+                return KeyedDecodingContainer(wrapping)
+            }
+        }
+
+        func nestedUnkeyedContainer(forKey key: Key) throws -> UnkeyedDecodingContainer {
+            return try decoder.with(pushedKey: key) {
+                guard let node = mapping[key.stringValue], let sequence = node.sequence else {
+                    // FIXME: Should throw type mismatch error
+                    throw DecodingError.keyNotFound(
+                        key,
+                        DecodingError.Context(
+                            codingPath: self.codingPath,
+                            debugDescription: "Cannot get UnkeyedDecodingContainer -- no value found for key \"\(key.stringValue)\""
+                        )
+                    )
+                }
+                let decoder = _YAMLDecoder(referencing: node, codingPath: self.decoder.codingPath)
+                return _YAMLUnkeyedDecodingContainer(decoder: decoder, wrapping: sequence)
+            }
+        }
+
+        private func _superDecoder(forKey key: CodingKey) throws -> Decoder {
+            return try self.decoder.with(pushedKey: key) {
+                guard let node = mapping[key.stringValue] else {
+                    throw DecodingError.keyNotFound(
+                        key,
+                        DecodingError.Context(
+                            codingPath: self.codingPath,
+                            debugDescription: "Cannot get superDecoder() -- no value found for key \"\(key.stringValue)\""
+                        )
+                    )
+                }
+
+                return _YAMLDecoder(referencing: node, codingPath: self.decoder.codingPath)
+            }
+        }
+
+        func superDecoder() throws -> Decoder {
+            return try _superDecoder(forKey: _YAMLDecodingSuperKey())
+        }
+
+        func superDecoder(forKey key: Key) throws -> Decoder {
+            return try _superDecoder(forKey: key)
+        }
+
+        // MARK: Utility
+
+        /// Encode ScalarConstructible
+        func construct<T: ScalarConstructible>(for key: Key) throws -> T? {
+            return decoder.with(pushedKey: key) {
+                guard let node = mapping[key.stringValue] else { return nil }
+                return T.construct(from: node)
+            }
+        }
+    }
+
+    fileprivate struct _YAMLDecodingSuperKey: CodingKey {
+        init() {}
+
+        var stringValue: String { return "super" }
+        init?(stringValue: String) {
+            guard stringValue == "super" else { return nil }
+        }
+
+        var intValue: Int? { return nil }
+        init?(intValue: Int) {
+            return nil
+        }
+    }
+
+    fileprivate struct _YAMLUnkeyedDecodingContainer: UnkeyedDecodingContainer {
+
+        let decoder: _YAMLDecoder
+        let sequence: Node.Sequence
+
+        /// The index of the element we're about to decode.
+        var currentIndex: Int
+
+        init(decoder: _YAMLDecoder, wrapping sequence: Node.Sequence) {
+            self.decoder = decoder
+            self.sequence = sequence
+            self.currentIndex = 0
+        }
+
+        // MARK: - UnkeyedDecodingContainer
+        var codingPath: [CodingKey?] {
+            return decoder.codingPath
+        }
+
+        var count: Int? {
+            return sequence.count
+        }
+
+        var isAtEnd: Bool {
+            return self.currentIndex >= sequence.count
+        }
+
+        mutating func decodeIfPresent(_ type: Bool.Type) throws -> Bool? { return try construct() }
+        mutating func decodeIfPresent(_ type: Int.Type) throws -> Int? { return try construct() }
+        mutating func decodeIfPresent(_ type: Int8.Type) throws -> Int8? { return try construct() }
+        mutating func decodeIfPresent(_ type: Int16.Type) throws -> Int16? { return try construct() }
+        mutating func decodeIfPresent(_ type: Int32.Type) throws -> Int32? { return try construct() }
+        mutating func decodeIfPresent(_ type: Int64.Type) throws -> Int64? { return try construct() }
+        mutating func decodeIfPresent(_ type: UInt.Type) throws -> UInt? { return try construct() }
+        mutating func decodeIfPresent(_ type: UInt8.Type) throws -> UInt8? { return try construct() }
+        mutating func decodeIfPresent(_ type: UInt16.Type) throws -> UInt16? { return try construct() }
+        mutating func decodeIfPresent(_ type: UInt32.Type) throws -> UInt32? { return try construct() }
+        mutating func decodeIfPresent(_ type: UInt64.Type) throws -> UInt64? { return try construct() }
+        mutating func decodeIfPresent(_ type: Float.Type) throws -> Float? { return try construct() }
+        mutating func decodeIfPresent(_ type: Double.Type) throws -> Double? { return try construct() }
+        mutating func decodeIfPresent(_ type: String.Type) throws -> String? { return try construct() }
+
+        mutating func decodeIfPresent<T>(_ type: T.Type) throws -> T? where T : Decodable {
+            guard !self.isAtEnd else { return nil }
+
+            let decoded: T? = try decoder.with(pushedKey: nil) {
+                let node = sequence[currentIndex]
+                if T.self == Data.self {
+                    return Data.construct(from: node) as? T
+                } else if T.self == Date.self {
+                    return Date.construct(from: node) as? T
+                }
+
+                let decoder = _YAMLDecoder(referencing: node, codingPath: self.decoder.codingPath)
+                return try T(from: decoder)
+            }
+            currentIndex += 1
+            return decoded
+        }
+
+        mutating func nestedContainer<NestedKey>(keyedBy type: NestedKey.Type) throws -> KeyedDecodingContainer<NestedKey> {
+            return try decoder.with(pushedKey: nil) {
+                guard !self.isAtEnd else {
+                    throw DecodingError.valueNotFound(
+                        KeyedDecodingContainer<NestedKey>.self,
+                        DecodingError.Context(
+                            codingPath: self.codingPath,
+                            debugDescription: "Cannot get nested keyed container -- unkeyed container is at end."
+                        )
+                    )
+                }
+                let node = sequence[currentIndex]
+                guard let mapping = node.mapping else {
+                    // FIXME: Should throw type mismatch error
+                    throw DecodingError.valueNotFound(
+                        KeyedDecodingContainer<NestedKey>.self,
+                        DecodingError.Context(
+                            codingPath: self.codingPath,
+                            debugDescription: "Cannot get \(KeyedDecodingContainer<NestedKey>.self) -- no value found at index \"\(currentIndex)\""
+                        )
+                    )
+                }
+
+                currentIndex += 1
+                let decoder = _YAMLDecoder(referencing: node, codingPath: self.decoder.codingPath)
+                let wrapping =  _YAMLKeyedDecodingContainer<NestedKey>(decoder: decoder, wrapping: mapping)
+                return KeyedDecodingContainer(wrapping)
+            }
+        }
+
+        mutating func nestedUnkeyedContainer() throws -> UnkeyedDecodingContainer {
+            return try decoder.with(pushedKey: nil) {
+                guard !self.isAtEnd else {
+                    throw DecodingError.valueNotFound(
+                        UnkeyedDecodingContainer.self,
+                        DecodingError.Context(
+                            codingPath: self.codingPath,
+                            debugDescription: "Cannot get UnkeyedDecodingContainer -- unkeyed container is at end."
+                        )
+                    )
+                }
+                let node = sequence[currentIndex]
+                guard let sequence = node.sequence else {
+                    // FIXME: Should throw type mismatch error
+                    throw DecodingError.typeMismatch(
+                        type(of: node),
+                        DecodingError.Context(
+                            codingPath: codingPath,
+                            debugDescription: "Cannot get UnkeyedDecodingContainer -- no value found at index \"\(currentIndex)\""
+                        )
+                    )
+                }
+                let decoder = _YAMLDecoder(referencing: node, codingPath: self.decoder.codingPath)
+                return _YAMLUnkeyedDecodingContainer(decoder: decoder, wrapping: sequence)
+            }
+        }
+
+        mutating func superDecoder() throws -> Decoder {
+            return try decoder.with(pushedKey: nil) {
+                guard !self.isAtEnd else {
+                    throw DecodingError.valueNotFound(
+                        Decoder.self,
+                        DecodingError.Context(
+                            codingPath: self.codingPath,
+                            debugDescription: "Cannot get superDecoder() -- unkeyed container is at end."
+                        )
+                    )
+                }
+
+                let node = sequence[currentIndex]
+                self.currentIndex += 1
+                return _YAMLDecoder(referencing: node, codingPath: self.decoder.codingPath)
+            }
+        }
+
+        // MARK: Utility
+
+        /// Encode ScalarConstructible
+        mutating func construct<T: ScalarConstructible>() throws -> T? {
+            guard !self.isAtEnd else { return nil }
+
+            return decoder.with(pushedKey: nil) {
+                let node = sequence[currentIndex]
+                currentIndex += 1
+                return T.construct(from: node)
+            }
+        }
+    }
+
+    extension _YAMLDecoder : SingleValueDecodingContainer {
+
+        // MARK: SingleValueDecodingContainer Methods
+
+        func decode(_ type: Bool.Type)   throws -> Bool { return try construct() }
+        func decode(_ type: Int.Type)    throws -> Int { return try construct() }
+        func decode(_ type: Int8.Type)   throws -> Int8 { return try construct() }
+        func decode(_ type: Int16.Type)  throws -> Int16 { return try construct() }
+        func decode(_ type: Int32.Type)  throws -> Int32 { return try construct() }
+        func decode(_ type: Int64.Type)  throws -> Int64 { return try construct() }
+        func decode(_ type: UInt.Type)   throws -> UInt { return try construct() }
+        func decode(_ type: UInt8.Type)  throws -> UInt8 { return try construct() }
+        func decode(_ type: UInt16.Type) throws -> UInt16 { return try construct() }
+        func decode(_ type: UInt32.Type) throws -> UInt32 { return try construct() }
+        func decode(_ type: UInt64.Type) throws -> UInt64 { return try construct() }
+        func decode(_ type: Float.Type)  throws -> Float { return try construct() }
+        func decode(_ type: Double.Type) throws -> Double { return try construct() }
+        func decode(_ type: String.Type) throws -> String { return try construct() }
+        func decode(_ type: Data.Type)   throws -> Data { return try construct() }
+
+        // MARK: Utility
+
+        /// Encode ScalarConstructible
+        func construct<T: ScalarConstructible>() throws -> T {
+            return try with(pushedKey: nil) {
+                guard let decoded = T.construct(from: node) else {
+                    // FIXME: Should throw type mismatch error
+                    throw DecodingError.typeMismatch(
+                        T.self,
+                        DecodingError.Context(
+                            codingPath: codingPath, debugDescription: ""
+                        )
+                    )
+                }
+                return decoded
+            }
+        }
+    }
+
+    extension BinaryInteger {
+        public static func construct(from node: Node) -> Self? {
+            return Int.construct(from: node) as? Self
+        }
+    }
+
+    extension Int16: ScalarConstructible {}
+    extension Int32: ScalarConstructible {}
+    extension Int64: ScalarConstructible {}
+    extension Int8: ScalarConstructible {}
+    extension UInt: ScalarConstructible {}
+    extension UInt16: ScalarConstructible {}
+    extension UInt32: ScalarConstructible {}
+    extension UInt64: ScalarConstructible {}
+    extension UInt8: ScalarConstructible {}
+
+    extension Float: ScalarConstructible {
+        public static func construct(from node: Node) -> Float? {
+            return Double.construct(from: node) as? Float
+        }
+    }
+
+#endif // swiftlint:disable:this file_length

--- a/Sources/Yams/Decoder.swift
+++ b/Sources/Yams/Decoder.swift
@@ -128,7 +128,7 @@
             return try decoder(for: key).unkeyedContainer()
         }
 
-        func superDecoder() throws -> Decoder { return try decoder(for: _YAMLDecodingKey.super) }
+        func superDecoder() throws -> Decoder { return try decoder(for: _YAMLCodingKey.super) }
         func superDecoder(forKey key: Key) throws -> Decoder { return try decoder(for: key) }
 
         // MARK: -
@@ -218,7 +218,7 @@
 
         // MARK: -
 
-        private var currentKey: CodingKey { return _YAMLDecodingKey(index: currentIndex) }
+        private var currentKey: CodingKey { return _YAMLCodingKey(index: currentIndex) }
         private var currentNode: Node { return sequence[currentIndex] }
         private var currentDecoder: _YAMLDecoder { return decoder.decoder(referencing: currentNode, as: currentKey) }
 
@@ -266,30 +266,6 @@
             }
             return value as? T
         }
-    }
-
-    // MARK: - CodingKey for `_YAMLUnkeyedDecodingContainer` and `superDecoders`
-
-    struct _YAMLDecodingKey: CodingKey { // swiftlint:disable:this type_name
-        var stringValue: String
-        var intValue: Int?
-
-        init?(stringValue: String) {
-            self.stringValue = stringValue
-            self.intValue = nil
-        }
-
-        init?(intValue: Int) {
-            self.stringValue = "\(intValue)"
-            self.intValue = intValue
-        }
-
-        init(index: Int) {
-            self.stringValue = "Index \(index)"
-            self.intValue = index
-        }
-
-        static let `super` = _YAMLDecodingKey(stringValue: "super")!
     }
 
     // MARK: - DecodingError helpers

--- a/Sources/Yams/Decoder.swift
+++ b/Sources/Yams/Decoder.swift
@@ -257,7 +257,6 @@
         func decode(_ type: Float.Type)  throws -> Float { return try construct() }
         func decode(_ type: Double.Type) throws -> Double { return try construct() }
         func decode(_ type: String.Type) throws -> String { return try construct() }
-        func decode(_ type: Data.Type)   throws -> Data { return try construct() }
         func decode<T>(_ type: T.Type)   throws -> T where T: Decodable { return try decode() ?? T(from: self) }
 
         // MARK: -

--- a/Sources/Yams/Decoder.swift
+++ b/Sources/Yams/Decoder.swift
@@ -26,7 +26,7 @@
 
         let node: Node
 
-        init(referencing node: Node, codingPath: [CodingKey?] = []) {
+        init(referencing node: Node, codingPath: [CodingKey] = []) {
             self.node = node
             self.codingPath = codingPath
         }
@@ -34,21 +34,14 @@
         // MARK: - Swift.Decoder Methods
 
         /// The path to the current point in encoding.
-        var codingPath: [CodingKey?]
+        var codingPath: [CodingKey]
 
         /// Contextual user-provided information for use during encoding.
         var userInfo: [CodingUserInfoKey : Any] = [:]
 
         func container<Key>(keyedBy type: Key.Type) throws -> KeyedDecodingContainer<Key> {
             guard let mapping = node.mapping else {
-                // FIXME: Should throw type mismatch error
-                throw DecodingError.valueNotFound(
-                    KeyedDecodingContainer<Key>.self,
-                    DecodingError.Context(
-                        codingPath: self.codingPath,
-                        debugDescription: "Cannot get keyed decoding container -- found null value instead."
-                    )
-                )
+                throw _typeMismatch(at: codingPath, expectation: Node.Mapping.self, reality: node)
             }
             let wrapper = _YAMLKeyedDecodingContainer<Key>(decoder: self, wrapping: mapping)
             return KeyedDecodingContainer(wrapper)
@@ -56,33 +49,13 @@
 
         func unkeyedContainer() throws -> UnkeyedDecodingContainer {
             guard let sequence = node.sequence else {
-                // FIXME: Should throw type mismatch error
-                throw DecodingError.valueNotFound(
-                    UnkeyedDecodingContainer.self,
-                    DecodingError.Context(
-                        codingPath: self.codingPath,
-                        debugDescription: "Cannot get unkeyed decoding container -- found null value instead."
-                    )
-                )
+                throw _typeMismatch(at: codingPath, expectation: Node.Sequence.self, reality: node)
             }
             return _YAMLUnkeyedDecodingContainer(decoder: self, wrapping: sequence)
         }
 
         func singleValueContainer() throws -> SingleValueDecodingContainer {
             return self
-        }
-
-        // MARK: Utility
-
-        /// Performs the given closure with the given key pushed onto the end of the current coding path.
-        ///
-        /// - parameter key: The key to push. May be nil for unkeyed containers.
-        /// - parameter work: The work to perform with the key in the path.
-        func with<T>(pushedKey key: CodingKey?, _ work: () throws -> T) rethrows -> T {
-            self.codingPath.append(key)
-            let ret: T = try work()
-            self.codingPath.removeLast()
-            return ret
         }
     }
 
@@ -100,7 +73,7 @@
 
         // MARK: - KeyedDecodingContainerProtocol
 
-        var codingPath: [CodingKey?] {
+        var codingPath: [CodingKey] {
             return decoder.codingPath
         }
 
@@ -115,90 +88,93 @@
             return false
         }
 
-        func decodeIfPresent(_ type: Bool.Type, forKey key: Key) throws -> Bool? { return try construct(for: key) }
-        func decodeIfPresent(_ type: Int.Type, forKey key: Key) throws -> Int? { return try construct(for: key) }
-        func decodeIfPresent(_ type: Int8.Type, forKey key: Key) throws -> Int8? { return try construct(for: key) }
-        func decodeIfPresent(_ type: Int16.Type, forKey key: Key) throws -> Int16? { return try construct(for: key) }
-        func decodeIfPresent(_ type: Int32.Type, forKey key: Key) throws -> Int32? { return try construct(for: key) }
-        func decodeIfPresent(_ type: Int64.Type, forKey key: Key) throws -> Int64? { return try construct(for: key) }
-        func decodeIfPresent(_ type: UInt.Type, forKey key: Key) throws -> UInt? { return try construct(for: key) }
-        func decodeIfPresent(_ type: UInt8.Type, forKey key: Key) throws -> UInt8? { return try construct(for: key) }
-        func decodeIfPresent(_ type: UInt16.Type, forKey key: Key) throws -> UInt16? { return try construct(for: key) }
-        func decodeIfPresent(_ type: UInt32.Type, forKey key: Key) throws -> UInt32? { return try construct(for: key) }
-        func decodeIfPresent(_ type: UInt64.Type, forKey key: Key) throws -> UInt64? { return try construct(for: key) }
-        func decodeIfPresent(_ type: Float.Type, forKey key: Key) throws -> Float? { return try construct(for: key) }
-        func decodeIfPresent(_ type: Double.Type, forKey key: Key) throws -> Double? { return try construct(for: key) }
-        func decodeIfPresent(_ type: String.Type, forKey key: Key) throws -> String? { return try construct(for: key) }
-
-        func decodeIfPresent<T>(_ type: T.Type, forKey key: Key) throws -> T? where T : Decodable {
-            return try decoder.with(pushedKey: key) {
-                guard let node = mapping[key.stringValue] else { return nil }
-                if let constructibleType = type.self as? ScalarConstructible.Type {
-                    return constructibleType.construct(from: node) as? T
-                }
-
-                let decoder = _YAMLDecoder(referencing: node, codingPath: self.decoder.codingPath)
-                return try T(from: decoder)
+        func decodeNil(forKey key: Key) throws -> Bool {
+            guard let node = mapping[key.stringValue] else {
+                throw _keyNotFound(at: codingPath, key, "No value associated with key \(key) (\"\(key.stringValue)\").")
             }
+            return node == Node("null", Tag(.null))
+        }
+
+        func decode(_ type: Bool.Type, forKey key: Key) throws -> Bool { return try construct(for: key) }
+        func decode(_ type: Int.Type, forKey key: Key) throws -> Int { return try construct(for: key) }
+        func decode(_ type: Int8.Type, forKey key: Key) throws -> Int8 { return try construct(for: key) }
+        func decode(_ type: Int16.Type, forKey key: Key) throws -> Int16 { return try construct(for: key) }
+        func decode(_ type: Int32.Type, forKey key: Key) throws -> Int32 { return try construct(for: key) }
+        func decode(_ type: Int64.Type, forKey key: Key) throws -> Int64 { return try construct(for: key) }
+        func decode(_ type: UInt.Type, forKey key: Key) throws -> UInt { return try construct(for: key) }
+        func decode(_ type: UInt8.Type, forKey key: Key) throws -> UInt8 { return try construct(for: key) }
+        func decode(_ type: UInt16.Type, forKey key: Key) throws -> UInt16 { return try construct(for: key) }
+        func decode(_ type: UInt32.Type, forKey key: Key) throws -> UInt32 { return try construct(for: key) }
+        func decode(_ type: UInt64.Type, forKey key: Key) throws -> UInt64 { return try construct(for: key) }
+        func decode(_ type: Float.Type, forKey key: Key) throws -> Float { return try construct(for: key) }
+        func decode(_ type: Double.Type, forKey key: Key) throws -> Double { return try construct(for: key) }
+        func decode(_ type: String.Type, forKey key: Key) throws -> String { return try construct(for: key) }
+
+        func decode<T>(_ type: T.Type, forKey key: Key) throws -> T where T : Decodable {
+            guard let node = mapping[key.stringValue] else {
+                throw _keyNotFound(at: codingPath, key, "No value associated with key \(key) (\"\(key.stringValue)\").")
+            }
+
+            decoder.codingPath.append(key)
+            defer { decoder.codingPath.removeLast() }
+
+            if let constructibleType = type.self as? ScalarConstructible.Type {
+                guard let value = constructibleType.construct(from: node) else {
+                    throw _valueNotFound(at: codingPath, T.self, "Expected \(T.self) value but found null instead.")
+                }
+                return value as! T // swiftlint:disable:this force_cast
+            }
+
+            return try T(from: _YAMLDecoder(referencing: node, codingPath: codingPath))
         }
 
         func nestedContainer<NestedKey>(keyedBy type: NestedKey.Type,
                                         forKey key: Key) throws -> KeyedDecodingContainer<NestedKey> {
-            return try decoder.with(pushedKey: key) {
-                guard let node = mapping[key.stringValue] else {
-                    // FIXME: Should throw type mismatch error
-                    throw DecodingError.keyNotFound(
-                        key,
-                        DecodingError.Context(
-                            codingPath: self.codingPath,
-                            debugDescription: "Cannot get \(KeyedDecodingContainer<NestedKey>.self) -- no value found for key \"\(key.stringValue)\""
-                        )
-                    )
-                }
-                guard let mapping = node.mapping else {
-                    fatalError("should throw type mismatch error")
-                }
-                let decoder = _YAMLDecoder(referencing: node, codingPath: self.decoder.codingPath)
-                let wrapping =  _YAMLKeyedDecodingContainer<NestedKey>(decoder: decoder, wrapping: mapping)
-                return KeyedDecodingContainer(wrapping)
+            guard let node = mapping[key.stringValue] else {
+                let description =
+                "Cannot get \(KeyedDecodingContainer<NestedKey>.self) -- no value found for key \"\(key.stringValue)\""
+                throw _keyNotFound(at: codingPath, key, description)
             }
+
+            decoder.codingPath.append(key)
+            defer { decoder.codingPath.removeLast() }
+
+            guard let mapping = node.mapping else {
+                throw _typeMismatch(at: codingPath, expectation: Node.Mapping.self, reality: node)
+            }
+
+            let nestedDecoder = _YAMLDecoder(referencing: node, codingPath: codingPath)
+            let wrapping =  _YAMLKeyedDecodingContainer<NestedKey>(decoder: nestedDecoder, wrapping: mapping)
+            return KeyedDecodingContainer(wrapping)
         }
 
         func nestedUnkeyedContainer(forKey key: Key) throws -> UnkeyedDecodingContainer {
-            return try decoder.with(pushedKey: key) {
-                guard let node = mapping[key.stringValue], let sequence = node.sequence else {
-                    // FIXME: Should throw type mismatch error
-                    throw DecodingError.keyNotFound(
-                        key,
-                        DecodingError.Context(
-                            codingPath: self.codingPath,
-                            debugDescription: "Cannot get UnkeyedDecodingContainer -- no value found for key \"\(key.stringValue)\""
-                        )
-                    )
-                }
-                let decoder = _YAMLDecoder(referencing: node, codingPath: self.decoder.codingPath)
-                return _YAMLUnkeyedDecodingContainer(decoder: decoder, wrapping: sequence)
+            guard let node = mapping[key.stringValue] else {
+                let description = "Cannot get UnkeyedDecodingContainer -- no value found for key \"\(key.stringValue)\""
+                throw _keyNotFound(at: codingPath, key, description)
             }
+
+            decoder.codingPath.append(key)
+            defer { decoder.codingPath.removeLast() }
+
+            guard let sequence = node.sequence else {
+                throw _typeMismatch(at: codingPath, expectation: Node.Sequence.self, reality: node)
+            }
+
+            let nestedDecoder = _YAMLDecoder(referencing: node, codingPath: codingPath)
+            return _YAMLUnkeyedDecodingContainer(decoder: nestedDecoder, wrapping: sequence)
         }
 
         private func _superDecoder(forKey key: CodingKey) throws -> Decoder {
-            return try self.decoder.with(pushedKey: key) {
-                guard let node = mapping[key.stringValue] else {
-                    throw DecodingError.keyNotFound(
-                        key,
-                        DecodingError.Context(
-                            codingPath: self.codingPath,
-                            debugDescription: "Cannot get superDecoder() -- no value found for key \"\(key.stringValue)\""
-                        )
-                    )
-                }
+            decoder.codingPath.append(key)
+            defer { decoder.codingPath.removeLast() }
 
-                return _YAMLDecoder(referencing: node, codingPath: self.decoder.codingPath)
-            }
+            let node = mapping[key.stringValue]  ?? ""
+            return _YAMLDecoder(referencing: node, codingPath: codingPath)
         }
 
         func superDecoder() throws -> Decoder {
-            return try _superDecoder(forKey: _YAMLDecodingSuperKey())
+            return try _superDecoder(forKey: _YAMLDecodingKey.super)
         }
 
         func superDecoder(forKey key: Key) throws -> Decoder {
@@ -207,27 +183,42 @@
 
         // MARK: Utility
 
-        /// Encode ScalarConstructible
-        func construct<T: ScalarConstructible>(for key: Key) throws -> T? {
-            return decoder.with(pushedKey: key) {
-                guard let node = mapping[key.stringValue] else { return nil }
-                return T.construct(from: node)
+        /// Decode ScalarConstructible
+        private func construct<T: ScalarConstructible>(for key: Key) throws -> T {
+            guard let node = mapping[key.stringValue] else {
+                throw _keyNotFound(at: codingPath, key, "No value associated with key \(key) (\"\(key.stringValue)\").")
             }
+
+            decoder.codingPath.append(key)
+            defer { decoder.codingPath.removeLast() }
+
+            guard let value = T.construct(from: node) else {
+                throw _valueNotFound(at: codingPath, T.self, "Expected \(T.self) value but found null instead.")
+            }
+            return value
         }
     }
 
-    fileprivate struct _YAMLDecodingSuperKey: CodingKey {
-        init() {}
+    fileprivate struct _YAMLDecodingKey: CodingKey {
+        public var stringValue: String
+        public var intValue: Int?
 
-        var stringValue: String { return "super" }
-        init?(stringValue: String) {
-            guard stringValue == "super" else { return nil }
+        public init?(stringValue: String) {
+            self.stringValue = stringValue
+            self.intValue = nil
         }
 
-        var intValue: Int? { return nil }
-        init?(intValue: Int) {
-            return nil
+        public init?(intValue: Int) {
+            self.stringValue = "\(intValue)"
+            self.intValue = intValue
         }
+
+        fileprivate init(index: Int) {
+            self.stringValue = "Index \(index)"
+            self.intValue = index
+        }
+
+        fileprivate static let `super` = _YAMLDecodingKey(stringValue: "super")!
     }
 
     fileprivate struct _YAMLUnkeyedDecodingContainer: UnkeyedDecodingContainer {
@@ -245,7 +236,7 @@
         }
 
         // MARK: - UnkeyedDecodingContainer
-        var codingPath: [CodingKey?] {
+        var codingPath: [CodingKey] {
             return decoder.codingPath
         }
 
@@ -254,126 +245,131 @@
         }
 
         var isAtEnd: Bool {
-            return self.currentIndex >= sequence.count
+            return currentIndex >= sequence.count
         }
 
-        mutating func decodeIfPresent(_ type: Bool.Type) throws -> Bool? { return try construct() }
-        mutating func decodeIfPresent(_ type: Int.Type) throws -> Int? { return try construct() }
-        mutating func decodeIfPresent(_ type: Int8.Type) throws -> Int8? { return try construct() }
-        mutating func decodeIfPresent(_ type: Int16.Type) throws -> Int16? { return try construct() }
-        mutating func decodeIfPresent(_ type: Int32.Type) throws -> Int32? { return try construct() }
-        mutating func decodeIfPresent(_ type: Int64.Type) throws -> Int64? { return try construct() }
-        mutating func decodeIfPresent(_ type: UInt.Type) throws -> UInt? { return try construct() }
-        mutating func decodeIfPresent(_ type: UInt8.Type) throws -> UInt8? { return try construct() }
-        mutating func decodeIfPresent(_ type: UInt16.Type) throws -> UInt16? { return try construct() }
-        mutating func decodeIfPresent(_ type: UInt32.Type) throws -> UInt32? { return try construct() }
-        mutating func decodeIfPresent(_ type: UInt64.Type) throws -> UInt64? { return try construct() }
-        mutating func decodeIfPresent(_ type: Float.Type) throws -> Float? { return try construct() }
-        mutating func decodeIfPresent(_ type: Double.Type) throws -> Double? { return try construct() }
-        mutating func decodeIfPresent(_ type: String.Type) throws -> String? { return try construct() }
+        mutating func decodeNil() throws -> Bool {
+            decoder.codingPath.append(_YAMLDecodingKey(index: currentIndex))
+            defer { decoder.codingPath.removeLast() }
 
-        mutating func decodeIfPresent<T>(_ type: T.Type) throws -> T? where T : Decodable {
-            guard !self.isAtEnd else { return nil }
-
-            let decoded: T? = try decoder.with(pushedKey: nil) {
-                let node = sequence[currentIndex]
-                if let scalarConstructibleType = type.self as? ScalarConstructible.Type {
-                    return scalarConstructibleType.construct(from: node) as? T
-                }
-
-                let decoder = _YAMLDecoder(referencing: node, codingPath: self.decoder.codingPath)
-                return try T(from: decoder)
+            guard !self.isAtEnd else {
+                throw _valueNotFound(at: codingPath, Any?.self, "Unkeyed container is at end.")
             }
+
+            if sequence[currentIndex] == Node("null", Tag(.null)) {
+                currentIndex += 1
+                return true
+            } else {
+                return false
+            }
+        }
+
+        mutating func decode(_ type: Bool.Type) throws -> Bool { return try construct() }
+        mutating func decode(_ type: Int.Type) throws -> Int { return try construct() }
+        mutating func decode(_ type: Int8.Type) throws -> Int8 { return try construct() }
+        mutating func decode(_ type: Int16.Type) throws -> Int16 { return try construct() }
+        mutating func decode(_ type: Int32.Type) throws -> Int32 { return try construct() }
+        mutating func decode(_ type: Int64.Type) throws -> Int64 { return try construct() }
+        mutating func decode(_ type: UInt.Type) throws -> UInt { return try construct() }
+        mutating func decode(_ type: UInt8.Type) throws -> UInt8 { return try construct() }
+        mutating func decode(_ type: UInt16.Type) throws -> UInt16 { return try construct() }
+        mutating func decode(_ type: UInt32.Type) throws -> UInt32 { return try construct() }
+        mutating func decode(_ type: UInt64.Type) throws -> UInt64 { return try construct() }
+        mutating func decode(_ type: Float.Type) throws -> Float { return try construct() }
+        mutating func decode(_ type: Double.Type) throws -> Double { return try construct() }
+        mutating func decode(_ type: String.Type) throws -> String { return try construct() }
+
+        mutating func decode<T>(_ type: T.Type) throws -> T where T : Decodable {
+            decoder.codingPath.append(_YAMLDecodingKey(index: currentIndex))
+            defer { decoder.codingPath.removeLast() }
+
+            guard !self.isAtEnd else {
+                throw _valueNotFound(at: codingPath, T.self, "Unkeyed container is at end.")
+            }
+
+            let node = sequence[currentIndex]
+            if let constructibleType = type.self as? ScalarConstructible.Type {
+                guard let value = constructibleType.construct(from: node) else {
+                    throw _valueNotFound(at: codingPath, T.self, "Expected \(T.self) value but found null instead.")
+                }
+                currentIndex += 1
+                return value as! T // swiftlint:disable:this force_cast
+            }
+
+            let value = try T(from: _YAMLDecoder(referencing: node, codingPath: codingPath))
             currentIndex += 1
-            return decoded
+            return value
         }
 
         mutating func nestedContainer<NestedKey>(keyedBy type: NestedKey.Type) throws -> KeyedDecodingContainer<NestedKey> {
-            return try decoder.with(pushedKey: nil) {
-                guard !self.isAtEnd else {
-                    throw DecodingError.valueNotFound(
-                        KeyedDecodingContainer<NestedKey>.self,
-                        DecodingError.Context(
-                            codingPath: self.codingPath,
-                            debugDescription: "Cannot get nested keyed container -- unkeyed container is at end."
-                        )
-                    )
-                }
-                let node = sequence[currentIndex]
-                guard let mapping = node.mapping else {
-                    // FIXME: Should throw type mismatch error
-                    throw DecodingError.valueNotFound(
-                        KeyedDecodingContainer<NestedKey>.self,
-                        DecodingError.Context(
-                            codingPath: self.codingPath,
-                            debugDescription: "Cannot get \(KeyedDecodingContainer<NestedKey>.self) -- no value found at index \"\(currentIndex)\""
-                        )
-                    )
-                }
+            decoder.codingPath.append(_YAMLDecodingKey(index: currentIndex))
+            defer { decoder.codingPath.removeLast() }
 
-                currentIndex += 1
-                let decoder = _YAMLDecoder(referencing: node, codingPath: self.decoder.codingPath)
-                let wrapping =  _YAMLKeyedDecodingContainer<NestedKey>(decoder: decoder, wrapping: mapping)
-                return KeyedDecodingContainer(wrapping)
+            guard !self.isAtEnd else {
+                throw _valueNotFound(at: codingPath, KeyedDecodingContainer<NestedKey>.self,
+                                     "Cannot get nested keyed container -- unkeyed container is at end.")
             }
+
+            let node = sequence[currentIndex]
+            guard let mapping = node.mapping else {
+                throw _typeMismatch(at: codingPath, expectation: Node.Mapping.self, reality: node)
+            }
+
+            currentIndex += 1
+            let nestedDecoder = _YAMLDecoder(referencing: node, codingPath: self.decoder.codingPath)
+            let wrapping =  _YAMLKeyedDecodingContainer<NestedKey>(decoder: nestedDecoder, wrapping: mapping)
+            return KeyedDecodingContainer(wrapping)
         }
 
         mutating func nestedUnkeyedContainer() throws -> UnkeyedDecodingContainer {
-            return try decoder.with(pushedKey: nil) {
-                guard !self.isAtEnd else {
-                    throw DecodingError.valueNotFound(
-                        UnkeyedDecodingContainer.self,
-                        DecodingError.Context(
-                            codingPath: self.codingPath,
-                            debugDescription: "Cannot get UnkeyedDecodingContainer -- unkeyed container is at end."
-                        )
-                    )
-                }
-                let node = sequence[currentIndex]
-                guard let sequence = node.sequence else {
-                    // FIXME: Should throw type mismatch error
-                    throw DecodingError.typeMismatch(
-                        type(of: node),
-                        DecodingError.Context(
-                            codingPath: codingPath,
-                            debugDescription: "Cannot get UnkeyedDecodingContainer -- no value found at index \"\(currentIndex)\""
-                        )
-                    )
-                }
-                let decoder = _YAMLDecoder(referencing: node, codingPath: self.decoder.codingPath)
-                return _YAMLUnkeyedDecodingContainer(decoder: decoder, wrapping: sequence)
+            decoder.codingPath.append(_YAMLDecodingKey(index: currentIndex))
+            defer { decoder.codingPath.removeLast() }
+
+            guard !self.isAtEnd else {
+                throw _valueNotFound(at: codingPath, UnkeyedDecodingContainer.self,
+                                     "Cannot get UnkeyedDecodingContainer -- unkeyed container is at end.")
             }
+
+            let node = sequence[currentIndex]
+            guard let sequence = node.sequence else {
+                throw _typeMismatch(at: codingPath, expectation: Node.Sequence.self, reality: node)
+            }
+
+            let nestedDecoder = _YAMLDecoder(referencing: node, codingPath: self.decoder.codingPath)
+            return _YAMLUnkeyedDecodingContainer(decoder: nestedDecoder, wrapping: sequence)
         }
 
         mutating func superDecoder() throws -> Decoder {
-            return try decoder.with(pushedKey: nil) {
-                guard !self.isAtEnd else {
-                    throw DecodingError.valueNotFound(
-                        Decoder.self,
-                        DecodingError.Context(
-                            codingPath: self.codingPath,
-                            debugDescription: "Cannot get superDecoder() -- unkeyed container is at end."
-                        )
-                    )
-                }
+            decoder.codingPath.append(_YAMLDecodingKey(index: currentIndex))
+            defer { decoder.codingPath.removeLast() }
 
-                let node = sequence[currentIndex]
-                self.currentIndex += 1
-                return _YAMLDecoder(referencing: node, codingPath: self.decoder.codingPath)
+            guard !self.isAtEnd else {
+                throw _valueNotFound(at: codingPath, Decoder.self,
+                                     "Cannot get superDecoder() -- unkeyed container is at end.")
             }
+
+            let node = sequence[currentIndex]
+            self.currentIndex += 1
+            return _YAMLDecoder(referencing: node, codingPath: codingPath)
         }
 
         // MARK: Utility
 
-        /// Encode ScalarConstructible
-        mutating func construct<T: ScalarConstructible>() throws -> T? {
-            guard !self.isAtEnd else { return nil }
+        /// Decode ScalarConstructible
+        mutating func construct<T: ScalarConstructible>() throws -> T {
+            decoder.codingPath.append(_YAMLDecodingKey(index: currentIndex))
+            defer { decoder.codingPath.removeLast() }
 
-            return decoder.with(pushedKey: nil) {
-                let node = sequence[currentIndex]
-                currentIndex += 1
-                return T.construct(from: node)
+            guard !self.isAtEnd else {
+                throw _valueNotFound(at: codingPath, T.self, "Unkeyed container is at end.")
             }
+
+            guard let decoded = T.construct(from: sequence[currentIndex]) else {
+                throw _valueNotFound(at: codingPath, T.self, "Expected \(T.self) but found null instead.")
+            }
+
+            currentIndex += 1
+            return decoded
         }
     }
 
@@ -399,8 +395,13 @@
         func decode(_ type: Data.Type)   throws -> Data { return try construct() }
 
         func decode<T>(_ type: T.Type) throws -> T where T : Decodable {
+            try expectNonNull(T.self)
+
             if let scalarConstructibleType = type.self as? ScalarConstructible.Type {
-                return scalarConstructibleType.construct(from: node) as! T // swiftlint:disable:this force_cast
+                guard let value = scalarConstructibleType.construct(from: node) else {
+                    throw _valueNotFound(at: codingPath, T.self, "Expected \(T.self) value but found null instead.")
+                }
+                return value as! T // swiftlint:disable:this force_cast
             }
 
             let decoder = _YAMLDecoder(referencing: node)
@@ -409,21 +410,37 @@
 
         // MARK: Utility
 
-        /// Encode ScalarConstructible
-        func construct<T: ScalarConstructible>() throws -> T {
-            return try with(pushedKey: nil) {
-                guard let decoded = T.construct(from: node) else {
-                    // FIXME: Should throw type mismatch error
-                    throw DecodingError.typeMismatch(
-                        T.self,
-                        DecodingError.Context(
-                            codingPath: codingPath, debugDescription: ""
-                        )
-                    )
-                }
-                return decoded
+        /// Decode ScalarConstructible
+        private func construct<T: ScalarConstructible>() throws -> T {
+            try expectNonNull(T.self)
+            guard let decoded = T.construct(from: node) else {
+                throw _typeMismatch(at: codingPath, expectation: T.self, reality: node)
+            }
+            return decoded
+        }
+
+        private func expectNonNull<T>(_ type: T.Type) throws {
+            guard !self.decodeNil() else {
+                throw _valueNotFound(at: codingPath, type, "Expected \(type) but found null value instead.")
             }
         }
+
+    }
+
+    private func _keyNotFound(at codingPath: [CodingKey], _ key: CodingKey, _ description: String) -> DecodingError {
+        let context = DecodingError.Context(codingPath: codingPath, debugDescription: description)
+        return.keyNotFound(key, context)
+    }
+
+    private func _valueNotFound(at codingPath: [CodingKey], _ type: Any.Type, _ description: String) -> DecodingError {
+        let context = DecodingError.Context(codingPath: codingPath, debugDescription: description)
+        return .valueNotFound(type, context)
+    }
+
+    private func _typeMismatch(at codingPath: [CodingKey], expectation: Any.Type, reality: Any) -> DecodingError {
+        let description = "Expected to decode \(expectation) but found \(type(of: reality)) instead."
+        let context = DecodingError.Context(codingPath: codingPath, debugDescription: description)
+        return .typeMismatch(expectation, context)
     }
 
     extension BinaryInteger {

--- a/Sources/Yams/Decoder.swift
+++ b/Sources/Yams/Decoder.swift
@@ -44,7 +44,7 @@
         var codingPath: [CodingKey]
 
         /// Contextual user-provided information for use during encoding.
-        var userInfo: [CodingUserInfoKey : Any] = [:]
+        var userInfo: [CodingUserInfoKey: Any] = [:]
 
         func container<Key>(keyedBy type: Key.Type) throws -> KeyedDecodingContainer<Key> {
             guard let mapping = node.mapping else {
@@ -117,7 +117,7 @@
         func decode(_ type: Double.Type, forKey key: Key) throws -> Double { return try construct(for: key) }
         func decode(_ type: String.Type, forKey key: Key) throws -> String { return try construct(for: key) }
 
-        func decode<T>(_ type: T.Type, forKey key: Key) throws -> T where T : Decodable {
+        func decode<T>(_ type: T.Type, forKey key: Key) throws -> T where T: Decodable {
             guard let node = mapping[key.stringValue] else {
                 throw _keyNotFound(at: codingPath, key, "No value associated with key \(key) (\"\(key.stringValue)\").")
             }
@@ -286,7 +286,7 @@
         mutating func decode(_ type: Double.Type) throws -> Double { return try construct() }
         mutating func decode(_ type: String.Type) throws -> String { return try construct() }
 
-        mutating func decode<T>(_ type: T.Type) throws -> T where T : Decodable {
+        mutating func decode<T>(_ type: T.Type) throws -> T where T: Decodable {
             decoder.codingPath.append(_YAMLDecodingKey(index: currentIndex))
             defer { decoder.codingPath.removeLast() }
 
@@ -308,7 +308,7 @@
             return value
         }
 
-        mutating func nestedContainer<NestedKey>(keyedBy type: NestedKey.Type) throws -> KeyedDecodingContainer<NestedKey> {
+        mutating func nestedContainer<NestedKey>(keyedBy type: NestedKey.Type) throws -> KeyedDecodingContainer<NestedKey> { // swiftlint:disable:this line_length
             decoder.codingPath.append(_YAMLDecodingKey(index: currentIndex))
             defer { decoder.codingPath.removeLast() }
 
@@ -380,7 +380,7 @@
         }
     }
 
-    extension _YAMLDecoder : SingleValueDecodingContainer {
+    extension _YAMLDecoder: SingleValueDecodingContainer {
 
         // MARK: SingleValueDecodingContainer Methods
 
@@ -401,7 +401,7 @@
         func decode(_ type: String.Type) throws -> String { return try construct() }
         func decode(_ type: Data.Type)   throws -> Data { return try construct() }
 
-        func decode<T>(_ type: T.Type) throws -> T where T : Decodable {
+        func decode<T>(_ type: T.Type) throws -> T where T: Decodable {
             if let scalarConstructibleType = type.self as? ScalarConstructible.Type {
                 guard let value = scalarConstructibleType.construct(from: node) else {
                     throw _valueNotFound(at: codingPath, T.self, "Expected \(T.self) value but found null instead.")

--- a/Sources/Yams/Decoder.swift
+++ b/Sources/Yams/Decoder.swift
@@ -29,7 +29,7 @@
         }
     }
 
-    fileprivate class _YAMLDecoder: Decoder {
+    private class _YAMLDecoder: Decoder {
 
         let node: Node
 
@@ -66,7 +66,7 @@
         }
     }
 
-    fileprivate struct _YAMLKeyedDecodingContainer<K: CodingKey> : KeyedDecodingContainerProtocol {
+    private struct _YAMLKeyedDecodingContainer<K: CodingKey> : KeyedDecodingContainerProtocol {
 
         typealias Key = K
 
@@ -206,7 +206,7 @@
         }
     }
 
-    fileprivate struct _YAMLDecodingKey: CodingKey {
+    private struct _YAMLDecodingKey: CodingKey {
         public var stringValue: String
         public var intValue: Int?
 
@@ -228,7 +228,7 @@
         fileprivate static let `super` = _YAMLDecodingKey(stringValue: "super")!
     }
 
-    fileprivate struct _YAMLUnkeyedDecodingContainer: UnkeyedDecodingContainer {
+    private struct _YAMLUnkeyedDecodingContainer: UnkeyedDecodingContainer {
 
         let decoder: _YAMLDecoder
         let sequence: Node.Sequence

--- a/Sources/Yams/Decoder.swift
+++ b/Sources/Yams/Decoder.swift
@@ -100,20 +100,20 @@
             return try node(for: key) == Node("null", Tag(.null))
         }
 
-        func decode(_ type: Bool.Type, forKey key: Key)   throws -> Bool { return try construct(for: key) }
-        func decode(_ type: Int.Type, forKey key: Key)    throws -> Int { return try construct(for: key) }
-        func decode(_ type: Int8.Type, forKey key: Key)   throws -> Int8 { return try construct(for: key) }
-        func decode(_ type: Int16.Type, forKey key: Key)  throws -> Int16 { return try construct(for: key) }
-        func decode(_ type: Int32.Type, forKey key: Key)  throws -> Int32 { return try construct(for: key) }
-        func decode(_ type: Int64.Type, forKey key: Key)  throws -> Int64 { return try construct(for: key) }
-        func decode(_ type: UInt.Type, forKey key: Key)   throws -> UInt { return try construct(for: key) }
-        func decode(_ type: UInt8.Type, forKey key: Key)  throws -> UInt8 { return try construct(for: key) }
-        func decode(_ type: UInt16.Type, forKey key: Key) throws -> UInt16 { return try construct(for: key) }
-        func decode(_ type: UInt32.Type, forKey key: Key) throws -> UInt32 { return try construct(for: key) }
-        func decode(_ type: UInt64.Type, forKey key: Key) throws -> UInt64 { return try construct(for: key) }
-        func decode(_ type: Float.Type, forKey key: Key)  throws -> Float { return try construct(for: key) }
-        func decode(_ type: Double.Type, forKey key: Key) throws -> Double { return try construct(for: key) }
-        func decode(_ type: String.Type, forKey key: Key) throws -> String { return try construct(for: key) }
+        func decode(_ type: Bool.Type, forKey key: Key)   throws -> Bool { return try decoder(for: key).construct() }
+        func decode(_ type: Int.Type, forKey key: Key)    throws -> Int { return try decoder(for: key).construct() }
+        func decode(_ type: Int8.Type, forKey key: Key)   throws -> Int8 { return try decoder(for: key).construct() }
+        func decode(_ type: Int16.Type, forKey key: Key)  throws -> Int16 { return try decoder(for: key).construct() }
+        func decode(_ type: Int32.Type, forKey key: Key)  throws -> Int32 { return try decoder(for: key).construct() }
+        func decode(_ type: Int64.Type, forKey key: Key)  throws -> Int64 { return try decoder(for: key).construct() }
+        func decode(_ type: UInt.Type, forKey key: Key)   throws -> UInt { return try decoder(for: key).construct() }
+        func decode(_ type: UInt8.Type, forKey key: Key)  throws -> UInt8 { return try decoder(for: key).construct() }
+        func decode(_ type: UInt16.Type, forKey key: Key) throws -> UInt16 { return try decoder(for: key).construct() }
+        func decode(_ type: UInt32.Type, forKey key: Key) throws -> UInt32 { return try decoder(for: key).construct() }
+        func decode(_ type: UInt64.Type, forKey key: Key) throws -> UInt64 { return try decoder(for: key).construct() }
+        func decode(_ type: Float.Type, forKey key: Key)  throws -> Float { return try decoder(for: key).construct() }
+        func decode(_ type: Double.Type, forKey key: Key) throws -> Double { return try decoder(for: key).construct() }
+        func decode(_ type: String.Type, forKey key: Key) throws -> String { return try decoder(for: key).construct() }
 
         func decode<T>(_ type: T.Type, forKey key: Key) throws -> T where T: Decodable {
             return try decoder(for: key).decode(type) // use SingleValueDecodingContainer's method
@@ -142,10 +142,6 @@
 
         private func decoder(for key: CodingKey) throws -> _YAMLDecoder {
             return decoder.decoder(referencing: try node(for: key), as: key)
-        }
-
-        private func construct<T: ScalarConstructible>(for key: Key) throws -> T {
-            return try decoder(for: key).construct()
         }
     }
 

--- a/Sources/Yams/Decoder.swift
+++ b/Sources/Yams/Decoder.swift
@@ -455,4 +455,18 @@
         }
     }
 
+    extension Decimal: ScalarConstructible {
+        public static func construct(from node: Node) -> Decimal? {
+            assert(node.isScalar) // swiftlint:disable:next force_unwrapping
+            return Decimal(string: node.scalar!.string)
+        }
+    }
+
+    extension URL: ScalarConstructible {
+        public static func construct(from node: Node) -> URL? {
+            assert(node.isScalar) // swiftlint:disable:next force_unwrapping
+            return URL(string: node.scalar!.string)
+        }
+    }
+
 #endif // swiftlint:disable:this file_length

--- a/Sources/Yams/Decoder.swift
+++ b/Sources/Yams/Decoder.swift
@@ -15,7 +15,14 @@
         public func decode<T: Swift.Decodable>(_ type: T.Type, from data: Data) throws -> T {
             // TODO: Detect string encoding
             let yaml = String(data: data, encoding: .utf8)! // swiftlint:disable:this force_unwrapping
-            let node = try Yams.compose(yaml: yaml) ?? ""
+            let node: Node
+            do {
+                node = try Yams.compose(yaml: yaml) ?? ""
+            } catch {
+                throw DecodingError.dataCorrupted(.init(codingPath: [],
+                                                        debugDescription: "The given data was not valid YAML.",
+                                                        underlyingError: error))
+            }
             let decoder = _YAMLDecoder(referencing: node)
             let container = try decoder.singleValueContainer()
             return try container.decode(T.self)

--- a/Sources/Yams/Decoder.swift
+++ b/Sources/Yams/Decoder.swift
@@ -30,7 +30,7 @@
         }
     }
 
-    private struct _YAMLDecoder: Decoder {
+    struct _YAMLDecoder: Decoder { // swiftlint:disable:this type_name
 
         private let node: Node
 
@@ -64,7 +64,7 @@
         // MARK: -
 
         /// constuct `T` from `node`
-        func construct<T: ScalarConstructible>() throws -> T {
+        fileprivate func construct<T: ScalarConstructible>() throws -> T {
             guard let constructed = T.construct(from: node) else {
                 throw _typeMismatch(at: codingPath, expectation: T.self, reality: node)
             }
@@ -72,19 +72,20 @@
         }
 
         /// create a new `_YAMLDecoder` instance referencing `node` as `key` inheriting `userInfo`
-        func decoder(referencing node: Node, `as` key: CodingKey) -> _YAMLDecoder {
+        fileprivate func decoder(referencing node: Node, `as` key: CodingKey) -> _YAMLDecoder {
             return .init(referencing: node, userInfo: userInfo, codingPath: codingPath + [key])
         }
     }
 
-    private struct _YAMLKeyedDecodingContainer<K: CodingKey> : KeyedDecodingContainerProtocol {
+    struct _YAMLKeyedDecodingContainer<K: CodingKey> : KeyedDecodingContainerProtocol {
+        // swiftlint:disable:previous type_name
 
         typealias Key = K
 
-        let decoder: _YAMLDecoder
-        let mapping: Node.Mapping
+        private let decoder: _YAMLDecoder
+        private let mapping: Node.Mapping
 
-        init(decoder: _YAMLDecoder, wrapping mapping: Node.Mapping) {
+        fileprivate init(decoder: _YAMLDecoder, wrapping mapping: Node.Mapping) {
             self.decoder = decoder
             self.mapping = mapping
         }
@@ -148,12 +149,12 @@
         }
     }
 
-    private struct _YAMLUnkeyedDecodingContainer: UnkeyedDecodingContainer {
+    struct _YAMLUnkeyedDecodingContainer: UnkeyedDecodingContainer { // swiftlint:disable:this type_name
 
-        let decoder: _YAMLDecoder
-        let sequence: Node.Sequence
+        private let decoder: _YAMLDecoder
+        private let sequence: Node.Sequence
 
-        init(decoder: _YAMLDecoder, wrapping sequence: Node.Sequence) {
+        fileprivate init(decoder: _YAMLDecoder, wrapping sequence: Node.Sequence) {
             self.decoder = decoder
             self.sequence = sequence
             self.currentIndex = 0
@@ -274,26 +275,26 @@
 
     // MARK: - CodingKey for `_YAMLUnkeyedDecodingContainer` and `superDecoders`
 
-    private struct _YAMLDecodingKey: CodingKey {
-        public var stringValue: String
-        public var intValue: Int?
+    struct _YAMLDecodingKey: CodingKey { // swiftlint:disable:this type_name
+        var stringValue: String
+        var intValue: Int?
 
-        public init?(stringValue: String) {
+        init?(stringValue: String) {
             self.stringValue = stringValue
             self.intValue = nil
         }
 
-        public init?(intValue: Int) {
+        init?(intValue: Int) {
             self.stringValue = "\(intValue)"
             self.intValue = intValue
         }
 
-        fileprivate init(index: Int) {
+        init(index: Int) {
             self.stringValue = "Index \(index)"
             self.intValue = index
         }
 
-        fileprivate static let `super` = _YAMLDecodingKey(stringValue: "super")!
+        static let `super` = _YAMLDecodingKey(stringValue: "super")!
     }
 
     // MARK: - DecodingError helpers

--- a/Sources/Yams/Emitter.swift
+++ b/Sources/Yams/Emitter.swift
@@ -337,6 +337,20 @@ public final class Emitter {
     }
 }
 
+extension Emitter.Options {
+    // initializer without exposing internal properties
+    public init(canonical: Bool = false, indent: Int = 0, width: Int = 0, allowUnicode: Bool = false,
+                lineBreak: Emitter.LineBreak = .ln, version: (major: Int, minor: Int)? = nil, sortKeys: Bool = false) {
+        self.canonical = canonical
+        self.indent = indent
+        self.width = width
+        self.allowUnicode = allowUnicode
+        self.lineBreak = lineBreak
+        self.version = version
+        self.sortKeys = sortKeys
+    }
+}
+
 // MARK: implementation details
 extension Emitter {
     fileprivate func emit(_ event: UnsafeMutablePointer<yaml_event_t>) throws {

--- a/Sources/Yams/Encoder.swift
+++ b/Sources/Yams/Encoder.swift
@@ -152,7 +152,7 @@
                     if let data = value as? Data {
                         encoder.node.sequence?.append(try data.represented())
                     } else if let date = value as? Date {
-                        encoder.node.sequence?.append(try date.represented())
+                        encoder.node.sequence?.append(date.representedForCodable())
                     } else {
                         try value.encode(to: referencingEncoder(for: key.stringValue))
                     }
@@ -229,7 +229,7 @@
                     if let data = value as? Data {
                         encoder.node.sequence?.append(try data.represented())
                     } else if let date = value as? Date {
-                        encoder.node.sequence?.append(try date.represented())
+                        encoder.node.sequence?.append(date.representedForCodable())
                     } else {
                         try value.encode(to: referencingEncoder())
                     }

--- a/Sources/Yams/Encoder.swift
+++ b/Sources/Yams/Encoder.swift
@@ -89,6 +89,11 @@
             node = try box(value)
         }
 
+        fileprivate func represent<T: ScalarRepresentableCustomizedForCodable>(_ value: T) throws {
+            assertCanEncodeNewValue()
+            node = value.representedForCodable()
+        }
+
         /// create a new `_YAMLReferencingEncoder` instance as `key` inheriting `userInfo`
         fileprivate func encoder(for key: CodingKey) -> _YAMLReferencingEncoder {
             return .init(referencing: self, key: key)
@@ -262,8 +267,8 @@
 
         func encode<T>(_ value: T) throws where T: Encodable {
             assertCanEncodeNewValue()
-            if let date = value as? Date {
-                node = date.representedForCodable()
+            if let customized = value as? ScalarRepresentableCustomizedForCodable {
+                node = customized.representedForCodable()
             } else if let representable = value as? ScalarRepresentable {
                 node = try box(representable)
             } else {

--- a/Sources/Yams/Encoder.swift
+++ b/Sources/Yams/Encoder.swift
@@ -28,19 +28,19 @@
         }
     }
 
-    fileprivate extension Node {
+    private extension Node {
         static let unused = Node("", .unused)
     }
 
-    fileprivate extension Tag {
+    private extension Tag {
         static let unused = Tag(.unused)
     }
 
-    fileprivate extension Tag.Name {
+    private extension Tag.Name {
         static let unused: Tag.Name = "tag:yams.encoder:unused"
     }
 
-    fileprivate class _YAMLEncoder: Swift.Encoder {
+    private class _YAMLEncoder: Swift.Encoder {
 
         var node: Node = .unused
 
@@ -121,7 +121,7 @@
         }
     }
 
-    fileprivate class _YAMLReferencingEncoder: _YAMLEncoder {
+    private class _YAMLReferencingEncoder: _YAMLEncoder {
         enum Reference {
             case sequence(Int)
             case mapping(String)
@@ -151,7 +151,7 @@
         }
     }
 
-    fileprivate struct _KeyedEncodingContainer<K: CodingKey> : KeyedEncodingContainerProtocol {
+    private struct _KeyedEncodingContainer<K: CodingKey> : KeyedEncodingContainerProtocol {
         typealias Key = K
 
         let encoder: _YAMLEncoder
@@ -230,7 +230,7 @@
         }
     }
 
-    fileprivate struct _YAMLEncodingKey: CodingKey {
+    private struct _YAMLEncodingKey: CodingKey {
         public var stringValue: String
         public var intValue: Int?
 
@@ -252,7 +252,7 @@
         fileprivate static let `super` = _YAMLEncodingKey(stringValue: "super")!
     }
 
-    fileprivate struct _UnkeyedEncodingContainer: UnkeyedEncodingContainer {
+    private struct _UnkeyedEncodingContainer: UnkeyedEncodingContainer {
 
         let encoder: _YAMLEncoder
 

--- a/Sources/Yams/Encoder.swift
+++ b/Sources/Yams/Encoder.swift
@@ -1,0 +1,324 @@
+//
+//  Encoder.swift
+//  Yams
+//
+//  Created by Norio Nomura on 5/2/17.
+//  Copyright (c) 2017 Yams. All rights reserved.
+//
+
+#if swift(>=4.0)
+
+    import Foundation
+
+    public class YAMLEncoder {
+        public init() {}
+        public func encode<T: Swift.Encodable>(_ value: T) throws -> Data {
+            let encoder = _YAMLEncoder()
+            try value.encode(to: encoder)
+            return try serialize(node: encoder.node).data(using: .utf8, allowLossyConversion: false) ?? Data()
+        }
+    }
+
+    fileprivate class _YAMLEncoder: Swift.Encoder {
+
+        var node: Node = ""
+
+        init(codingPath: [CodingKey?] = []) {
+            self.codingPath = codingPath
+        }
+
+        // MARK: - Swift.Encoder Methods
+
+        /// The path to the current point in encoding.
+        var codingPath: [CodingKey?]
+
+        /// Contextual user-provided information for use during encoding.
+        var userInfo: [CodingUserInfoKey : Any] = [:]
+
+        func container<Key>(keyedBy type: Key.Type) -> KeyedEncodingContainer<Key> {
+            assertCanRequestNewContainer()
+            node = [:]
+            let wrapper = _KeyedEncodingContainer<Key>(referencing: self)
+            return KeyedEncodingContainer(wrapper)
+        }
+
+        func unkeyedContainer() -> UnkeyedEncodingContainer {
+            assertCanRequestNewContainer()
+            node = []
+            return _UnkeyedEncodingContainer(referencing: self)
+        }
+
+        func singleValueContainer() -> SingleValueEncodingContainer {
+            assertCanRequestNewContainer()
+            return self
+        }
+
+        // MARK: Utility
+
+        /// Performs the given closure with the given key pushed onto the end of the current coding path.
+        ///
+        /// - parameter key: The key to push. May be nil for unkeyed containers.
+        /// - parameter work: The work to perform with the key in the path.
+        func with(pushedKey key: CodingKey?, _ work: () throws -> Void) rethrows {
+            self.codingPath.append(key)
+            try work()
+            self.codingPath.removeLast()
+        }
+
+        /// Asserts that a new container can be requested at this coding path.
+        /// `preconditionFailure()`s if one cannot be requested.
+        func assertCanRequestNewContainer() {
+            guard node == "" else {
+                let previousContainerType: String
+                switch node {
+                case .mapping:
+                    previousContainerType = "keyed"
+                case .sequence:
+                    previousContainerType = "unkeyed"
+                case .scalar:
+                    previousContainerType = "single value"
+                }
+                preconditionFailure(
+                    "Attempt to encode with new container when already encoded with \(previousContainerType) container."
+                )
+            }
+        }
+    }
+
+    fileprivate class _YAMLReferencingEncoder: _YAMLEncoder {
+        enum Reference {
+            case sequence(Int)
+            case mapping(String)
+        }
+        let encoder: _YAMLEncoder
+        let reference: Reference
+
+        init(referencing encoder: _YAMLEncoder, at index: Int) {
+            self.encoder = encoder
+            reference = .sequence(index)
+            super.init(codingPath: encoder.codingPath)
+        }
+
+        init(referencing encoder: _YAMLEncoder, key: String) {
+            self.encoder = encoder
+            reference = .mapping(key)
+            super.init(codingPath: encoder.codingPath)
+        }
+
+        deinit {
+            switch reference {
+            case .sequence(let index):
+                encoder.node[index] = node
+            case .mapping(let key):
+                encoder.node[key] = node
+            }
+        }
+    }
+
+    fileprivate struct _KeyedEncodingContainer<K: CodingKey> : KeyedEncodingContainerProtocol {
+        typealias Key = K
+
+        let encoder: _YAMLEncoder
+
+        init(referencing encoder: _YAMLEncoder) {
+            self.encoder = encoder
+        }
+
+        // MARK: - KeyedEncodingContainerProtocol
+
+        var codingPath: [CodingKey?] {
+            return encoder.codingPath
+        }
+
+        // assumes following methods never throws
+        func encode(_ value: Bool?, forKey key: Key)   throws { try represent(value, for: key) }
+        func encode(_ value: Int?, forKey key: Key)    throws { try represent(value, for: key) }
+        func encode(_ value: Int8?, forKey key: Key)   throws { try represent(value, for: key) }
+        func encode(_ value: Int16?, forKey key: Key)  throws { try represent(value, for: key) }
+        func encode(_ value: Int32?, forKey key: Key)  throws { try represent(value, for: key) }
+        func encode(_ value: Int64?, forKey key: Key)  throws { try represent(value, for: key) }
+        func encode(_ value: UInt?, forKey key: Key)   throws { try represent(value, for: key) }
+        func encode(_ value: UInt8?, forKey key: Key)  throws { try represent(value, for: key) }
+        func encode(_ value: UInt16?, forKey key: Key) throws { try represent(value, for: key) }
+        func encode(_ value: UInt32?, forKey key: Key) throws { try represent(value, for: key) }
+        func encode(_ value: UInt64?, forKey key: Key) throws { try represent(value, for: key) }
+        func encode(_ value: Float?, forKey key: Key)  throws { try represent(value, for: key) }
+        func encode(_ value: Double?, forKey key: Key) throws { try represent(value, for: key) }
+        func encode(_ value: String?, forKey key: Key) throws { try represent(value, for: key) }
+
+        func encode<T>(_ value: T?, forKey key: Key) throws where T : Encodable {
+            try encoder.with(pushedKey: key) {
+                if let value = value {
+                    if let data = value as? Data {
+                        encoder.node.sequence?.append(try data.represented())
+                    } else if let date = value as? Date {
+                        encoder.node.sequence?.append(try date.represented())
+                    } else {
+                        try value.encode(to: referencingEncoder(for: key.stringValue))
+                    }
+                } else {
+                    encoder.node.sequence?.append(Node("null", Tag(.null)))
+                }
+            }
+        }
+
+        func nestedContainer<NestedKey>(keyedBy keyType: NestedKey.Type,
+                                        forKey key: Key) -> KeyedEncodingContainer<NestedKey> {
+            let wrapper = _KeyedEncodingContainer<NestedKey>(referencing: referencingEncoder(for: key.stringValue))
+            return KeyedEncodingContainer(wrapper)
+        }
+
+        func nestedUnkeyedContainer(forKey key: Key) -> UnkeyedEncodingContainer {
+            return _UnkeyedEncodingContainer(referencing: referencingEncoder(for: key.stringValue))
+        }
+
+        func superEncoder() -> Encoder {
+            return referencingEncoder(for: "super")
+        }
+
+        func superEncoder(forKey key: Key) -> Encoder {
+            return referencingEncoder(for: key.stringValue)
+        }
+
+        // MARK: Utility
+
+        /// Encode NodeRepresentable
+        private func represent<T: NodeRepresentable>(_ value: T, for key: Key) throws {
+            // assumes this function is used for types that never throws.
+            encoder.node.mapping?[key.stringValue] = try Node(value)
+        }
+
+        private func referencingEncoder(for key: String) -> _YAMLReferencingEncoder {
+            return _YAMLReferencingEncoder(referencing: self.encoder, key: key)
+        }
+    }
+
+    fileprivate struct _UnkeyedEncodingContainer: UnkeyedEncodingContainer {
+
+        let encoder: _YAMLEncoder
+
+        init(referencing encoder: _YAMLEncoder) {
+            self.encoder = encoder
+        }
+
+        // MARK: - UnkeyedEncodingContainer
+
+        var codingPath: [CodingKey?] {
+            return encoder.codingPath
+        }
+
+        func encode(_ value: Bool?)   throws { try represent(value) }
+        func encode(_ value: Int?)    throws { try represent(value) }
+        func encode(_ value: Int8?)   throws { try represent(value) }
+        func encode(_ value: Int16?)  throws { try represent(value) }
+        func encode(_ value: Int32?)  throws { try represent(value) }
+        func encode(_ value: Int64?)  throws { try represent(value) }
+        func encode(_ value: UInt?)   throws { try represent(value) }
+        func encode(_ value: UInt8?)  throws { try represent(value) }
+        func encode(_ value: UInt16?) throws { try represent(value) }
+        func encode(_ value: UInt32?) throws { try represent(value) }
+        func encode(_ value: UInt64?) throws { try represent(value) }
+        func encode(_ value: Float?)  throws { try represent(value) }
+        func encode(_ value: Double?) throws { try represent(value) }
+        func encode(_ value: String?) throws { try represent(value) }
+
+        func encode<T>(_ value: T?) throws where T : Encodable {
+            // Since generic types may throw, the coding path needs to contain this key.
+            try encoder.with(pushedKey: nil) {
+                if let value = value {
+                    if let data = value as? Data {
+                        encoder.node.sequence?.append(try data.represented())
+                    } else if let date = value as? Date {
+                        encoder.node.sequence?.append(try date.represented())
+                    } else {
+                        try value.encode(to: referencingEncoder())
+                    }
+                } else {
+                    encoder.node.sequence?.append(Node("null", Tag(.null)))
+                }
+            }
+        }
+
+        func nestedContainer<NestedKey>(keyedBy keyType: NestedKey.Type) -> KeyedEncodingContainer<NestedKey> {
+            let wrapper = _KeyedEncodingContainer<NestedKey>(referencing: referencingEncoder())
+            return KeyedEncodingContainer(wrapper)
+        }
+
+        func nestedUnkeyedContainer() -> UnkeyedEncodingContainer {
+            return _UnkeyedEncodingContainer(referencing: referencingEncoder())
+        }
+
+        func superEncoder() -> Encoder {
+            return referencingEncoder()
+        }
+
+        // MARK: Utility
+
+        /// Encode NodeRepresentable
+        private func represent<T: NodeRepresentable>(_ value: T) throws {
+            // assumes this function is used for types that never throws.
+            encoder.node.sequence?.append(try Node(value))
+        }
+
+        private func referencingEncoder() -> _YAMLReferencingEncoder {
+            let index: Int = encoder.node.sequence?.count ?? 0
+            encoder.node.sequence?.append("")
+            return _YAMLReferencingEncoder(referencing: self.encoder, at: index)
+        }
+    }
+
+    extension _YAMLEncoder: SingleValueEncodingContainer {
+
+        // MARK: - SingleValueEncodingContainer Methods
+
+        func encode(_ value: Bool)   throws { try represent(value) }
+        func encode(_ value: Int)    throws { try represent(value) }
+        func encode(_ value: Int8)   throws { try represent(value) }
+        func encode(_ value: Int16)  throws { try represent(value) }
+        func encode(_ value: Int32)  throws { try represent(value) }
+        func encode(_ value: Int64)  throws { try represent(value) }
+        func encode(_ value: UInt)   throws { try represent(value) }
+        func encode(_ value: UInt8)  throws { try represent(value) }
+        func encode(_ value: UInt16) throws { try represent(value) }
+        func encode(_ value: UInt32) throws { try represent(value) }
+        func encode(_ value: UInt64) throws { try represent(value) }
+        func encode(_ value: Float)  throws { try represent(value) }
+        func encode(_ value: Double) throws { try represent(value) }
+
+        func encode(_ value: String) throws {
+            assertCanEncodeSingleValue()
+            node = Node(value)
+        }
+
+        // MARK: Utility
+
+        /// Asserts that a single value can be encoded at the current coding path
+        /// (i.e. that one has not already been encoded through this container).
+        /// `preconditionFailure()`s if one cannot be encoded.
+        ///
+        /// This is similar to assertCanRequestNewContainer above.
+        func assertCanEncodeSingleValue() {
+            guard node == "" else {
+                let previousContainerType: String
+                switch node {
+                case .mapping:
+                    previousContainerType = "keyed"
+                case .sequence:
+                    previousContainerType = "unkeyed"
+                case .scalar:
+                    preconditionFailure("Attempt to encode multiple values in a single value container.")
+                }
+                preconditionFailure(
+                    "Attempt to encode with new container when already encoded with \(previousContainerType) container."
+                )
+            }
+        }
+
+        /// Encode NodeRepresentable
+        func represent<T: NodeRepresentable>(_ value: T) throws {
+            assertCanEncodeSingleValue()
+            node = try Node(value)
+        }
+    }
+
+#endif

--- a/Sources/Yams/Encoder.swift
+++ b/Sources/Yams/Encoder.swift
@@ -156,19 +156,19 @@
 
         var codingPath: [CodingKey] { return encoder.codingPath }
         func encodeNil(forKey key: Key)               throws { encoder.mapping[key.stringValue] = .null }
-        func encode(_ value: Bool, forKey key: Key)   throws { try represent(value, for: key) }
-        func encode(_ value: Int, forKey key: Key)    throws { try represent(value, for: key) }
-        func encode(_ value: Int8, forKey key: Key)   throws { try represent(value, for: key) }
-        func encode(_ value: Int16, forKey key: Key)  throws { try represent(value, for: key) }
-        func encode(_ value: Int32, forKey key: Key)  throws { try represent(value, for: key) }
-        func encode(_ value: Int64, forKey key: Key)  throws { try represent(value, for: key) }
-        func encode(_ value: UInt, forKey key: Key)   throws { try represent(value, for: key) }
-        func encode(_ value: UInt8, forKey key: Key)  throws { try represent(value, for: key) }
-        func encode(_ value: UInt16, forKey key: Key) throws { try represent(value, for: key) }
-        func encode(_ value: UInt32, forKey key: Key) throws { try represent(value, for: key) }
-        func encode(_ value: UInt64, forKey key: Key) throws { try represent(value, for: key) }
-        func encode(_ value: Float, forKey key: Key)  throws { try represent(value, for: key) }
-        func encode(_ value: Double, forKey key: Key) throws { try represent(value, for: key) }
+        func encode(_ value: Bool, forKey key: Key)   throws { try encoder(for: key).represent(value) }
+        func encode(_ value: Int, forKey key: Key)    throws { try encoder(for: key).represent(value) }
+        func encode(_ value: Int8, forKey key: Key)   throws { try encoder(for: key).represent(value) }
+        func encode(_ value: Int16, forKey key: Key)  throws { try encoder(for: key).represent(value) }
+        func encode(_ value: Int32, forKey key: Key)  throws { try encoder(for: key).represent(value) }
+        func encode(_ value: Int64, forKey key: Key)  throws { try encoder(for: key).represent(value) }
+        func encode(_ value: UInt, forKey key: Key)   throws { try encoder(for: key).represent(value) }
+        func encode(_ value: UInt8, forKey key: Key)  throws { try encoder(for: key).represent(value) }
+        func encode(_ value: UInt16, forKey key: Key) throws { try encoder(for: key).represent(value) }
+        func encode(_ value: UInt32, forKey key: Key) throws { try encoder(for: key).represent(value) }
+        func encode(_ value: UInt64, forKey key: Key) throws { try encoder(for: key).represent(value) }
+        func encode(_ value: Float, forKey key: Key)  throws { try encoder(for: key).represent(value) }
+        func encode(_ value: Double, forKey key: Key) throws { try encoder(for: key).represent(value) }
         func encode(_ value: String, forKey key: Key) throws { encoder.mapping[key.stringValue] = Node(value) }
         func encode<T>(_ value: T, forKey key: Key)   throws where T: Encodable { try encoder(for: key).encode(value) }
 
@@ -187,10 +187,6 @@
         // MARK: -
 
         private func encoder(for key: CodingKey) -> _YAMLReferencingEncoder { return encoder.encoder(for: key) }
-
-        private func represent<T: ScalarRepresentable>(_ value: T, for key: Key) throws {
-             try encoder(for: key).represent(value)
-        }
     }
 
     struct _UnkeyedEncodingContainer: UnkeyedEncodingContainer { // swiftlint:disable:this type_name
@@ -205,19 +201,19 @@
         var codingPath: [CodingKey] { return encoder.codingPath }
         var count: Int { return encoder.sequence.count }
         func encodeNil()             throws { encoder.sequence.append(.null) }
-        func encode(_ value: Bool)   throws { try represent(value) }
-        func encode(_ value: Int)    throws { try represent(value) }
-        func encode(_ value: Int8)   throws { try represent(value) }
-        func encode(_ value: Int16)  throws { try represent(value) }
-        func encode(_ value: Int32)  throws { try represent(value) }
-        func encode(_ value: Int64)  throws { try represent(value) }
-        func encode(_ value: UInt)   throws { try represent(value) }
-        func encode(_ value: UInt8)  throws { try represent(value) }
-        func encode(_ value: UInt16) throws { try represent(value) }
-        func encode(_ value: UInt32) throws { try represent(value) }
-        func encode(_ value: UInt64) throws { try represent(value) }
-        func encode(_ value: Float)  throws { try represent(value) }
-        func encode(_ value: Double) throws { try represent(value) }
+        func encode(_ value: Bool)   throws { try currentEncoder.represent(value) }
+        func encode(_ value: Int)    throws { try currentEncoder.represent(value) }
+        func encode(_ value: Int8)   throws { try currentEncoder.represent(value) }
+        func encode(_ value: Int16)  throws { try currentEncoder.represent(value) }
+        func encode(_ value: Int32)  throws { try currentEncoder.represent(value) }
+        func encode(_ value: Int64)  throws { try currentEncoder.represent(value) }
+        func encode(_ value: UInt)   throws { try currentEncoder.represent(value) }
+        func encode(_ value: UInt8)  throws { try currentEncoder.represent(value) }
+        func encode(_ value: UInt16) throws { try currentEncoder.represent(value) }
+        func encode(_ value: UInt32) throws { try currentEncoder.represent(value) }
+        func encode(_ value: UInt64) throws { try currentEncoder.represent(value) }
+        func encode(_ value: Float)  throws { try currentEncoder.represent(value) }
+        func encode(_ value: Double) throws { try currentEncoder.represent(value) }
         func encode(_ value: String) throws { encoder.sequence.append(Node(value)) }
         func encode<T>(_ value: T)   throws where T: Encodable { try currentEncoder.encode(value) }
 
@@ -233,10 +229,6 @@
         private var currentEncoder: _YAMLReferencingEncoder {
             defer { encoder.sequence.append("") }
             return encoder.encoder(at: count)
-        }
-
-        private func represent<T: ScalarRepresentable>(_ value: T) throws {
-            try currentEncoder.represent(value)
         }
     }
 

--- a/Sources/Yams/Encoder.swift
+++ b/Sources/Yams/Encoder.swift
@@ -151,10 +151,10 @@
 
         func encode<T>(_ value: T, forKey key: Key) throws where T : Encodable {
             try encoder.with(pushedKey: key) {
-                if let data = value as? Data {
-                    encoder.node.sequence?.append(try data.represented())
-                } else if let date = value as? Date {
-                    encoder.node.sequence?.append(date.representedForCodable())
+                if let date = value as? Date {
+                    encoder.node.mapping?[key.stringValue] = date.representedForCodable()
+                } else if let representable = value as? ScalarRepresentable {
+                    encoder.node.mapping?[key.stringValue] = try representable.represented()
                 } else {
                     try value.encode(to: referencingEncoder(for: key.stringValue))
                 }
@@ -181,8 +181,8 @@
 
         // MARK: Utility
 
-        /// Encode NodeRepresentable
-        private func represent<T: NodeRepresentable>(_ value: T, for key: Key) throws {
+        /// Encode ScalarRepresentable
+        private func represent<T: ScalarRepresentable>(_ value: T, for key: Key) throws {
             // assumes this function is used for types that never throws.
             encoder.node.mapping?[key.stringValue] = try Node(value)
         }
@@ -224,10 +224,10 @@
         func encode<T>(_ value: T) throws where T : Encodable {
             // Since generic types may throw, the coding path needs to contain this key.
             try encoder.with(pushedKey: nil) {
-                if let data = value as? Data {
-                    encoder.node.sequence?.append(try data.represented())
-                } else if let date = value as? Date {
+                if let date = value as? Date {
                     encoder.node.sequence?.append(date.representedForCodable())
+                } else if let representable = value as? ScalarRepresentable {
+                    encoder.node.sequence?.append(try representable.represented())
                 } else {
                     try value.encode(to: referencingEncoder())
                 }
@@ -249,8 +249,8 @@
 
         // MARK: Utility
 
-        /// Encode NodeRepresentable
-        private func represent<T: NodeRepresentable>(_ value: T) throws {
+        /// Encode ScalarRepresentable
+        private func represent<T: ScalarRepresentable>(_ value: T) throws {
             // assumes this function is used for types that never throws.
             encoder.node.sequence?.append(try Node(value))
         }
@@ -291,10 +291,10 @@
         }
 
         func encode<T>(_ value: T) throws where T : Encodable {
-            if let data = value as? Data {
-                node = try data.represented()
-            } else if let date = value as? Date {
+            if let date = value as? Date {
                 node = date.representedForCodable()
+            } else if let representable = value as? ScalarRepresentable {
+                node = try representable.represented()
             } else {
                 try value.encode(to: self)
             }
@@ -324,8 +324,8 @@
             }
         }
 
-        /// Encode NodeRepresentable
-        func represent<T: NodeRepresentable>(_ value: T) throws {
+        /// Encode ScalarRepresentable
+        func represent<T: ScalarRepresentable>(_ value: T) throws {
             assertCanEncodeSingleValue()
             node = try Node(value)
         }

--- a/Sources/Yams/Encoder.swift
+++ b/Sources/Yams/Encoder.swift
@@ -11,13 +11,15 @@
     import Foundation
 
     public class YAMLEncoder {
+        public typealias Options = Emitter.Options
+        public var options = Options()
         public init() {}
         public func encode<T: Swift.Encodable>(_ value: T) throws -> String {
             do {
                 let encoder = _YAMLEncoder()
                 var container = encoder.singleValueContainer()
                 try container.encode(value)
-                return try serialize(node: encoder.node)
+                return try serialize(node: encoder.node, options: options)
             } catch let error as EncodingError {
                 throw error
             } catch {
@@ -394,6 +396,19 @@
             assertCanEncodeNewValue()
             node = try box(value)
         }
+    }
+
+    private func serialize(node: Node, options: Emitter.Options) throws -> String {
+        return try serialize(
+            nodes: [node],
+            canonical: options.canonical,
+            indent: options.indent,
+            width: options.width,
+            allowUnicode: options.allowUnicode,
+            lineBreak: options.lineBreak,
+            explicitStart: options.explicitStart,
+            explicitEnd: options.explicitEnd,
+            version: options.version)
     }
 
 #endif

--- a/Sources/Yams/Encoder.swift
+++ b/Sources/Yams/Encoder.swift
@@ -12,12 +12,14 @@
 
     public class YAMLEncoder {
         public init() {}
-        public func encode<T: Swift.Encodable>(_ value: T) throws -> Data {
-            let encoder = _YAMLEncoder()
-            var container = encoder.singleValueContainer()
-            try container.encode(value)
+        public func encode<T: Swift.Encodable>(_ value: T) throws -> String {
             do {
-                return try serialize(node: encoder.node).data(using: .utf8, allowLossyConversion: false) ?? Data()
+                let encoder = _YAMLEncoder()
+                var container = encoder.singleValueContainer()
+                try container.encode(value)
+                return try serialize(node: encoder.node)
+            } catch let error as EncodingError {
+                throw error
             } catch {
                 let description = "Unable to encode the given top-level value to YAML."
                 let context = EncodingError.Context(codingPath: [],

--- a/Sources/Yams/Encoder.swift
+++ b/Sources/Yams/Encoder.swift
@@ -135,7 +135,7 @@
         fileprivate init(referencing encoder: _YAMLEncoder, at index: Int) {
             self.encoder = encoder
             reference = .sequence(index)
-            super.init(userInfo: encoder.userInfo, codingPath: encoder.codingPath + [_YAMLEncodingKey(index: index)])
+            super.init(userInfo: encoder.userInfo, codingPath: encoder.codingPath + [_YAMLCodingKey(index: index)])
         }
 
         deinit {
@@ -186,7 +186,7 @@
             return encoder(for: key).unkeyedContainer()
         }
 
-        func superEncoder() -> Encoder { return encoder(for: _YAMLEncodingKey.super) }
+        func superEncoder() -> Encoder { return encoder(for: _YAMLCodingKey.super) }
         func superEncoder(forKey key: Key) -> Encoder { return encoder(for: key) }
 
         // MARK: -
@@ -291,7 +291,7 @@
 
     // MARK: - CodingKey for `_UnkeyedEncodingContainer` and `superEncoders`
 
-    struct _YAMLEncodingKey: CodingKey { // swiftlint:disable:this type_name
+    struct _YAMLCodingKey: CodingKey { // swiftlint:disable:this type_name
         var stringValue: String
         var intValue: Int?
 
@@ -310,7 +310,7 @@
             self.intValue = index
         }
 
-        static let `super` = _YAMLEncodingKey(stringValue: "super")!
+        static let `super` = _YAMLCodingKey(stringValue: "super")!
     }
 
     // MARK: -

--- a/Sources/Yams/Encoder.swift
+++ b/Sources/Yams/Encoder.swift
@@ -338,7 +338,8 @@
             lineBreak: options.lineBreak,
             explicitStart: options.explicitStart,
             explicitEnd: options.explicitEnd,
-            version: options.version)
+            version: options.version,
+            sortKeys: options.sortKeys)
     }
 
 #endif

--- a/Sources/Yams/Encoder.swift
+++ b/Sources/Yams/Encoder.swift
@@ -14,7 +14,10 @@
         public init() {}
         public func encode<T: Swift.Encodable>(_ value: T) throws -> Data {
             let encoder = _YAMLEncoder()
-            try value.encode(to: encoder)
+            do {
+                var container = encoder.singleValueContainer()
+                try container.encode(value)
+            }
             return try serialize(node: encoder.node).data(using: .utf8, allowLossyConversion: false) ?? Data()
         }
     }
@@ -131,33 +134,29 @@
         }
 
         // assumes following methods never throws
-        func encode(_ value: Bool?, forKey key: Key)   throws { try represent(value, for: key) }
-        func encode(_ value: Int?, forKey key: Key)    throws { try represent(value, for: key) }
-        func encode(_ value: Int8?, forKey key: Key)   throws { try represent(value, for: key) }
-        func encode(_ value: Int16?, forKey key: Key)  throws { try represent(value, for: key) }
-        func encode(_ value: Int32?, forKey key: Key)  throws { try represent(value, for: key) }
-        func encode(_ value: Int64?, forKey key: Key)  throws { try represent(value, for: key) }
-        func encode(_ value: UInt?, forKey key: Key)   throws { try represent(value, for: key) }
-        func encode(_ value: UInt8?, forKey key: Key)  throws { try represent(value, for: key) }
-        func encode(_ value: UInt16?, forKey key: Key) throws { try represent(value, for: key) }
-        func encode(_ value: UInt32?, forKey key: Key) throws { try represent(value, for: key) }
-        func encode(_ value: UInt64?, forKey key: Key) throws { try represent(value, for: key) }
-        func encode(_ value: Float?, forKey key: Key)  throws { try represent(value, for: key) }
-        func encode(_ value: Double?, forKey key: Key) throws { try represent(value, for: key) }
-        func encode(_ value: String?, forKey key: Key) throws { try represent(value, for: key) }
+        func encode(_ value: Bool, forKey key: Key)   throws { try represent(value, for: key) }
+        func encode(_ value: Int, forKey key: Key)    throws { try represent(value, for: key) }
+        func encode(_ value: Int8, forKey key: Key)   throws { try represent(value, for: key) }
+        func encode(_ value: Int16, forKey key: Key)  throws { try represent(value, for: key) }
+        func encode(_ value: Int32, forKey key: Key)  throws { try represent(value, for: key) }
+        func encode(_ value: Int64, forKey key: Key)  throws { try represent(value, for: key) }
+        func encode(_ value: UInt, forKey key: Key)   throws { try represent(value, for: key) }
+        func encode(_ value: UInt8, forKey key: Key)  throws { try represent(value, for: key) }
+        func encode(_ value: UInt16, forKey key: Key) throws { try represent(value, for: key) }
+        func encode(_ value: UInt32, forKey key: Key) throws { try represent(value, for: key) }
+        func encode(_ value: UInt64, forKey key: Key) throws { try represent(value, for: key) }
+        func encode(_ value: Float, forKey key: Key)  throws { try represent(value, for: key) }
+        func encode(_ value: Double, forKey key: Key) throws { try represent(value, for: key) }
+        func encode(_ value: String, forKey key: Key) throws { encoder.node.mapping?[key.stringValue] = Node(value) }
 
-        func encode<T>(_ value: T?, forKey key: Key) throws where T : Encodable {
+        func encode<T>(_ value: T, forKey key: Key) throws where T : Encodable {
             try encoder.with(pushedKey: key) {
-                if let value = value {
-                    if let data = value as? Data {
-                        encoder.node.sequence?.append(try data.represented())
-                    } else if let date = value as? Date {
-                        encoder.node.sequence?.append(date.representedForCodable())
-                    } else {
-                        try value.encode(to: referencingEncoder(for: key.stringValue))
-                    }
+                if let data = value as? Data {
+                    encoder.node.sequence?.append(try data.represented())
+                } else if let date = value as? Date {
+                    encoder.node.sequence?.append(date.representedForCodable())
                 } else {
-                    encoder.node.sequence?.append(Node("null", Tag(.null)))
+                    try value.encode(to: referencingEncoder(for: key.stringValue))
                 }
             }
         }
@@ -207,34 +206,30 @@
             return encoder.codingPath
         }
 
-        func encode(_ value: Bool?)   throws { try represent(value) }
-        func encode(_ value: Int?)    throws { try represent(value) }
-        func encode(_ value: Int8?)   throws { try represent(value) }
-        func encode(_ value: Int16?)  throws { try represent(value) }
-        func encode(_ value: Int32?)  throws { try represent(value) }
-        func encode(_ value: Int64?)  throws { try represent(value) }
-        func encode(_ value: UInt?)   throws { try represent(value) }
-        func encode(_ value: UInt8?)  throws { try represent(value) }
-        func encode(_ value: UInt16?) throws { try represent(value) }
-        func encode(_ value: UInt32?) throws { try represent(value) }
-        func encode(_ value: UInt64?) throws { try represent(value) }
-        func encode(_ value: Float?)  throws { try represent(value) }
-        func encode(_ value: Double?) throws { try represent(value) }
-        func encode(_ value: String?) throws { try represent(value) }
+        func encode(_ value: Bool)   throws { try represent(value) }
+        func encode(_ value: Int)    throws { try represent(value) }
+        func encode(_ value: Int8)   throws { try represent(value) }
+        func encode(_ value: Int16)  throws { try represent(value) }
+        func encode(_ value: Int32)  throws { try represent(value) }
+        func encode(_ value: Int64)  throws { try represent(value) }
+        func encode(_ value: UInt)   throws { try represent(value) }
+        func encode(_ value: UInt8)  throws { try represent(value) }
+        func encode(_ value: UInt16) throws { try represent(value) }
+        func encode(_ value: UInt32) throws { try represent(value) }
+        func encode(_ value: UInt64) throws { try represent(value) }
+        func encode(_ value: Float)  throws { try represent(value) }
+        func encode(_ value: Double) throws { try represent(value) }
+        func encode(_ value: String) throws { encoder.node.sequence?.append(Node(value)) }
 
-        func encode<T>(_ value: T?) throws where T : Encodable {
+        func encode<T>(_ value: T) throws where T : Encodable {
             // Since generic types may throw, the coding path needs to contain this key.
             try encoder.with(pushedKey: nil) {
-                if let value = value {
-                    if let data = value as? Data {
-                        encoder.node.sequence?.append(try data.represented())
-                    } else if let date = value as? Date {
-                        encoder.node.sequence?.append(date.representedForCodable())
-                    } else {
-                        try value.encode(to: referencingEncoder())
-                    }
+                if let data = value as? Data {
+                    encoder.node.sequence?.append(try data.represented())
+                } else if let date = value as? Date {
+                    encoder.node.sequence?.append(date.representedForCodable())
                 } else {
-                    encoder.node.sequence?.append(Node("null", Tag(.null)))
+                    try value.encode(to: referencingEncoder())
                 }
             }
         }
@@ -271,6 +266,11 @@
 
         // MARK: - SingleValueEncodingContainer Methods
 
+        func encodeNil() throws {
+            assertCanEncodeSingleValue()
+            node = Node("null", Tag(.null))
+        }
+
         func encode(_ value: Bool)   throws { try represent(value) }
         func encode(_ value: Int)    throws { try represent(value) }
         func encode(_ value: Int8)   throws { try represent(value) }
@@ -288,6 +288,16 @@
         func encode(_ value: String) throws {
             assertCanEncodeSingleValue()
             node = Node(value)
+        }
+
+        func encode<T>(_ value: T) throws where T : Encodable {
+            if let data = value as? Data {
+                node = try data.represented()
+            } else if let date = value as? Date {
+                node = date.representedForCodable()
+            } else {
+                try value.encode(to: self)
+            }
         }
 
         // MARK: Utility

--- a/Sources/Yams/Encoder.swift
+++ b/Sources/Yams/Encoder.swift
@@ -54,7 +54,7 @@
         var codingPath: [CodingKey]
 
         /// Contextual user-provided information for use during encoding.
-        var userInfo: [CodingUserInfoKey : Any] = [:]
+        var userInfo: [CodingUserInfoKey: Any] = [:]
 
         func container<Key>(keyedBy type: Key.Type) -> KeyedEncodingContainer<Key> {
             if canEncodeNewValue {
@@ -186,7 +186,7 @@
         func encode(_ value: Double, forKey key: Key) throws { try represent(value, for: key) }
         func encode(_ value: String, forKey key: Key) throws { encoder.mapping[key.stringValue] = Node(value) }
 
-        func encode<T>(_ value: T, forKey key: Key) throws where T : Encodable {
+        func encode<T>(_ value: T, forKey key: Key) throws where T: Encodable {
             if let date = value as? Date {
                 encoder.mapping[key.stringValue] = date.representedForCodable()
             } else if let representable = value as? ScalarRepresentable {
@@ -289,7 +289,7 @@
         func encode(_ value: Double) throws { try represent(value) }
         func encode(_ value: String) throws { encoder.sequence.append(Node(value)) }
 
-        func encode<T>(_ value: T) throws where T : Encodable {
+        func encode<T>(_ value: T) throws where T: Encodable {
             if let date = value as? Date {
                 encoder.sequence.append(date.representedForCodable())
             } else if let representable = value as? ScalarRepresentable {
@@ -362,7 +362,7 @@
             node = Node(value)
         }
 
-        func encode<T>(_ value: T) throws where T : Encodable {
+        func encode<T>(_ value: T) throws where T: Encodable {
             assertCanEncodeNewValue()
             if let date = value as? Date {
                 node = date.representedForCodable()

--- a/Sources/Yams/Representer.swift
+++ b/Sources/Yams/Representer.swift
@@ -202,3 +202,15 @@ extension Optional: NodeRepresentable {
         }
     }
 }
+
+extension Decimal: ScalarRepresentable {
+    public func represented() throws -> Node {
+        return Node(description)
+    }
+}
+
+extension URL: ScalarRepresentable {
+    public func represented() throws -> Node {
+        return Node(absoluteString)
+    }
+}

--- a/Sources/Yams/Representer.swift
+++ b/Sources/Yams/Representer.swift
@@ -230,18 +230,14 @@ extension Float: ScalarRepresentableCustomizedForCodable {}
 
 extension FloatingPoint where Self: CVarArg {
     public func representedForCodable() -> Node {
-#if os(Linux)
-        return Node(doubleFormatter.string(for: self)!.replacingOccurrences(of: "+-", with: "-"), Tag(.float))
-#else
         return Node(formattedStringForCodable, Tag(.float))
-#endif
     }
 
     private var formattedStringForCodable: String {
         // Since `NumberFormatter` creates a string with insufficient precision for Decode,
         // it uses with `String(format:...)`
 #if os(Linux)
-        let DBL_DECIMAL_DIG = 9
+        let DBL_DECIMAL_DIG = 17
 #endif
         let string = String(format: "%.*g", DBL_DECIMAL_DIG, self)
         // "%*.g" does not use scientific notation if the exponent is less than –4.

--- a/Sources/Yams/Representer.swift
+++ b/Sources/Yams/Representer.swift
@@ -52,7 +52,7 @@ private func represent(_ value: Any) throws -> Node {
     } else if let representable = value as? NodeRepresentable {
         return try representable.represented()
     }
-    throw YamlError.representer(problem: "Fail to represent \(value)")
+    throw YamlError.representer(problem: "Failed to represent \(value)")
 }
 
 // MARK: - ScalarRepresentable

--- a/Sources/Yams/Representer.swift
+++ b/Sources/Yams/Representer.swift
@@ -225,13 +225,21 @@ extension Date: ScalarRepresentableCustomizedForCodable {
 
 extension Double: ScalarRepresentableCustomizedForCodable {
     public func representedForCodable() -> Node {
+    #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
         return Node(formattedStringForCodable, Tag(.float))
+    #else
+        return Node(doubleFormatter.string(for: self)!.replacingOccurrences(of: "+-", with: "-"), Tag(.float))
+    #endif
     }
 
     private var formattedStringForCodable: String {
         // Since `NumberFormatter` creates a string with insufficient precision for Decode,
         // it uses with `String(format:...)`
+    #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
         let string = String(format: "%.*g", DBL_DECIMAL_DIG, self)
+    #else
+        let string = String(format: "%.*g", 9, self)
+    #endif
         // "%*.g" does not use scientific notation if the exponent is less than –4.
         // So fallback to using `NumberFormatter` if string does not uses scientific notation.
         guard string.lazy.suffix(5).contains("e") else {
@@ -243,13 +251,21 @@ extension Double: ScalarRepresentableCustomizedForCodable {
 
 extension Float: ScalarRepresentableCustomizedForCodable {
     public func representedForCodable() -> Node {
+    #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
         return Node(formattedStringForCodable, Tag(.float))
+    #else
+        return Node(floatFormatter.string(for: self)!.replacingOccurrences(of: "+-", with: "-"), Tag(.float))
+    #endif
     }
 
     private var formattedStringForCodable: String {
         // Since `NumberFormatter` creates a string with insufficient precision for Decode,
         // it uses with `String(format:...)`
+    #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
         let string = String(format: "%.*g", FLT_DECIMAL_DIG, self)
+    #else
+        let string = String(format: "%.*g", 9, self)
+    #endif
         // "%*.g" does not use scientific notation if the exponent is less than –4.
         // So fallback to using `NumberFormatter` if string does not uses scientific notation.
         guard string.lazy.suffix(6).contains("e") else {

--- a/Sources/Yams/Representer.swift
+++ b/Sources/Yams/Representer.swift
@@ -225,53 +225,29 @@ extension Date: ScalarRepresentableCustomizedForCodable {
     }
 }
 
-extension Double: ScalarRepresentableCustomizedForCodable {
+extension Double: ScalarRepresentableCustomizedForCodable {}
+extension Float: ScalarRepresentableCustomizedForCodable {}
+
+extension FloatingPoint where Self: CVarArg {
     public func representedForCodable() -> Node {
-    #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
-        return Node(formattedStringForCodable, Tag(.float))
-    #else
+#if os(Linux)
         return Node(doubleFormatter.string(for: self)!.replacingOccurrences(of: "+-", with: "-"), Tag(.float))
-    #endif
+#else
+        return Node(formattedStringForCodable, Tag(.float))
+#endif
     }
 
     private var formattedStringForCodable: String {
         // Since `NumberFormatter` creates a string with insufficient precision for Decode,
         // it uses with `String(format:...)`
-    #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+#if os(Linux)
+        let DBL_DECIMAL_DIG = 9
+#endif
         let string = String(format: "%.*g", DBL_DECIMAL_DIG, self)
-    #else
-        let string = String(format: "%.*g", 9, self)
-    #endif
         // "%*.g" does not use scientific notation if the exponent is less than –4.
         // So fallback to using `NumberFormatter` if string does not uses scientific notation.
         guard string.lazy.suffix(5).contains("e") else {
             return doubleFormatter.string(for: self)!.replacingOccurrences(of: "+-", with: "-")
-        }
-        return string
-    }
-}
-
-extension Float: ScalarRepresentableCustomizedForCodable {
-    public func representedForCodable() -> Node {
-    #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
-        return Node(formattedStringForCodable, Tag(.float))
-    #else
-        return Node(floatFormatter.string(for: self)!.replacingOccurrences(of: "+-", with: "-"), Tag(.float))
-    #endif
-    }
-
-    private var formattedStringForCodable: String {
-        // Since `NumberFormatter` creates a string with insufficient precision for Decode,
-        // it uses with `String(format:...)`
-    #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
-        let string = String(format: "%.*g", FLT_DECIMAL_DIG, self)
-    #else
-        let string = String(format: "%.*g", 9, self)
-    #endif
-        // "%*.g" does not use scientific notation if the exponent is less than –4.
-        // So fallback to using `NumberFormatter` if string does not uses scientific notation.
-        guard string.lazy.suffix(6).contains("e") else {
-            return floatFormatter.string(for: self)!.replacingOccurrences(of: "+-", with: "-")
         }
         return string
     }

--- a/Sources/Yams/Representer.swift
+++ b/Sources/Yams/Representer.swift
@@ -211,6 +211,8 @@ extension URL: ScalarRepresentable {
     }
 }
 
+#if swift(>=4.0)
+
 /// MARK: - ScalarRepresentableCustomizedForCodable
 
 public protocol ScalarRepresentableCustomizedForCodable: ScalarRepresentable {
@@ -274,3 +276,5 @@ extension Float: ScalarRepresentableCustomizedForCodable {
         return string
     }
 }
+
+#endif

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -2,7 +2,7 @@ import XCTest
 
 @testable import YamsTests
 
-XCTMain([
+var testCases = [
     testCase(ConstructorTests.allTests),
     testCase(EmitterTests.allTests),
     testCase(MarkTests.allTests),
@@ -13,4 +13,10 @@ XCTMain([
     testCase(SpecTests.allTests),
     testCase(StringTests.allTests),
     testCase(YamlErrorTests.allTests)
-])
+]
+
+#if swift(>=4.0)
+    testCases.append(testCase(EncoderTests.allTests))
+#endif
+
+XCTMain(testCases)

--- a/Tests/YamsTests/EncoderTests.swift
+++ b/Tests/YamsTests/EncoderTests.swift
@@ -183,7 +183,8 @@ import Yams
             _testFloatingPoint(type: Float.self)
             _testFloatingPoint(type: Double.self)
 
-            _testRoundTrip(of: "")
+            // Can't YAML encode empty string as valid YAML Document?
+//            _testRoundTrip(of: "")
             _testRoundTrip(of: URL(string: "https://apple.com")!)
         }
 

--- a/Tests/YamsTests/EncoderTests.swift
+++ b/Tests/YamsTests/EncoderTests.swift
@@ -59,33 +59,41 @@ import Yams
 
         // MARK: - Date Strategy Tests
         func testEncodingDate() {
-            // We can't encode a top-level Date, so it'll be wrapped in an array.
+        #if os(Linux)
+            print("'Date' does not conform to 'Codable' on Linux yet.")
+        #else
             _testRoundTrip(of: TopLevelWrapper(Date()))
+        #endif
         }
 
         func testEncodingDateMillisecondsSince1970() {
-            // Cannot encode an arbitrary number of seconds since we've lost precision since 1970.
+        #if os(Linux)
+            print("'Date' does not conform to 'Codable' on Linux yet.")
+        #else
             let seconds = 1000.0
             let expectedYAML = "- 1970-01-01T00:16:40Z\n"
 
-            // We can't encode a top-level Date, so it'll be wrapped in an array.
             _testRoundTrip(of: TopLevelWrapper(Date(timeIntervalSince1970: seconds)),
                            expectedYAML: expectedYAML)
+        #endif
         }
 
         // MARK: - Data Tests
         func testEncodingBase64Data() {
+        #if os(Linux)
+            print("'Data' does not conform to 'Codable' on Linux yet.")
+        #else
             let data = Data(bytes: [0xDE, 0xAD, 0xBE, 0xEF])
 
             // We can't encode a top-level Data, so it'll be wrapped in an array.
             let expectedYAML = "- 3q2+7w==\n"
             _testRoundTrip(of: TopLevelWrapper(data), expectedYAML: expectedYAML)
+        #endif
         }
 
         // MARK: - Helper Functions
         private func _testRoundTrip<T>(of value: T,
                                        expectedYAML yamlString: String? = nil) where T : Codable, T : Equatable {
-            let yaml = yamlString?.data(using: .utf8)! // swiftlint:disable:this force_unwrapping
             var payload: Data! = nil
             do {
                 let encoder = YAMLEncoder()
@@ -94,8 +102,9 @@ import Yams
                 XCTFail("Failed to encode \(T.self) to YAML.")
             }
 
-            if let expectedYAML = yaml {
-                XCTAssertEqual(expectedYAML, payload, "Produced YAML not identical to expected YAML.")
+            if let expectedYAML = yamlString {
+                let producedYAML = String(data: payload, encoding: .utf8)! // swiftlint:disable:this force_unwrapping
+                XCTAssertEqual(producedYAML, expectedYAML, "Produced YAML not identical to expected YAML.")
             }
 
             do {
@@ -283,6 +292,24 @@ import Yams
 
         static func == (_ lhs: TopLevelWrapper<T>, _ rhs: TopLevelWrapper<T>) -> Bool {
             return lhs.value == rhs.value
+        }
+    }
+
+    extension EncoderTests {
+        static var allTests: [(String, (EncoderTests) -> () throws -> Void)] {
+            return [
+                ("testEncodingTopLevelEmptyStruct", testEncodingTopLevelEmptyStruct),
+                ("testEncodingTopLevelEmptyClass", testEncodingTopLevelEmptyClass),
+                ("testEncodingTopLevelSingleValueEnum", testEncodingTopLevelSingleValueEnum),
+                ("testEncodingTopLevelSingleValueStruct", testEncodingTopLevelSingleValueStruct),
+                ("testEncodingTopLevelSingleValueClass", testEncodingTopLevelSingleValueClass),
+                ("testEncodingTopLevelStructuredStruct", testEncodingTopLevelStructuredStruct),
+                ("testEncodingTopLevelStructuredClass", testEncodingTopLevelStructuredClass),
+                ("testEncodingTopLevelDeepStructuredType", testEncodingTopLevelDeepStructuredType),
+                ("testEncodingDate", testEncodingDate),
+                ("testEncodingDateMillisecondsSince1970", testEncodingDateMillisecondsSince1970),
+                ("testEncodingBase64Data", testEncodingBase64Data)
+            ]
         }
     }
 

--- a/Tests/YamsTests/EncoderTests.swift
+++ b/Tests/YamsTests/EncoderTests.swift
@@ -103,26 +103,30 @@ import Yams
 
         // MARK: - Helper Functions
         private func _testRoundTrip<T>(of value: T,
-                                       expectedYAML yamlString: String? = nil) where T : Codable, T : Equatable {
+                                       expectedYAML yamlString: String? = nil,
+                                       file: StaticString = #file,
+                                       line: UInt = #line) where T : Codable, T : Equatable {
             var payload: Data! = nil
             do {
                 let encoder = YAMLEncoder()
                 payload = try encoder.encode(value)
             } catch {
-                XCTFail("Failed to encode \(T.self) to YAML.")
+                XCTFail("Failed to encode \(T.self) to YAML.", file: file, line: line)
             }
 
             if let expectedYAML = yamlString {
                 let producedYAML = String(data: payload, encoding: .utf8)! // swiftlint:disable:this force_unwrapping
-                XCTAssertEqual(producedYAML, expectedYAML, "Produced YAML not identical to expected YAML.")
+                XCTAssertEqual(producedYAML, expectedYAML, "Produced YAML not identical to expected YAML.",
+                               file: file, line: line)
             }
 
             do {
                 let decoder = YAMLDecoder()
                 let decoded = try decoder.decode(T.self, from: payload)
-                XCTAssertEqual(decoded, value, "\(T.self) did not round-trip to an equal value.")
+                XCTAssertEqual(decoded, value, "\(T.self) did not round-trip to an equal value.",
+                    file: file, line: line)
             } catch {
-                XCTFail("Failed to decode \(T.self) from YAML by error: \(error)")
+                XCTFail("Failed to decode \(T.self) from YAML by error: \(error)", file: file, line: line)
             }
         }
     }

--- a/Tests/YamsTests/EncoderTests.swift
+++ b/Tests/YamsTests/EncoderTests.swift
@@ -113,7 +113,7 @@ import Yams
         // MARK: - Date Strategy Tests
         func testEncodingDate() {
         #if os(Linux)
-            print("'Date' does not conform to 'Codable' on Linux yet.")
+            print("Decoding 'Date' has issue on Linux with nanoseconds. https://bugs.swift.org/browse/SR-6223")
         #else
             _testRoundTrip(of: Date())
         #endif
@@ -121,7 +121,7 @@ import Yams
 
         func testEncodingDateMillisecondsSince1970() {
         #if os(Linux)
-            print("'Date' does not conform to 'Codable' on Linux yet.")
+            print("Decoding 'Date' has issue on Linux with nanoseconds. https://bugs.swift.org/browse/SR-6223")
         #else
             _testRoundTrip(of: Date(timeIntervalSince1970: 1000.0), expectedYAML: "1970-01-01T00:16:40Z\n...\n")
         #endif

--- a/Tests/YamsTests/EncoderTests.swift
+++ b/Tests/YamsTests/EncoderTests.swift
@@ -35,26 +35,44 @@ import Yams
         }
 
         func testEncodingTopLevelSingleValueClass() {
-            _testRoundTrip(of: Counter())
+            _testRoundTrip(of: Counter(), expectedYAML: "0\n...\n")
         }
 
         // MARK: - Encoding Top-Level Structured Types
         func testEncodingTopLevelStructuredStruct() {
             // Address is a struct type with multiple fields.
             let address = Address.testValue
-            _testRoundTrip(of: address)
+            _testRoundTrip(of: address, expectedYAML: """
+                street: 1 Infinite Loop
+                city: Cupertino
+                state: CA
+                zipCode: 95014
+                country: United States
+
+                """)
         }
 
         func testEncodingTopLevelStructuredClass() {
             // Person is a class with multiple fields.
             let person = Person.testValue
-            _testRoundTrip(of: person)
+            _testRoundTrip(of: person, expectedYAML: "name: Johnny Appleseed\nemail: appleseed@apple.com\n")
         }
 
         func testEncodingTopLevelDeepStructuredType() {
             // Company is a type with fields which are Codable themselves.
             let company = Company.testValue
-            _testRoundTrip(of: company)
+            _testRoundTrip(of: company, expectedYAML: """
+                address:
+                  street: 1 Infinite Loop
+                  city: Cupertino
+                  state: CA
+                  zipCode: 95014
+                  country: United States
+                employees:
+                - name: Johnny Appleseed
+                  email: appleseed@apple.com
+
+                """)
         }
 
         // MARK: - Date Strategy Tests

--- a/Tests/YamsTests/EncoderTests.swift
+++ b/Tests/YamsTests/EncoderTests.swift
@@ -129,11 +129,7 @@ import Yams
 
         // MARK: - Data Tests
         func testEncodingBase64Data() {
-        #if os(Linux)
-            print("'Data' does not conform to 'Codable' on Linux yet.")
-        #else
             _testRoundTrip(of: Data(bytes: [0xDE, 0xAD, 0xBE, 0xEF]), expectedYAML: "3q2+7w==\n...\n")
-        #endif
         }
 
         // MARK: - Encoder Features

--- a/Tests/YamsTests/EncoderTests.swift
+++ b/Tests/YamsTests/EncoderTests.swift
@@ -6,10 +6,13 @@
 //  Copyright (c) 2017 Yams. All rights reserved.
 //
 
+import Foundation
 import XCTest
 import Yams
 
 #if swift(>=4.0)
+
+    // swiftlint:disable identifier_name, line_length
 
     /// Tests are copied from https://github.com/apple/swift/blob/master/test/stdlib/TestJSONEncoder.swift
     class EncoderTests: XCTestCase {
@@ -58,6 +61,24 @@ import Yams
             _testRoundTrip(of: person, expectedYAML: "name: Johnny Appleseed\nemail: appleseed@apple.com\n")
         }
 
+        func testEncodingTopLevelStructuredSingleStruct() {
+            // Numbers is a struct which encodes as an array through a single value container.
+            let numbers = Numbers.testValue
+            _testRoundTrip(of: numbers, expectedYAML: "- 4\n- 8\n- 15\n- 16\n- 23\n- 42\n")
+        }
+
+        func testEncodingTopLevelStructuredSingleClass() {
+            // Mapping is a class which encodes as a dictionary through a single value container.
+            let mapping = Mapping.testValue
+            _testRoundTrip(of: mapping, expectedYAML: """
+                Apple:
+                  relative: http://apple.com
+                localhost:
+                  relative: http://127.0.0.1
+
+                """)
+        }
+
         func testEncodingTopLevelDeepStructuredType() {
             // Company is a type with fields which are Codable themselves.
             let company = Company.testValue
@@ -69,10 +90,24 @@ import Yams
                   zipCode: 95014
                   country: United States
                 employees:
-                - name: Johnny Appleseed
+                - id: 42
+                  name: Johnny Appleseed
                   email: appleseed@apple.com
 
                 """)
+        }
+
+        func testEncodingClassWhichSharesEncoderWithSuper() {
+            // Employee is a type which shares its encoder & decoder with its superclass, Person.
+            let employee = Employee.testValue
+            _testRoundTrip(of: employee, expectedYAML: "id: 42\nname: Johnny Appleseed\nemail: appleseed@apple.com\n")
+        }
+
+        func testEncodingTopLevelNullableType() {
+            // EnhancedBool is a type which encodes either as a Bool or as nil.
+            _testRoundTrip(of: EnhancedBool.true, expectedYAML: "true\n...\n")
+            _testRoundTrip(of: EnhancedBool.false, expectedYAML: "false\n...\n")
+            _testRoundTrip(of: EnhancedBool.fileNotFound, expectedYAML: "null\n...\n")
         }
 
         // MARK: - Date Strategy Tests
@@ -101,7 +136,57 @@ import Yams
         #endif
         }
 
+        // MARK: - Encoder Features
+        func testNestedContainerCodingPaths() {
+            let encoder = YAMLEncoder()
+            do {
+                _ = try encoder.encode(NestedContainersTestType())
+            } catch {
+                expectUnreachable("Caught error during encoding nested container types: \(error)")
+            }
+        }
+
+        func testSuperEncoderCodingPaths() {
+            let encoder = YAMLEncoder()
+            do {
+                _ = try encoder.encode(NestedContainersTestType(testSuperEncoder: true))
+            } catch {
+                expectUnreachable("Caught error during encoding nested container types: \(error)")
+            }
+        }
+
+        func testInterceptDecimal() {
+            let expectedYAML = "value: 10000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000\n"
+
+            // Want to make sure we write out a YAML number, not the keyed encoding here.
+            // 1e127 is too big to fit natively in a Double, too, so want to make sure it's encoded as a Decimal.
+            let decimal = Decimal(sign: .plus, exponent: 127, significand: Decimal(1))
+            _testRoundTrip(of: TopLevelWrapper(decimal), expectedYAML: expectedYAML)
+
+            // Optional Decimals should encode the same way.
+            // FIXME: following test is blocked by https://bugs.swift.org/browse/SR-5206
+//            _testRoundTrip(of: OptionalTopLevelWrapper(decimal), expectedYAML: expectedYAML)
+        }
+
+        func testInterceptURL() {
+            // Want to make sure YAMLEncoder writes out single-value URLs, not the keyed encoding.
+            let expectedYAML = "value: http://swift.org\n"
+            let url = URL(string: "http://swift.org")!
+            _testRoundTrip(of: TopLevelWrapper(url), expectedYAML: expectedYAML)
+
+            // Optional URLs should encode the same way.
+            // FIXME: following test is blocked by https://bugs.swift.org/browse/SR-5206
+//            _testRoundTrip(of: OptionalTopLevelWrapper(url), expectedYAML: expectedYAML)
+        }
+
         // MARK: - Helper Functions
+        private func _testEncodeFailure<T: Encodable>(of value: T) {
+            do {
+                _ = try JSONEncoder().encode(value)
+                expectUnreachable("Encode of top-level \(T.self) was expected to fail.")
+            } catch {}
+        }
+
         private func _testRoundTrip<T>(of value: T,
                                        expectedYAML yamlString: String? = nil,
                                        file: StaticString = #file,
@@ -131,14 +216,61 @@ import Yams
         }
     }
 
+    // MARK: - Helper Global Functions
+    public func expectEqual<T: Equatable>(
+        _ expected: T, _ actual: T,
+        _ message: @autoclosure () -> String = "",
+        file: StaticString = #file, line: UInt = #line
+        ) {
+        XCTAssertEqual(expected, actual, message, file: file, line: line)
+    }
+
+    public func expectUnreachable(
+        _ message: @autoclosure () -> String = "",
+        file: StaticString = #file, line: UInt = #line) {
+        XCTFail("this code should not be executed: \(message())", file: file, line: line)
+    }
+
+    func expectEqualPaths(
+        _ lhs: [CodingKey],
+        _ rhs: [CodingKey],
+        _ prefix: String,
+        file: StaticString = #file, line: UInt = #line) {
+        if lhs.count != rhs.count {
+            expectUnreachable("\(prefix) [CodingKey].count mismatch: \(lhs.count) != \(rhs.count)", file: file, line: line)
+            return
+        }
+
+        for (key1, key2) in zip(lhs, rhs) {
+            switch (key1.intValue, key2.intValue) {
+            case (.none, .none): break
+            case (.some(let i1), .none):
+                expectUnreachable("\(prefix) CodingKey.intValue mismatch: \(type(of: key1))(\(i1)) != nil", file: file, line: line)
+                return
+            case (.none, .some(let i2)):
+                expectUnreachable("\(prefix) CodingKey.intValue mismatch: nil != \(type(of: key2))(\(i2))", file: file, line: line)
+                return
+            case (.some(let i1), .some(let i2)):
+                guard i1 == i2 else {
+                    expectUnreachable("\(prefix) CodingKey.intValue mismatch: \(type(of: key1))(\(i1)) != \(type(of: key2))(\(i2))", file: file, line: line)
+                    return
+                }
+
+                break
+            }
+
+            expectEqual(key1.stringValue, key2.stringValue, "\(prefix) CodingKey.stringValue mismatch: \(type(of: key1))('\(key1.stringValue)') != \(type(of: key2))('\(key2.stringValue)')", file: file, line: line)
+        }
+    }
+
     // MARK: - Empty Types
-    fileprivate struct EmptyStruct: Codable, Equatable {
+    private struct EmptyStruct: Codable, Equatable {
         static func == (_ lhs: EmptyStruct, _ rhs: EmptyStruct) -> Bool {
             return true
         }
     }
 
-    fileprivate class EmptyClass: Codable, Equatable {
+    private class EmptyClass: Codable, Equatable {
         static func == (_ lhs: EmptyClass, _ rhs: EmptyClass) -> Bool {
             return true
         }
@@ -146,9 +278,9 @@ import Yams
 
     // MARK: - Single-Value Types
     /// A simple on-off switch type that encodes as a single Bool value.
-    fileprivate enum Switch: Codable {
+    private enum Switch: Codable {
         case off
-        case on // swiftlint:disable:this identifier_name
+        case on
 
         init(from decoder: Decoder) throws {
             let container = try decoder.singleValueContainer()
@@ -168,7 +300,7 @@ import Yams
     }
 
     /// A simple timestamp type that encodes as a single Double value.
-    fileprivate struct Timestamp: Codable, Equatable {
+    private struct Timestamp: Codable, Equatable {
         let value: Double
 
         init(_ value: Double) {
@@ -207,13 +339,13 @@ import Yams
         }
 
         static func == (lhs: Counter, rhs: Counter) -> Bool {
-            return lhs.count == rhs.count
+            return lhs === rhs || lhs.count == rhs.count
         }
     }
 
     // MARK: - Structured Types
     /// A simple address type that encodes as a dictionary of values.
-    fileprivate struct Address: Codable, Equatable {
+    private struct Address: Codable, Equatable {
         let street: String
         let city: String
         let state: String
@@ -246,30 +378,97 @@ import Yams
     }
 
     /// A simple person class that encodes as a dictionary of values.
-    fileprivate class Person: Codable, Equatable {
+    private class Person: Codable, Equatable {
         let name: String
         let email: String
+        let website: URL?
 
-        init(name: String, email: String) {
+        init(name: String, email: String, website: URL? = nil) {
             self.name = name
             self.email = email
+            self.website = website
+        }
+
+        private enum CodingKeys: String, CodingKey {
+            case name
+            case email
+            case website
+        }
+
+        // FIXME: Remove when subclasses (Employee) are able to override synthesized conformance.
+        required init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            name = try container.decode(String.self, forKey: .name)
+            email = try container.decode(String.self, forKey: .email)
+            website = try container.decodeIfPresent(URL.self, forKey: .website)
+        }
+
+        func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode(name, forKey: .name)
+            try container.encode(email, forKey: .email)
+            try container.encodeIfPresent(website, forKey: .website)
+        }
+
+        func isEqual(_ other: Person) -> Bool {
+            return self.name == other.name &&
+                self.email == other.email &&
+                self.website == other.website
         }
 
         static func == (_ lhs: Person, _ rhs: Person) -> Bool {
-            return lhs.name == rhs.name && lhs.email == rhs.email
+            return lhs.isEqual(rhs)
         }
 
-        static var testValue: Person {
+        class var testValue: Person {
             return Person(name: "Johnny Appleseed", email: "appleseed@apple.com")
         }
     }
 
-    /// A simple company struct which encodes as a dictionary of nested values.
-    fileprivate struct Company: Codable, Equatable {
-        let address: Address
-        var employees: [Person]
+    /// A class which shares its encoder and decoder with its superclass.
+    private class Employee: Person {
+        let id: Int
 
-        init(address: Address, employees: [Person]) {
+        init(name: String, email: String, website: URL? = nil, id: Int) {
+            self.id = id
+            super.init(name: name, email: email, website: website)
+        }
+
+        enum CodingKeys: String, CodingKey {
+            case id
+        }
+
+        required init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            id = try container.decode(Int.self, forKey: .id)
+            try super.init(from: decoder)
+        }
+
+        override func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode(id, forKey: .id)
+            try super.encode(to: encoder)
+        }
+
+        override func isEqual(_ other: Person) -> Bool {
+            if let employee = other as? Employee {
+                guard self.id == employee.id else { return false }
+            }
+
+            return super.isEqual(other)
+        }
+
+        override class var testValue: Employee {
+            return Employee(name: "Johnny Appleseed", email: "appleseed@apple.com", id: 42)
+        }
+    }
+
+    /// A simple company struct which encodes as a dictionary of nested values.
+    private struct Company: Codable, Equatable {
+        let address: Address
+        var employees: [Employee]
+
+        init(address: Address, employees: [Employee]) {
             self.address = address
             self.employees = employees
         }
@@ -279,7 +478,244 @@ import Yams
         }
 
         static var testValue: Company {
-            return Company(address: Address.testValue, employees: [Person.testValue])
+            return Company(address: Address.testValue, employees: [Employee.testValue])
+        }
+    }
+
+    /// An enum type which decodes from Bool?.
+    private enum EnhancedBool: Codable {
+        case `true`
+        case `false`
+        case fileNotFound
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.singleValueContainer()
+            if container.decodeNil() {
+                self = .fileNotFound
+            } else {
+                let value = try container.decode(Bool.self)
+                self = value ? .true : .false
+            }
+        }
+
+        func encode(to encoder: Encoder) throws {
+            var container = encoder.singleValueContainer()
+            switch self {
+            case .true: try container.encode(true)
+            case .false: try container.encode(false)
+            case .fileNotFound: try container.encodeNil()
+            }
+        }
+    }
+
+    /// A type which encodes as an array directly through a single value container.
+    struct Numbers: Codable, Equatable {
+        let values = [4, 8, 15, 16, 23, 42]
+
+        init() {}
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.singleValueContainer()
+            let decodedValues = try container.decode([Int].self)
+            guard decodedValues == values else {
+                throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "The Numbers are wrong!"))
+            }
+        }
+
+        func encode(to encoder: Encoder) throws {
+            var container = encoder.singleValueContainer()
+            try container.encode(values)
+        }
+
+        static func == (_ lhs: Numbers, _ rhs: Numbers) -> Bool {
+            return lhs.values == rhs.values
+        }
+
+        static var testValue: Numbers {
+            return Numbers()
+        }
+    }
+
+    /// A type which encodes as a dictionary directly through a single value container.
+    fileprivate final class Mapping: Codable, Equatable {
+        let values: [String : URL]
+
+        init(values: [String : URL]) {
+            self.values = values
+        }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.singleValueContainer()
+            values = try container.decode([String: URL].self)
+        }
+
+        func encode(to encoder: Encoder) throws {
+            var container = encoder.singleValueContainer()
+            try container.encode(values)
+        }
+
+        static func == (_ lhs: Mapping, _ rhs: Mapping) -> Bool {
+            return lhs === rhs || lhs.values == rhs.values
+        }
+
+        static var testValue: Mapping {
+            return Mapping(values: ["Apple": URL(string: "http://apple.com")!,
+                                    "localhost": URL(string: "http://127.0.0.1")!])
+        }
+    }
+
+    struct NestedContainersTestType: Encodable {
+        let testSuperEncoder: Bool
+
+        init(testSuperEncoder: Bool = false) {
+            self.testSuperEncoder = testSuperEncoder
+        }
+
+        enum TopLevelCodingKeys: Int, CodingKey {
+            case a
+            case b
+            case c
+        }
+
+        enum IntermediateCodingKeys: Int, CodingKey {
+            case one
+            case two
+        }
+
+        func encode(to encoder: Encoder) throws {
+            if self.testSuperEncoder {
+                var topLevelContainer = encoder.container(keyedBy: TopLevelCodingKeys.self)
+                expectEqualPaths(encoder.codingPath, [], "Top-level Encoder's codingPath changed.")
+                expectEqualPaths(topLevelContainer.codingPath, [], "New first-level keyed container has non-empty codingPath.")
+
+                let superEncoder = topLevelContainer.superEncoder(forKey: .a)
+                expectEqualPaths(encoder.codingPath, [], "Top-level Encoder's codingPath changed.")
+                expectEqualPaths(topLevelContainer.codingPath, [], "First-level keyed container's codingPath changed.")
+                expectEqualPaths(superEncoder.codingPath, [TopLevelCodingKeys.a], "New superEncoder had unexpected codingPath.")
+                _testNestedContainers(in: superEncoder, baseCodingPath: [TopLevelCodingKeys.a])
+            } else {
+                _testNestedContainers(in: encoder, baseCodingPath: [])
+            }
+        }
+
+        func _testNestedContainers(in encoder: Encoder, baseCodingPath: [CodingKey]) {
+            expectEqualPaths(encoder.codingPath, baseCodingPath, "New encoder has non-empty codingPath.")
+
+            // codingPath should not change upon fetching a non-nested container.
+            var firstLevelContainer = encoder.container(keyedBy: TopLevelCodingKeys.self)
+            expectEqualPaths(encoder.codingPath, baseCodingPath, "Top-level Encoder's codingPath changed.")
+            expectEqualPaths(firstLevelContainer.codingPath, baseCodingPath, "New first-level keyed container has non-empty codingPath.")
+
+            // Nested Keyed Container
+            do {
+                // Nested container for key should have a new key pushed on.
+                var secondLevelContainer = firstLevelContainer.nestedContainer(keyedBy: IntermediateCodingKeys.self, forKey: .a)
+                expectEqualPaths(encoder.codingPath, baseCodingPath, "Top-level Encoder's codingPath changed.")
+                expectEqualPaths(firstLevelContainer.codingPath, baseCodingPath, "First-level keyed container's codingPath changed.")
+                expectEqualPaths(secondLevelContainer.codingPath, baseCodingPath + [TopLevelCodingKeys.a], "New second-level keyed container had unexpected codingPath.")
+
+                // Inserting a keyed container should not change existing coding paths.
+                let thirdLevelContainerKeyed = secondLevelContainer.nestedContainer(keyedBy: IntermediateCodingKeys.self, forKey: .one)
+                expectEqualPaths(encoder.codingPath, baseCodingPath, "Top-level Encoder's codingPath changed.")
+                expectEqualPaths(firstLevelContainer.codingPath, baseCodingPath, "First-level keyed container's codingPath changed.")
+                expectEqualPaths(secondLevelContainer.codingPath, baseCodingPath + [TopLevelCodingKeys.a], "Second-level keyed container's codingPath changed.")
+                expectEqualPaths(thirdLevelContainerKeyed.codingPath, baseCodingPath + [TopLevelCodingKeys.a, IntermediateCodingKeys.one], "New third-level keyed container had unexpected codingPath.")
+
+                // Inserting an unkeyed container should not change existing coding paths.
+                let thirdLevelContainerUnkeyed = secondLevelContainer.nestedUnkeyedContainer(forKey: .two)
+                expectEqualPaths(encoder.codingPath, baseCodingPath + [], "Top-level Encoder's codingPath changed.")
+                expectEqualPaths(firstLevelContainer.codingPath, baseCodingPath + [], "First-level keyed container's codingPath changed.")
+                expectEqualPaths(secondLevelContainer.codingPath, baseCodingPath + [TopLevelCodingKeys.a], "Second-level keyed container's codingPath changed.")
+                expectEqualPaths(thirdLevelContainerUnkeyed.codingPath, baseCodingPath + [TopLevelCodingKeys.a, IntermediateCodingKeys.two], "New third-level unkeyed container had unexpected codingPath.")
+            }
+
+            // Nested Unkeyed Container
+            do {
+                // Nested container for key should have a new key pushed on.
+                var secondLevelContainer = firstLevelContainer.nestedUnkeyedContainer(forKey: .b)
+                expectEqualPaths(encoder.codingPath, baseCodingPath, "Top-level Encoder's codingPath changed.")
+                expectEqualPaths(firstLevelContainer.codingPath, baseCodingPath, "First-level keyed container's codingPath changed.")
+                expectEqualPaths(secondLevelContainer.codingPath, baseCodingPath + [TopLevelCodingKeys.b], "New second-level keyed container had unexpected codingPath.")
+
+                // Appending a keyed container should not change existing coding paths.
+                let thirdLevelContainerKeyed = secondLevelContainer.nestedContainer(keyedBy: IntermediateCodingKeys.self)
+                expectEqualPaths(encoder.codingPath, baseCodingPath, "Top-level Encoder's codingPath changed.")
+                expectEqualPaths(firstLevelContainer.codingPath, baseCodingPath, "First-level keyed container's codingPath changed.")
+                expectEqualPaths(secondLevelContainer.codingPath, baseCodingPath + [TopLevelCodingKeys.b], "Second-level unkeyed container's codingPath changed.")
+                expectEqualPaths(thirdLevelContainerKeyed.codingPath, baseCodingPath + [TopLevelCodingKeys.b, _TestKey(index: 0)], "New third-level keyed container had unexpected codingPath.")
+
+                // Appending an unkeyed container should not change existing coding paths.
+                let thirdLevelContainerUnkeyed = secondLevelContainer.nestedUnkeyedContainer()
+                expectEqualPaths(encoder.codingPath, baseCodingPath, "Top-level Encoder's codingPath changed.")
+                expectEqualPaths(firstLevelContainer.codingPath, baseCodingPath, "First-level keyed container's codingPath changed.")
+                expectEqualPaths(secondLevelContainer.codingPath, baseCodingPath + [TopLevelCodingKeys.b], "Second-level unkeyed container's codingPath changed.")
+                expectEqualPaths(thirdLevelContainerUnkeyed.codingPath, baseCodingPath + [TopLevelCodingKeys.b, _TestKey(index: 1)], "New third-level unkeyed container had unexpected codingPath.")
+            }
+        }
+    }
+
+    // MARK: - Helper Types
+
+    /// A key type which can take on any string or integer value.
+    /// This needs to mirror _YAMLKey.
+    private struct _TestKey: CodingKey {
+        var stringValue: String
+        var intValue: Int?
+
+        init?(stringValue: String) {
+            self.stringValue = stringValue
+            self.intValue = nil
+        }
+
+        init?(intValue: Int) {
+            self.stringValue = "\(intValue)"
+            self.intValue = intValue
+        }
+
+        init(index: Int) {
+            self.stringValue = "Index \(index)"
+            self.intValue = index
+        }
+    }
+
+    /// Wraps a type T so that it can be encoded at the top level of a payload.
+    private struct TopLevelWrapper<T> : Codable, Equatable where T : Codable, T : Equatable {
+        let value: T
+
+        init(_ value: T) {
+            self.value = value
+        }
+
+        static func == (_ lhs: TopLevelWrapper<T>, _ rhs: TopLevelWrapper<T>) -> Bool {
+            return lhs.value == rhs.value
+        }
+    }
+
+    /// Wraps a type T (as T?) so that it can be encoded at the top level of a payload.
+    private struct OptionalTopLevelWrapper<T> : Codable, Equatable where T : Codable, T : Equatable {
+        let value: T?
+
+        init(_ value: T) {
+            self.value = value
+        }
+
+        // Provide an implementation of Codable to encode(forKey:) instead of encodeIfPresent(forKey:).
+        private enum CodingKeys: String, CodingKey {
+            case value
+        }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            value = try container.decode(T?.self, forKey: .value)
+        }
+
+        func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode(value, forKey: .value)
+        }
+
+        static func == (_ lhs: OptionalTopLevelWrapper<T>, _ rhs: OptionalTopLevelWrapper<T>) -> Bool {
+            return lhs.value == rhs.value
         }
     }
 
@@ -293,12 +729,20 @@ import Yams
                 ("testEncodingTopLevelSingleValueClass", testEncodingTopLevelSingleValueClass),
                 ("testEncodingTopLevelStructuredStruct", testEncodingTopLevelStructuredStruct),
                 ("testEncodingTopLevelStructuredClass", testEncodingTopLevelStructuredClass),
+                ("testEncodingTopLevelStructuredSingleStruct", testEncodingTopLevelStructuredSingleStruct),
+                ("testEncodingTopLevelStructuredSingleClass", testEncodingTopLevelStructuredSingleClass),
                 ("testEncodingTopLevelDeepStructuredType", testEncodingTopLevelDeepStructuredType),
+                ("testEncodingClassWhichSharesEncoderWithSuper", testEncodingClassWhichSharesEncoderWithSuper),
+                ("testEncodingTopLevelNullableType", testEncodingTopLevelNullableType),
                 ("testEncodingDate", testEncodingDate),
                 ("testEncodingDateMillisecondsSince1970", testEncodingDateMillisecondsSince1970),
-                ("testEncodingBase64Data", testEncodingBase64Data)
+                ("testEncodingBase64Data", testEncodingBase64Data),
+                ("testNestedContainerCodingPaths", testNestedContainerCodingPaths),
+                ("testSuperEncoderCodingPaths", testSuperEncoderCodingPaths),
+                ("testInterceptDecimal", testInterceptDecimal),
+                ("testInterceptURL", testInterceptURL)
             ]
         }
     }
 
-#endif
+#endif // swiftlint:disable:this file_length

--- a/Tests/YamsTests/EncoderTests.swift
+++ b/Tests/YamsTests/EncoderTests.swift
@@ -62,7 +62,7 @@ import Yams
         #if os(Linux)
             print("'Date' does not conform to 'Codable' on Linux yet.")
         #else
-            _testRoundTrip(of: TopLevelWrapper(Date()))
+            _testRoundTrip(of: Date())
         #endif
         }
 
@@ -70,11 +70,7 @@ import Yams
         #if os(Linux)
             print("'Date' does not conform to 'Codable' on Linux yet.")
         #else
-            let seconds = 1000.0
-            let expectedYAML = "- 1970-01-01T00:16:40Z\n"
-
-            _testRoundTrip(of: TopLevelWrapper(Date(timeIntervalSince1970: seconds)),
-                           expectedYAML: expectedYAML)
+            _testRoundTrip(of: Date(timeIntervalSince1970: 1000.0), expectedYAML: "1970-01-01T00:16:40Z\n...\n")
         #endif
         }
 
@@ -83,11 +79,7 @@ import Yams
         #if os(Linux)
             print("'Data' does not conform to 'Codable' on Linux yet.")
         #else
-            let data = Data(bytes: [0xDE, 0xAD, 0xBE, 0xEF])
-
-            // We can't encode a top-level Data, so it'll be wrapped in an array.
-            let expectedYAML = "- 3q2+7w==\n"
-            _testRoundTrip(of: TopLevelWrapper(data), expectedYAML: expectedYAML)
+            _testRoundTrip(of: Data(bytes: [0xDE, 0xAD, 0xBE, 0xEF]), expectedYAML: "3q2+7w==\n...\n")
         #endif
         }
 
@@ -266,32 +258,6 @@ import Yams
 
         static var testValue: Company {
             return Company(address: Address.testValue, employees: [Person.testValue])
-        }
-    }
-
-    // MARK: - Helper Types
-
-    /// Wraps a type T so that it can be encoded at the top level of a payload.
-    fileprivate struct TopLevelWrapper<T> : Codable, Equatable where T : Codable, T : Equatable {
-        let value: T
-
-        init(_ value: T) {
-            self.value = value
-        }
-
-        func encode(to encoder: Encoder) throws {
-            var container = encoder.unkeyedContainer()
-            try container.encode(value)
-        }
-
-        init(from decoder: Decoder) throws {
-            var container = try decoder.unkeyedContainer()
-            value = try container.decode(T.self)
-            assert(container.isAtEnd)
-        }
-
-        static func == (_ lhs: TopLevelWrapper<T>, _ rhs: TopLevelWrapper<T>) -> Bool {
-            return lhs.value == rhs.value
         }
     }
 

--- a/Tests/YamsTests/EncoderTests.swift
+++ b/Tests/YamsTests/EncoderTests.swift
@@ -165,6 +165,61 @@ import Yams
 //            _testRoundTrip(of: OptionalTopLevelWrapper(url), expectedYAML: expectedYAML)
         }
 
+        func testValuesInSingleValueContainer() throws {
+            _testRoundTrip(of: true)
+            _testRoundTrip(of: false)
+
+            _testFixedWidthInteger(type: Int.self)
+            _testFixedWidthInteger(type: Int8.self)
+            _testFixedWidthInteger(type: Int16.self)
+            _testFixedWidthInteger(type: Int32.self)
+            _testFixedWidthInteger(type: Int64.self)
+            _testFixedWidthInteger(type: UInt.self)
+            _testFixedWidthInteger(type: UInt8.self)
+            _testFixedWidthInteger(type: UInt16.self)
+            _testFixedWidthInteger(type: UInt32.self)
+            _testFixedWidthInteger(type: UInt64.self)
+
+            _testFloatingPoint(type: Float.self)
+            _testFloatingPoint(type: Double.self)
+
+            _testRoundTrip(of: "")
+            _testRoundTrip(of: URL(string: "https://apple.com")!)
+        }
+
+        private func _testFixedWidthInteger<T>(type: T.Type,
+                                               file: StaticString = #file,
+                                               line: UInt = #line) where T: FixedWidthInteger & Codable {
+            _testRoundTrip(of: type.min, file: file, line: line)
+            _testRoundTrip(of: type.max, file: file, line: line)
+        }
+
+        private func _testFloatingPoint<T>(type: T.Type,
+                                           file: StaticString = #file,
+                                           line: UInt = #line) where T: FloatingPoint & Codable {
+            _testRoundTrip(of: type.leastNormalMagnitude, file: file, line: line)
+            _testRoundTrip(of: type.greatestFiniteMagnitude, file: file, line: line)
+            _testRoundTrip(of: type.infinity, file: file, line: line)
+        }
+
+        func testValuesInKeyedContainer() throws {
+            _testRoundTrip(of: KeyedSynthesized(
+                bool: true, int: .max, int8: .max, int16: .max, int32: .max, int64: .max,
+                uint: .max, uint8: .max, uint16: .max, uint32: .max, uint64: .max,
+                float: .greatestFiniteMagnitude, double: .greatestFiniteMagnitude, string: "", optionalString: nil,
+                url: URL(string: "https://apple.com")!
+            ))
+        }
+
+        func testValuesInUnkeyedContainer() throws {
+            _testRoundTrip(of: Unkeyed(
+                bool: true, int: .max, int8: .max, int16: .max, int32: .max, int64: .max,
+                uint: .max, uint8: .max, uint16: .max, uint32: .max, uint64: .max,
+                float: .greatestFiniteMagnitude, double: .greatestFiniteMagnitude, string: "", optionalString: nil,
+                url: URL(string: "https://apple.com")!
+            ))
+        }
+
         // MARK: - Helper Functions
         private func _testEncodeFailure<T: Encodable>(of value: T) {
             do {
@@ -782,6 +837,130 @@ import Yams
         }
     }
 
+    /// Coder supported types in KeyedContainer
+    struct KeyedSynthesized: Codable, Equatable {
+        static func == (lhs: KeyedSynthesized, rhs: KeyedSynthesized) -> Bool {
+            return lhs.bool == rhs.bool &&
+                lhs.int == rhs.int && lhs.int8 == rhs.int8 &&  lhs.int16 == rhs.int16 &&
+                lhs.int32 == rhs.int32 && lhs.int64 == rhs.int64 &&
+                lhs.uint == rhs.uint && lhs.uint8 == rhs.uint8 &&  lhs.uint16 == rhs.uint16 &&
+                lhs.uint32 == rhs.uint32 && lhs.uint64 == rhs.uint64 &&
+                lhs.float == rhs.float && lhs.double == rhs.double &&
+                lhs.string == rhs.string && lhs.optionalString == rhs.optionalString &&
+                lhs.url == rhs.url
+        }
+
+        var bool: Bool = true
+        let int: Int
+        let int8: Int8
+        let int16: Int16
+        let int32: Int32
+        let int64: Int64
+        let uint: UInt
+        let uint8: UInt8
+        let uint16: UInt16
+        let uint32: UInt32
+        let uint64: UInt64
+        let float: Float
+        let double: Double
+        let string: String
+        let optionalString: String?
+        let url: URL
+    }
+
+    /// Coder supported types in UnkeyedContainer
+    struct Unkeyed: Codable, Equatable {
+        static func == (lhs: Unkeyed, rhs: Unkeyed) -> Bool {
+            return lhs.bool == rhs.bool &&
+                lhs.int == rhs.int && lhs.int8 == rhs.int8 &&  lhs.int16 == rhs.int16 &&
+                lhs.int32 == rhs.int32 && lhs.int64 == rhs.int64 &&
+                lhs.uint == rhs.uint && lhs.uint8 == rhs.uint8 &&  lhs.uint16 == rhs.uint16 &&
+                lhs.uint32 == rhs.uint32 && lhs.uint64 == rhs.uint64 &&
+                lhs.float == rhs.float && lhs.double == rhs.double &&
+                lhs.string == rhs.string && lhs.optionalString == rhs.optionalString &&
+                lhs.url == rhs.url
+        }
+
+        let bool: Bool
+        let int: Int
+        let int8: Int8
+        let int16: Int16
+        let int32: Int32
+        let int64: Int64
+        let uint: UInt
+        let uint8: UInt8
+        let uint16: UInt16
+        let uint32: UInt32
+        let uint64: UInt64
+        let float: Float
+        let double: Double
+        let string: String
+        let optionalString: String?
+        let url: URL
+
+        init(
+            bool: Bool, int: Int, int8: Int8, int16: Int16, int32: Int32, int64: Int64,
+            uint: UInt, uint8: UInt8, uint16: UInt16, uint32: UInt32, uint64: UInt64,
+            float: Float, double: Double, string: String, optionalString: String?, url: URL) {
+            self.bool = bool
+            self.int = int
+            self.int8 = int8
+            self.int16 = int16
+            self.int32 = int32
+            self.int64 = int64
+            self.uint = uint
+            self.uint8 = uint8
+            self.uint16 = uint16
+            self.uint32 = uint32
+            self.uint64 = uint64
+            self.float = float
+            self.double = double
+            self.string = string
+            self.optionalString = optionalString
+            self.url = url
+        }
+
+        init(from decoder: Decoder) throws {
+            var container = try decoder.unkeyedContainer()
+            bool = try container.decode(Bool.self)
+            int = try container.decode(Int.self)
+            int8 = try container.decode(Int8.self)
+            int16 = try container.decode(Int16.self)
+            int32 = try container.decode(Int32.self)
+            int64 = try container.decode(Int64.self)
+            uint = try container.decode(UInt.self)
+            uint8 = try container.decode(UInt8.self)
+            uint16 = try container.decode(UInt16.self)
+            uint32 = try container.decode(UInt32.self)
+            uint64 = try container.decode(UInt64.self)
+            float = try container.decode(Float.self)
+            double = try container.decode(Double.self)
+            string = try container.decode(String.self)
+            optionalString = try container.decode(String?.self)
+            url = try container.decode(URL.self)
+        }
+
+        func encode(to encoder: Encoder) throws {
+            var container = encoder.unkeyedContainer()
+            try container.encode(bool)
+            try container.encode(int)
+            try container.encode(int8)
+            try container.encode(int16)
+            try container.encode(int32)
+            try container.encode(int64)
+            try container.encode(uint)
+            try container.encode(uint8)
+            try container.encode(uint16)
+            try container.encode(uint32)
+            try container.encode(uint64)
+            try container.encode(float)
+            try container.encode(double)
+            try container.encode(string)
+            try container.encode(optionalString)
+            try container.encode(url)
+        }
+    }
+
     extension EncoderTests {
         static var allTests: [(String, (EncoderTests) -> () throws -> Void)] {
             return [
@@ -803,7 +982,10 @@ import Yams
                 ("testNestedContainerCodingPaths", testNestedContainerCodingPaths),
                 ("testSuperEncoderCodingPaths", testSuperEncoderCodingPaths),
                 ("testInterceptDecimal", testInterceptDecimal),
-                ("testInterceptURL", testInterceptURL)
+                ("testInterceptURL", testInterceptURL),
+                ("testValuesInSingleValueContainer", testValuesInSingleValueContainer),
+                ("testValuesInKeyedContainer", testValuesInKeyedContainer),
+                ("testValuesInUnkeyedContainer", testValuesInUnkeyedContainer)
             ]
         }
     }

--- a/Tests/YamsTests/EncoderTests.swift
+++ b/Tests/YamsTests/EncoderTests.swift
@@ -70,7 +70,7 @@ import Yams
         func testEncodingTopLevelStructuredSingleClass() {
             // Mapping is a class which encodes as a dictionary through a single value container.
             let mapping = Mapping.testValue
-            _testRoundTrip(of: mapping, expectedYAML: """
+            _testRoundTrip(of: mapping, with: YAMLEncoder.Options(sortKeys: true), expectedYAML: """
                 Apple:
                   relative: http://apple.com
                 localhost:
@@ -230,11 +230,13 @@ import Yams
         }
 
         private func _testRoundTrip<T>(of value: T,
+                                       with options: YAMLEncoder.Options = .init(),
                                        expectedYAML yamlString: String? = nil,
                                        file: StaticString = #file,
                                        line: UInt = #line) where T: Codable, T: Equatable {
             do {
                 let encoder = YAMLEncoder()
+                encoder.options = options
                 let producedYAML = try encoder.encode(value)
 
                 if let expectedYAML = yamlString {

--- a/Tests/YamsTests/EncoderTests.swift
+++ b/Tests/YamsTests/EncoderTests.swift
@@ -180,12 +180,8 @@ import Yams
             _testFixedWidthInteger(type: UInt32.self)
             _testFixedWidthInteger(type: UInt64.self)
 
-        #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
             _testFloatingPoint(type: Float.self)
             _testFloatingPoint(type: Double.self)
-        #else
-            print("Encoding/Decoding `Double` and `Float` with full precision are supported only on Apple platforms")
-        #endif
 
             // Can't YAML encode empty string as valid YAML Document?
 //            _testRoundTrip(of: "")
@@ -208,29 +204,21 @@ import Yams
         }
 
         func testValuesInKeyedContainer() throws {
-        #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
             _testRoundTrip(of: KeyedSynthesized(
                 bool: true, int: .max, int8: .max, int16: .max, int32: .max, int64: .max,
                 uint: .max, uint8: .max, uint16: .max, uint32: .max, uint64: .max,
                 float: .greatestFiniteMagnitude, double: .greatestFiniteMagnitude, string: "", optionalString: nil,
                 url: URL(string: "https://apple.com")!
             ))
-        #else
-            print("Encoding/Decoding `Double` and `Float` with full precision are supported only on Apple platforms")
-        #endif
         }
 
         func testValuesInUnkeyedContainer() throws {
-        #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
             _testRoundTrip(of: Unkeyed(
                 bool: true, int: .max, int8: .max, int16: .max, int32: .max, int64: .max,
                 uint: .max, uint8: .max, uint16: .max, uint32: .max, uint64: .max,
                 float: .greatestFiniteMagnitude, double: .greatestFiniteMagnitude, string: "", optionalString: nil,
                 url: URL(string: "https://apple.com")!
             ))
-        #else
-            print("Encoding/Decoding `Double` and `Float` with full precision are supported only on Apple platforms")
-        #endif
         }
 
         // MARK: - Helper Functions

--- a/Tests/YamsTests/EncoderTests.swift
+++ b/Tests/YamsTests/EncoderTests.swift
@@ -1,0 +1,289 @@
+//
+//  EncoderTests.swift
+//  Yams
+//
+//  Created by Norio Nomura on 5/2/17.
+//  Copyright (c) 2017 Yams. All rights reserved.
+//
+
+import XCTest
+import Yams
+
+#if swift(>=4.0)
+
+    /// Tests are copied from https://github.com/apple/swift/blob/master/test/stdlib/TestJSONEncoder.swift
+    class EncoderTests: XCTestCase {
+        // MARK: - Encoding Top-Level Empty Types
+        func testEncodingTopLevelEmptyStruct() {
+            let empty = EmptyStruct()
+            _testRoundTrip(of: empty, expectedYAML: "{}\n")
+        }
+
+        func testEncodingTopLevelEmptyClass() {
+            let empty = EmptyClass()
+            _testRoundTrip(of: empty, expectedYAML: "{}\n")
+        }
+
+        // MARK: - Encoding Top-Level Single-Value Types
+        func testEncodingTopLevelSingleValueEnum() {
+            _testRoundTrip(of: Switch.off, expectedYAML: "false\n...\n")
+            _testRoundTrip(of: Switch.on, expectedYAML: "true\n...\n")
+        }
+
+        func testEncodingTopLevelSingleValueStruct() {
+            _testRoundTrip(of: Timestamp(3141592653), expectedYAML: "3.141592653e+9\n...\n")
+        }
+
+        func testEncodingTopLevelSingleValueClass() {
+            _testRoundTrip(of: Counter())
+        }
+
+        // MARK: - Encoding Top-Level Structured Types
+        func testEncodingTopLevelStructuredStruct() {
+            // Address is a struct type with multiple fields.
+            let address = Address.testValue
+            _testRoundTrip(of: address)
+        }
+
+        func testEncodingTopLevelStructuredClass() {
+            // Person is a class with multiple fields.
+            let person = Person.testValue
+            _testRoundTrip(of: person)
+        }
+
+        func testEncodingTopLevelDeepStructuredType() {
+            // Company is a type with fields which are Codable themselves.
+            let company = Company.testValue
+            _testRoundTrip(of: company)
+        }
+
+        // MARK: - Date Strategy Tests
+        func testEncodingDate() {
+            // We can't encode a top-level Date, so it'll be wrapped in an array.
+            _testRoundTrip(of: TopLevelWrapper(Date()))
+        }
+
+        func testEncodingDateMillisecondsSince1970() {
+            // Cannot encode an arbitrary number of seconds since we've lost precision since 1970.
+            let seconds = 1000.0
+            let expectedYAML = "- 1970-01-01T00:16:40Z\n"
+
+            // We can't encode a top-level Date, so it'll be wrapped in an array.
+            _testRoundTrip(of: TopLevelWrapper(Date(timeIntervalSince1970: seconds)),
+                           expectedYAML: expectedYAML)
+        }
+
+        // MARK: - Data Tests
+        func testEncodingBase64Data() {
+            let data = Data(bytes: [0xDE, 0xAD, 0xBE, 0xEF])
+
+            // We can't encode a top-level Data, so it'll be wrapped in an array.
+            let expectedYAML = "- 3q2+7w==\n"
+            _testRoundTrip(of: TopLevelWrapper(data), expectedYAML: expectedYAML)
+        }
+
+        // MARK: - Helper Functions
+        private func _testRoundTrip<T>(of value: T,
+                                       expectedYAML yamlString: String? = nil) where T : Codable, T : Equatable {
+            let yaml = yamlString?.data(using: .utf8)! // swiftlint:disable:this force_unwrapping
+            var payload: Data! = nil
+            do {
+                let encoder = YAMLEncoder()
+                payload = try encoder.encode(value)
+            } catch {
+                XCTFail("Failed to encode \(T.self) to YAML.")
+            }
+
+            if let expectedYAML = yaml {
+                XCTAssertEqual(expectedYAML, payload, "Produced YAML not identical to expected YAML.")
+            }
+
+            do {
+                let decoder = YAMLDecoder()
+                let decoded = try decoder.decode(T.self, from: payload)
+                XCTAssertEqual(decoded, value, "\(T.self) did not round-trip to an equal value.")
+            } catch {
+                XCTFail("Failed to decode \(T.self) from YAML by error: \(error)")
+            }
+        }
+    }
+
+    // MARK: - Empty Types
+    fileprivate struct EmptyStruct: Codable, Equatable {
+        static func == (_ lhs: EmptyStruct, _ rhs: EmptyStruct) -> Bool {
+            return true
+        }
+    }
+
+    fileprivate class EmptyClass: Codable, Equatable {
+        static func == (_ lhs: EmptyClass, _ rhs: EmptyClass) -> Bool {
+            return true
+        }
+    }
+
+    // MARK: - Single-Value Types
+    /// A simple on-off switch type that encodes as a single Bool value.
+    fileprivate enum Switch: Codable {
+        case off
+        case on // swiftlint:disable:this identifier_name
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.singleValueContainer()
+            switch try container.decode(Bool.self) {
+            case false: self = .off
+            case true:  self = .on
+            }
+        }
+
+        func encode(to encoder: Encoder) throws {
+            var container = encoder.singleValueContainer()
+            switch self {
+            case .off: try container.encode(false)
+            case .on:  try container.encode(true)
+            }
+        }
+    }
+
+    /// A simple timestamp type that encodes as a single Double value.
+    fileprivate struct Timestamp: Codable, Equatable {
+        let value: Double
+
+        init(_ value: Double) {
+            self.value = value
+        }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.singleValueContainer()
+            value = try container.decode(Double.self)
+        }
+
+        func encode(to encoder: Encoder) throws {
+            var container = encoder.singleValueContainer()
+            try container.encode(self.value)
+        }
+
+        static func == (lhs: Timestamp, rhs: Timestamp) -> Bool {
+            return lhs.value == rhs.value
+        }
+    }
+
+    /// A simple referential counter type that encodes as a single Int value.
+    fileprivate final class Counter: Codable, Equatable {
+        var count: Int = 0
+
+        init() {}
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.singleValueContainer()
+            count = try container.decode(Int.self)
+        }
+
+        func encode(to encoder: Encoder) throws {
+            var container = encoder.singleValueContainer()
+            try container.encode(self.count)
+        }
+
+        static func == (lhs: Counter, rhs: Counter) -> Bool {
+            return lhs.count == rhs.count
+        }
+    }
+
+    // MARK: - Structured Types
+    /// A simple address type that encodes as a dictionary of values.
+    fileprivate struct Address: Codable, Equatable {
+        let street: String
+        let city: String
+        let state: String
+        let zipCode: Int
+        let country: String
+
+        init(street: String, city: String, state: String, zipCode: Int, country: String) {
+            self.street = street
+            self.city = city
+            self.state = state
+            self.zipCode = zipCode
+            self.country = country
+        }
+
+        static func == (_ lhs: Address, _ rhs: Address) -> Bool {
+            return lhs.street == rhs.street &&
+                lhs.city == rhs.city &&
+                lhs.state == rhs.state &&
+                lhs.zipCode == rhs.zipCode &&
+                lhs.country == rhs.country
+        }
+
+        static var testValue: Address {
+            return Address(street: "1 Infinite Loop",
+                           city: "Cupertino",
+                           state: "CA",
+                           zipCode: 95014,
+                           country: "United States")
+        }
+    }
+
+    /// A simple person class that encodes as a dictionary of values.
+    fileprivate class Person: Codable, Equatable {
+        let name: String
+        let email: String
+
+        init(name: String, email: String) {
+            self.name = name
+            self.email = email
+        }
+
+        static func == (_ lhs: Person, _ rhs: Person) -> Bool {
+            return lhs.name == rhs.name && lhs.email == rhs.email
+        }
+
+        static var testValue: Person {
+            return Person(name: "Johnny Appleseed", email: "appleseed@apple.com")
+        }
+    }
+
+    /// A simple company struct which encodes as a dictionary of nested values.
+    fileprivate struct Company: Codable, Equatable {
+        let address: Address
+        var employees: [Person]
+
+        init(address: Address, employees: [Person]) {
+            self.address = address
+            self.employees = employees
+        }
+
+        static func == (_ lhs: Company, _ rhs: Company) -> Bool {
+            return lhs.address == rhs.address && lhs.employees == rhs.employees
+        }
+
+        static var testValue: Company {
+            return Company(address: Address.testValue, employees: [Person.testValue])
+        }
+    }
+
+    // MARK: - Helper Types
+
+    /// Wraps a type T so that it can be encoded at the top level of a payload.
+    fileprivate struct TopLevelWrapper<T> : Codable, Equatable where T : Codable, T : Equatable {
+        let value: T
+
+        init(_ value: T) {
+            self.value = value
+        }
+
+        func encode(to encoder: Encoder) throws {
+            var container = encoder.unkeyedContainer()
+            try container.encode(value)
+        }
+
+        init(from decoder: Decoder) throws {
+            var container = try decoder.unkeyedContainer()
+            value = try container.decode(T.self)
+            assert(container.isAtEnd)
+        }
+
+        static func == (_ lhs: TopLevelWrapper<T>, _ rhs: TopLevelWrapper<T>) -> Bool {
+            return lhs.value == rhs.value
+        }
+    }
+
+#endif

--- a/Tests/YamsTests/EncoderTests.swift
+++ b/Tests/YamsTests/EncoderTests.swift
@@ -12,7 +12,7 @@ import Yams
 
 #if swift(>=4.0)
 
-    // swiftlint:disable identifier_name, line_length
+    // swiftlint:disable identifier_name line_length
 
     /// Tests are copied from https://github.com/apple/swift/blob/master/test/stdlib/TestJSONEncoder.swift
     class EncoderTests: XCTestCase {
@@ -190,7 +190,7 @@ import Yams
         private func _testRoundTrip<T>(of value: T,
                                        expectedYAML yamlString: String? = nil,
                                        file: StaticString = #file,
-                                       line: UInt = #line) where T : Codable, T : Equatable {
+                                       line: UInt = #line) where T: Codable, T: Equatable {
             var payload: Data! = nil
             do {
                 let encoder = YAMLEncoder()
@@ -255,8 +255,6 @@ import Yams
                     expectUnreachable("\(prefix) CodingKey.intValue mismatch: \(type(of: key1))(\(i1)) != \(type(of: key2))(\(i2))", file: file, line: line)
                     return
                 }
-
-                break
             }
 
             expectEqual(key1.stringValue, key2.stringValue, "\(prefix) CodingKey.stringValue mismatch: \(type(of: key1))('\(key1.stringValue)') != \(type(of: key2))('\(key2.stringValue)')", file: file, line: line)
@@ -538,9 +536,9 @@ import Yams
 
     /// A type which encodes as a dictionary directly through a single value container.
     private final class Mapping: Codable, Equatable {
-        let values: [String : URL]
+        let values: [String: URL]
 
-        init(values: [String : URL]) {
+        init(values: [String: URL]) {
             self.values = values
         }
 
@@ -679,7 +677,7 @@ import Yams
     }
 
     /// Wraps a type T so that it can be encoded at the top level of a payload.
-    private struct TopLevelWrapper<T> : Codable, Equatable where T : Codable, T : Equatable {
+    private struct TopLevelWrapper<T> : Codable, Equatable where T: Codable, T: Equatable {
         let value: T
 
         init(_ value: T) {
@@ -692,7 +690,7 @@ import Yams
     }
 
     /// Wraps a type T (as T?) so that it can be encoded at the top level of a payload.
-    private struct OptionalTopLevelWrapper<T> : Codable, Equatable where T : Codable, T : Equatable {
+    private struct OptionalTopLevelWrapper<T> : Codable, Equatable where T: Codable, T: Equatable {
         let value: T?
 
         init(_ value: T) {

--- a/Tests/YamsTests/EncoderTests.swift
+++ b/Tests/YamsTests/EncoderTests.swift
@@ -323,7 +323,7 @@ import Yams
     }
 
     /// A simple referential counter type that encodes as a single Int value.
-    fileprivate final class Counter: Codable, Equatable {
+    private final class Counter: Codable, Equatable {
         var count: Int = 0
 
         init() {}
@@ -537,7 +537,7 @@ import Yams
     }
 
     /// A type which encodes as a dictionary directly through a single value container.
-    fileprivate final class Mapping: Codable, Equatable {
+    private final class Mapping: Codable, Equatable {
         let values: [String : URL]
 
         init(values: [String : URL]) {

--- a/Tests/YamsTests/EncoderTests.swift
+++ b/Tests/YamsTests/EncoderTests.swift
@@ -180,8 +180,12 @@ import Yams
             _testFixedWidthInteger(type: UInt32.self)
             _testFixedWidthInteger(type: UInt64.self)
 
+        #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
             _testFloatingPoint(type: Float.self)
             _testFloatingPoint(type: Double.self)
+        #else
+            print("Encoding/Decoding `Double` and `Float` with full precision are supported only on Apple platforms")
+        #endif
 
             // Can't YAML encode empty string as valid YAML Document?
 //            _testRoundTrip(of: "")
@@ -204,21 +208,29 @@ import Yams
         }
 
         func testValuesInKeyedContainer() throws {
+        #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
             _testRoundTrip(of: KeyedSynthesized(
                 bool: true, int: .max, int8: .max, int16: .max, int32: .max, int64: .max,
                 uint: .max, uint8: .max, uint16: .max, uint32: .max, uint64: .max,
                 float: .greatestFiniteMagnitude, double: .greatestFiniteMagnitude, string: "", optionalString: nil,
                 url: URL(string: "https://apple.com")!
             ))
+        #else
+            print("Encoding/Decoding `Double` and `Float` with full precision are supported only on Apple platforms")
+        #endif
         }
 
         func testValuesInUnkeyedContainer() throws {
+        #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
             _testRoundTrip(of: Unkeyed(
                 bool: true, int: .max, int8: .max, int16: .max, int32: .max, int64: .max,
                 uint: .max, uint8: .max, uint16: .max, uint32: .max, uint64: .max,
                 float: .greatestFiniteMagnitude, double: .greatestFiniteMagnitude, string: "", optionalString: nil,
                 url: URL(string: "https://apple.com")!
             ))
+        #else
+            print("Encoding/Decoding `Double` and `Float` with full precision are supported only on Apple platforms")
+        #endif
         }
 
         // MARK: - Helper Functions

--- a/Yams.xcodeproj/project.pbxproj
+++ b/Yams.xcodeproj/project.pbxproj
@@ -17,12 +17,15 @@
 		6C3C90B91E0FFB6B009DEFE8 /* NodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C3C90B81E0FFB6B009DEFE8 /* NodeTests.swift */; };
 		6C4A22071DF8553C002A0206 /* String+Yams.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C4A22061DF8553C002A0206 /* String+Yams.swift */; };
 		6C4A22091DF855BB002A0206 /* StringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C4A22081DF855BB002A0206 /* StringTests.swift */; };
+		6C4AF3201EBE1705008775BC /* Decoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C4AF31E1EBE14A1008775BC /* Decoder.swift */; };
 		6C6834C81E0281880047B4D1 /* Node.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C6834C71E0281880047B4D1 /* Node.swift */; };
 		6C6834CC1E0283980047B4D1 /* Parser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C6834CB1E0283980047B4D1 /* Parser.swift */; };
 		6C6834CD1E02847D0047B4D1 /* Tag.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C6834C91E0281D90047B4D1 /* Tag.swift */; };
 		6C6834D11E0297390047B4D1 /* SpecTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C6834D01E0297390047B4D1 /* SpecTests.swift */; };
 		6C6834D31E02B9760047B4D1 /* Resolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C6834D21E02B9760047B4D1 /* Resolver.swift */; };
 		6C6834D51E02BC1F0047B4D1 /* ResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C6834D41E02BC1F0047B4D1 /* ResolverTests.swift */; };
+		6C788A011EB87232005386F0 /* EncoderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C788A001EB87232005386F0 /* EncoderTests.swift */; };
+		6C788A041EB89162005386F0 /* Encoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C788A021EB876C4005386F0 /* Encoder.swift */; };
 		6C78C5651E29B27D0096215F /* RepresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C78C5631E29B1CE0096215F /* RepresenterTests.swift */; };
 		6CBAEE1A1E3839500021BF87 /* Yams.h in Headers */ = {isa = PBXBuildFile; fileRef = 6CBAEE191E3839500021BF87 /* Yams.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		6CC2E33F1E22347B00F62269 /* Representer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CC2E33E1E22347B00F62269 /* Representer.swift */; };
@@ -66,12 +69,15 @@
 		6C4A22061DF8553C002A0206 /* String+Yams.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+Yams.swift"; sourceTree = "<group>"; };
 		6C4A22081DF855BB002A0206 /* StringTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StringTests.swift; sourceTree = "<group>"; };
 		6C4A220A1DF85793002A0206 /* LinuxMain.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LinuxMain.swift; sourceTree = "<group>"; };
+		6C4AF31E1EBE14A1008775BC /* Decoder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Decoder.swift; sourceTree = "<group>"; };
 		6C6834C71E0281880047B4D1 /* Node.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Node.swift; sourceTree = "<group>"; };
 		6C6834C91E0281D90047B4D1 /* Tag.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Tag.swift; sourceTree = "<group>"; };
 		6C6834CB1E0283980047B4D1 /* Parser.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Parser.swift; sourceTree = "<group>"; };
 		6C6834D01E0297390047B4D1 /* SpecTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SpecTests.swift; sourceTree = "<group>"; };
 		6C6834D21E02B9760047B4D1 /* Resolver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Resolver.swift; sourceTree = "<group>"; };
 		6C6834D41E02BC1F0047B4D1 /* ResolverTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ResolverTests.swift; sourceTree = "<group>"; };
+		6C788A001EB87232005386F0 /* EncoderTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EncoderTests.swift; sourceTree = "<group>"; };
+		6C788A021EB876C4005386F0 /* Encoder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Encoder.swift; sourceTree = "<group>"; };
 		6C78C5631E29B1CE0096215F /* RepresenterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RepresenterTests.swift; sourceTree = "<group>"; };
 		6CBAEE191E3839500021BF87 /* Yams.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Yams.h; sourceTree = "<group>"; };
 		6CC2E33E1E22347B00F62269 /* Representer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Representer.swift; sourceTree = "<group>"; };
@@ -127,7 +133,9 @@
 			isa = PBXGroup;
 			children = (
 				6C0D2A351E0A934B00C45545 /* Constructor.swift */,
+				6C4AF31E1EBE14A1008775BC /* Decoder.swift */,
 				6CE603971E13502E00A13D8D /* Emitter.swift */,
+				6C788A021EB876C4005386F0 /* Encoder.swift */,
 				6CF025371E9CF4380061FB47 /* Mark.swift */,
 				6C6834C71E0281880047B4D1 /* Node.swift */,
 				6C0409AB1E607E9900C95D83 /* Node.Scalar.swift */,
@@ -160,6 +168,7 @@
 				6CF6CE071E0E3A5900CB87D4 /* Fixtures */,
 				6C0488ED1E0CBD56006F9F80 /* ConstructorTests.swift */,
 				6C0A00D41E152D6200222704 /* EmitterTests.swift */,
+				6C788A001EB87232005386F0 /* EncoderTests.swift */,
 				6CF025391E9D12680061FB47 /* MarkTests.swift */,
 				6C3C90B81E0FFB6B009DEFE8 /* NodeTests.swift */,
 				6CF6CE081E0E3B1000CB87D4 /* PerformanceTests.swift */,
@@ -347,12 +356,14 @@
 				E8EDB8881DE2181B0062268D /* loader.c in Sources */,
 				E8EDB88C1DE2181B0062268D /* writer.c in Sources */,
 				E8EDB88B1DE2181B0062268D /* scanner.c in Sources */,
+				6C4AF3201EBE1705008775BC /* Decoder.swift in Sources */,
 				6C0409AC1E607E9900C95D83 /* Node.Scalar.swift in Sources */,
 				6C4A22071DF8553C002A0206 /* String+Yams.swift in Sources */,
 				E8EDB8891DE2181B0062268D /* parser.c in Sources */,
 				6CF025381E9CF4380061FB47 /* Mark.swift in Sources */,
 				OBJ_50 /* YamlError.swift in Sources */,
 				E8EDB88A1DE2181B0062268D /* reader.c in Sources */,
+				6C788A041EB89162005386F0 /* Encoder.swift in Sources */,
 				6C6834CD1E02847D0047B4D1 /* Tag.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -361,6 +372,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 0;
 			files = (
+				6C788A011EB87232005386F0 /* EncoderTests.swift in Sources */,
 				6CF6CE091E0E3B1000CB87D4 /* PerformanceTests.swift in Sources */,
 				6C4A22091DF855BB002A0206 /* StringTests.swift in Sources */,
 				6C0488EC1E0BE113006F9F80 /* TestHelper.swift in Sources */,


### PR DESCRIPTION
Support [SE-0166 Swift Archival & Serialization](https://github.com/apple/swift-evolution/blob/master/proposals/0166-swift-archival-serialization.md)
Fixes #38 

~This uses local built toolchain https://github.com/norio-nomura/swift-dev/releases/tag/20170501a~

TODOs for merging:
- ~~[ ] Add text encoding detection to `YAMLDecoder.decode(_:from:)`~~
- [x] Revise throwing errors on failing Encode and Decode
- [x] Add more tests
- [x] Support first snapshot of Swift 4.0

