### PR TITLE
Test with `swift-4.0-DEVELOPMENT-SNAPSHOT-2017-06-23-a`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,15 +38,27 @@ matrix:
       os: osx
       osx_image: xcode8.3
     - script:
-        - docker run -v `pwd`:`pwd` -w `pwd` --rm swift:3.0.2 swift test
-        - docker run -v `pwd`:`pwd` -w `pwd` --rm swift:3.0.2 swift test -Xswiftc -DUSE_UTF8
-      env: JOB=Linux-Swift3.0.2
+        - docker run -v `pwd`:`pwd` -w `pwd` --rm $DOCKER_IMAGE swift test
+        - docker run -v `pwd`:`pwd` -w `pwd` --rm $DOCKER_IMAGE swift test -Xswiftc -DUSE_UTF8
+      env:
+        - JOB=Docker
+        - DOCKER_IMAGE=swift:3.0.2
       sudo: required
       services: docker
     - script:
-        - docker run -v `pwd`:`pwd` -w `pwd` --rm swift:3.1 swift test
-        - docker run -v `pwd`:`pwd` -w `pwd` --rm swift:3.1 swift test -Xswiftc -DUSE_UTF8
-      env: JOB=Linux-Swift3.1
+        - docker run -v `pwd`:`pwd` -w `pwd` --rm $DOCKER_IMAGE swift test
+        - docker run -v `pwd`:`pwd` -w `pwd` --rm $DOCKER_IMAGE swift test -Xswiftc -DUSE_UTF8
+      env:
+        - JOB=Docker
+        - DOCKER_IMAGE=swift:3.1
+      sudo: required
+      services: docker
+    - script:
+        - docker run -v `pwd`:`pwd` -w `pwd` --rm $DOCKER_IMAGE swift test
+        - docker run -v `pwd`:`pwd` -w `pwd` --rm $DOCKER_IMAGE swift test -Xswiftc -DUSE_UTF8
+      env:
+        - JOB=Docker
+        - DOCKER_IMAGE=norionomura/swift:4020170623a
       sudo: required
       services: docker
 notifications:

--- a/Package@swift-4.swift
+++ b/Package@swift-4.swift
@@ -1,0 +1,15 @@
+// swift-tools-version:4.0
+import PackageDescription
+
+let package = Package(
+    name: "Yams",
+    products: [
+      .library(name: "Yams", targets: ["Yams"])
+    ],
+    targets: [
+        .target(name: "CYaml"),
+        .target(name: "Yams", dependencies: ["CYaml"]),
+        .testTarget(name: "YamsTests",dependencies: ["Yams"])
+    ],
+    swiftLanguageVersions: [3, 4]
+)


### PR DESCRIPTION
- Yams is still buildable with Swift 3.0.2 by adding `Package@swift-4.swift` instead of using `swiftLanguageVersions: [3, 4]` in `Package.swift`.
- Swift 4 job on macOS will be added when Xcode 9 comes to Travis, since `swift-4.0-DEVELOPMENT-SNAPSHOT-2017-06-23-a` requires Xcode 9.