### PR TITLE
Use `..<` instead of `...` as equivalent to `substring(to:)`

### DIFF
--- a/Sources/Yams/Constructor.swift
+++ b/Sources/Yams/Constructor.swift
@@ -121,7 +121,7 @@ extension Date: ScalarConstructible {
                 nanosecond = Int($0 + String(repeating: "0", count: 9 - length))
             } else {
 #if swift(>=4.0)
-                nanosecond = Int($0[...$0.index($0.startIndex, offsetBy: 9)])
+                nanosecond = Int($0[..<$0.index($0.startIndex, offsetBy: 9)])
 #else
                 nanosecond = Int($0.substring(to: $0.index($0.startIndex, offsetBy: 9)))
 #endif

--- a/Tests/YamsTests/ConstructorTests.swift
+++ b/Tests/YamsTests/ConstructorTests.swift
@@ -351,6 +351,23 @@ class ConstructorTests: XCTestCase { // swiftlint:disable:this type_body_length
         YamsAssertEqual(objects, expected)
     }
 
+    func testTimestampWithNanosecond() throws {
+        #if os(Linux)
+            // FIXME: swift-corelibs-foundation can't format date with nanosecond.
+            // https://bugs.swift.org/browse/SR-3158
+        #else
+            let example = [
+                "nanosecond: 2001-12-15T02:59:43.123456789Z",
+                ""
+                ].joined(separator: "\n")
+            let objects = try Yams.load(yaml: example)
+            let expected: [String:Any] = [
+                "nanosecond": timestamp( 0, 2001, 12, 15, 02, 59, 43, 0.123456789)
+            ]
+            YamsAssertEqual(objects, expected)
+        #endif
+    }
+
     func testValue() throws {
         let example = [
             "---     # Old schema",

--- a/Tests/YamsTests/ConstructorTests.swift
+++ b/Tests/YamsTests/ConstructorTests.swift
@@ -413,6 +413,7 @@ extension ConstructorTests {
             ("testSet", testSet),
             ("testSeq", testSeq),
             ("testTimestamp", testTimestamp),
+            ("testTimestampWithNanosecond", testTimestampWithNanosecond),
             ("testValue", testValue)
         ]
     }

--- a/Tests/YamsTests/ConstructorTests.swift
+++ b/Tests/YamsTests/ConstructorTests.swift
@@ -356,10 +356,7 @@ class ConstructorTests: XCTestCase { // swiftlint:disable:this type_body_length
             // FIXME: swift-corelibs-foundation can't format date with nanosecond.
             // https://bugs.swift.org/browse/SR-3158
         #else
-            let example = [
-                "nanosecond: 2001-12-15T02:59:43.123456789Z",
-                ""
-                ].joined(separator: "\n")
+            let example = "nanosecond: 2001-12-15T02:59:43.123456789Z\n"
             let objects = try Yams.load(yaml: example)
             let expected: [String:Any] = [
                 "nanosecond": timestamp( 0, 2001, 12, 15, 02, 59, 43, 0.123456789)


### PR DESCRIPTION
Fix https://travis-ci.org/jpsim/Yams/jobs/263299535#L102
> Test Case '-[YamsTests.EncoderTests testEncodingDate]' started.
> fatal error: cannot increment beyond endIndex