### PR TITLE
Add `Emitter.Options.sortKeys`

### DIFF
--- a/Sources/Yams/Emitter.swift
+++ b/Sources/Yams/Emitter.swift
@@ -35,7 +35,7 @@ public func dump<Objects>(
     explicitStart: Bool = false,
     explicitEnd: Bool = false,
     version: (major: Int, minor: Int)? = nil,
-    sortedKeys: Bool = false) throws -> String
+    sortKeys: Bool = false) throws -> String
     where Objects: Sequence {
         func representable(from object: Any) throws -> NodeRepresentable {
             if let representable = object as? NodeRepresentable {
@@ -54,7 +54,7 @@ public func dump<Objects>(
             explicitStart: explicitStart,
             explicitEnd: explicitEnd,
             version: version,
-            sortedKeys: sortedKeys)
+            sortKeys: sortKeys)
 }
 
 /// Produce YAML String from object
@@ -81,7 +81,7 @@ public func dump(
     explicitStart: Bool = false,
     explicitEnd: Bool = false,
     version: (major: Int, minor: Int)? = nil,
-    sortedKeys: Bool = false) throws -> String {
+    sortKeys: Bool = false) throws -> String {
     return try serialize(
         node: object.represented(),
         canonical: canonical,
@@ -92,7 +92,7 @@ public func dump(
         explicitStart: explicitStart,
         explicitEnd: explicitEnd,
         version: version,
-        sortedKeys: sortedKeys)
+        sortKeys: sortKeys)
 }
 
 /// Produce YAML String from `Node`
@@ -119,7 +119,7 @@ public func serialize<Nodes>(
     explicitStart: Bool = false,
     explicitEnd: Bool = false,
     version: (major: Int, minor: Int)? = nil,
-    sortedKeys: Bool = false) throws -> String
+    sortKeys: Bool = false) throws -> String
     where Nodes: Sequence, Nodes.Iterator.Element == Node {
         let emitter = Emitter(
             canonical: canonical,
@@ -130,7 +130,7 @@ public func serialize<Nodes>(
             explicitStart: explicitStart,
             explicitEnd: explicitEnd,
             version: version,
-            sortedKeys: sortedKeys)
+            sortKeys: sortKeys)
         try emitter.open()
         try nodes.forEach(emitter.serialize)
         try emitter.close()
@@ -165,7 +165,7 @@ public func serialize(
     explicitStart: Bool = false,
     explicitEnd: Bool = false,
     version: (major: Int, minor: Int)? = nil,
-    sortedKeys: Bool = false) throws -> String {
+    sortKeys: Bool = false) throws -> String {
     return try serialize(
         nodes: [node],
         canonical: canonical,
@@ -176,7 +176,7 @@ public func serialize(
         explicitStart: explicitStart,
         explicitEnd: explicitEnd,
         version: version,
-        sortedKeys: sortedKeys)
+        sortKeys: sortKeys)
 }
 
 public final class Emitter {
@@ -211,7 +211,7 @@ public final class Emitter {
         public var version: (major: Int, minor: Int)?
 
         /// Set if emitter should sort keys in lexicographic order.
-        public var sortedKeys: Bool = false
+        public var sortKeys: Bool = false
     }
 
     public var options: Options {
@@ -228,7 +228,7 @@ public final class Emitter {
                 explicitStart: Bool = false,
                 explicitEnd: Bool = false,
                 version: (major: Int, minor: Int)? = nil,
-                sortedKeys: Bool = false) {
+                sortKeys: Bool = false) {
         options = Options(canonical: canonical,
                           indent: indent,
                           width: width,
@@ -237,7 +237,7 @@ public final class Emitter {
                           explicitStart: explicitStart,
                           explicitEnd: explicitEnd,
                           version: version,
-                          sortedKeys: sortedKeys)
+                          sortKeys: sortKeys)
         // configure emitter
         yaml_emitter_initialize(&emitter)
         yaml_emitter_set_output(&self.emitter, { pointer, buffer, size in
@@ -411,7 +411,7 @@ extension Emitter {
                 mapping_style)
         }
         try emit(&event)
-        if options.sortedKeys {
+        if options.sortKeys {
             try mapping.keys.sorted().forEach {
                 try self.serializeNode($0)
                 try self.serializeNode(mapping[$0]!) // swiftlint:disable:this force_unwrapping

--- a/Sources/Yams/Emitter.swift
+++ b/Sources/Yams/Emitter.swift
@@ -34,7 +34,8 @@ public func dump<Objects>(
     lineBreak: Emitter.LineBreak = .ln,
     explicitStart: Bool = false,
     explicitEnd: Bool = false,
-    version: (major: Int, minor: Int)? = nil) throws -> String
+    version: (major: Int, minor: Int)? = nil,
+    sortedKeys: Bool = false) throws -> String
     where Objects: Sequence {
         func representable(from object: Any) throws -> NodeRepresentable {
             if let representable = object as? NodeRepresentable {
@@ -52,7 +53,8 @@ public func dump<Objects>(
             lineBreak: lineBreak,
             explicitStart: explicitStart,
             explicitEnd: explicitEnd,
-            version: version)
+            version: version,
+            sortedKeys: sortedKeys)
 }
 
 /// Produce YAML String from object
@@ -78,7 +80,8 @@ public func dump(
     lineBreak: Emitter.LineBreak = .ln,
     explicitStart: Bool = false,
     explicitEnd: Bool = false,
-    version: (major: Int, minor: Int)? = nil) throws -> String {
+    version: (major: Int, minor: Int)? = nil,
+    sortedKeys: Bool = false) throws -> String {
     return try serialize(
         node: object.represented(),
         canonical: canonical,
@@ -88,7 +91,8 @@ public func dump(
         lineBreak: lineBreak,
         explicitStart: explicitStart,
         explicitEnd: explicitEnd,
-        version: version)
+        version: version,
+        sortedKeys: sortedKeys)
 }
 
 /// Produce YAML String from `Node`
@@ -114,7 +118,8 @@ public func serialize<Nodes>(
     lineBreak: Emitter.LineBreak = .ln,
     explicitStart: Bool = false,
     explicitEnd: Bool = false,
-    version: (major: Int, minor: Int)? = nil) throws -> String
+    version: (major: Int, minor: Int)? = nil,
+    sortedKeys: Bool = false) throws -> String
     where Nodes: Sequence, Nodes.Iterator.Element == Node {
         let emitter = Emitter(
             canonical: canonical,
@@ -124,7 +129,8 @@ public func serialize<Nodes>(
             lineBreak: lineBreak,
             explicitStart: explicitStart,
             explicitEnd: explicitEnd,
-            version: version)
+            version: version,
+            sortedKeys: sortedKeys)
         try emitter.open()
         try nodes.forEach(emitter.serialize)
         try emitter.close()
@@ -158,7 +164,8 @@ public func serialize(
     lineBreak: Emitter.LineBreak = .ln,
     explicitStart: Bool = false,
     explicitEnd: Bool = false,
-    version: (major: Int, minor: Int)? = nil) throws -> String {
+    version: (major: Int, minor: Int)? = nil,
+    sortedKeys: Bool = false) throws -> String {
     return try serialize(
         nodes: [node],
         canonical: canonical,
@@ -168,7 +175,8 @@ public func serialize(
         lineBreak: lineBreak,
         explicitStart: explicitStart,
         explicitEnd: explicitEnd,
-        version: version)
+        version: version,
+        sortedKeys: sortedKeys)
 }
 
 public final class Emitter {
@@ -201,6 +209,9 @@ public final class Emitter {
 
         /// The %YAML directive value or nil
         public var version: (major: Int, minor: Int)?
+
+        /// Set if emitter should sort keys in lexicographic order.
+        public var sortedKeys: Bool = false
     }
 
     public var options: Options {
@@ -216,7 +227,8 @@ public final class Emitter {
                 lineBreak: LineBreak = .ln,
                 explicitStart: Bool = false,
                 explicitEnd: Bool = false,
-                version: (major: Int, minor: Int)? = nil) {
+                version: (major: Int, minor: Int)? = nil,
+                sortedKeys: Bool = false) {
         options = Options(canonical: canonical,
                           indent: indent,
                           width: width,
@@ -224,7 +236,8 @@ public final class Emitter {
                           lineBreak: lineBreak,
                           explicitStart: explicitStart,
                           explicitEnd: explicitEnd,
-                          version: version)
+                          version: version,
+                          sortedKeys: sortedKeys)
         // configure emitter
         yaml_emitter_initialize(&emitter)
         yaml_emitter_set_output(&self.emitter, { pointer, buffer, size in
@@ -398,9 +411,16 @@ extension Emitter {
                 mapping_style)
         }
         try emit(&event)
-        try mapping.forEach {
-            try self.serializeNode($0.key)
-            try self.serializeNode($0.value)
+        if options.sortedKeys {
+            try mapping.keys.sorted().forEach {
+                try self.serializeNode($0)
+                try self.serializeNode(mapping[$0]!) // swiftlint:disable:this force_unwrapping
+            }
+        } else {
+            try mapping.forEach {
+                try self.serializeNode($0.key)
+                try self.serializeNode($0.value)
+            }
         }
         yaml_mapping_end_event_initialize(&event)
         try emit(&event)

--- a/Tests/YamsTests/EmitterTests.swift
+++ b/Tests/YamsTests/EmitterTests.swift
@@ -110,7 +110,7 @@ class EmitterTests: XCTestCase {
         }
     }
 
-    func testSortedKeys() throws {
+    func testSortKeys() throws {
         let node: Node = [
             "key3": "value3",
             "key2": "value2",
@@ -119,7 +119,7 @@ class EmitterTests: XCTestCase {
         let yaml = try Yams.serialize(node: node)
         let expected = "key3: value3\nkey2: value2\nkey1: value1\n"
         XCTAssertEqual(yaml, expected)
-        let yamlSorted = try Yams.serialize(node: node, sortedKeys: true)
+        let yamlSorted = try Yams.serialize(node: node, sortKeys: true)
         let expectedSorted = "key1: value1\nkey2: value2\nkey3: value3\n"
         XCTAssertEqual(yamlSorted, expectedSorted)
     }
@@ -133,7 +133,7 @@ extension EmitterTests {
             ("testMapping", testMapping),
             ("testLineBreaks", testLineBreaks),
             ("testAllowUnicode", testAllowUnicode),
-            ("testSortedKeys", testSortedKeys)
+            ("testSortKeys", testSortKeys)
         ]
     }
 }

--- a/Tests/YamsTests/EmitterTests.swift
+++ b/Tests/YamsTests/EmitterTests.swift
@@ -109,6 +109,20 @@ class EmitterTests: XCTestCase {
             }
         }
     }
+
+    func testSortedKeys() throws {
+        let node: Node = [
+            "key3": "value3",
+            "key2": "value2",
+            "key1": "value1"
+        ]
+        let yaml = try Yams.serialize(node: node)
+        let expected = "key3: value3\nkey2: value2\nkey1: value1\n"
+        XCTAssertEqual(yaml, expected)
+        let yamlSorted = try Yams.serialize(node: node, sortedKeys: true)
+        let expectedSorted = "key1: value1\nkey2: value2\nkey3: value3\n"
+        XCTAssertEqual(yamlSorted, expectedSorted)
+    }
 }
 
 extension EmitterTests {
@@ -118,7 +132,8 @@ extension EmitterTests {
             ("testSequence", testSequence),
             ("testMapping", testMapping),
             ("testLineBreaks", testLineBreaks),
-            ("testAllowUnicode", testAllowUnicode)
+            ("testAllowUnicode", testAllowUnicode),
+            ("testSortedKeys", testSortedKeys)
         ]
     }
 }


### PR DESCRIPTION
Set if emitter should sort keys in lexicographic order.
This will be used for stabilizing `EncoderTests.testEncodingTopLevelStructuredSingleClass` in #43 on Linux.