### PR TITLE
Apply upstream changes from libYAML

### DIFF
--- a/Sources/CYaml/include/yaml.h
+++ b/Sources/CYaml/include/yaml.h
@@ -26,7 +26,9 @@ extern "C" {
 
 /** The public API declaration. */
 
-#ifdef _WIN32
+#if defined(__MINGW32__)
+#   define  YAML_DECLARE(type)  type
+#elif defined(WIN32)
 #   if defined(YAML_DECLARE_STATIC)
 #       define  YAML_DECLARE(type)  type
 #   elif defined(YAML_DECLARE_EXPORT)

--- a/Sources/CYaml/include/yaml.h
+++ b/Sources/CYaml/include/yaml.h
@@ -663,7 +663,7 @@ yaml_event_delete(yaml_event_t *event);
 
 /** The tag @c !!null with the only possible value: @c null. */
 #define YAML_NULL_TAG       "tag:yaml.org,2002:null"
-/** The tag @c !!bool with the values: @c true and @c falce. */
+/** The tag @c !!bool with the values: @c true and @c false. */
 #define YAML_BOOL_TAG       "tag:yaml.org,2002:bool"
 /** The tag @c !!str for string values. */
 #define YAML_STR_TAG        "tag:yaml.org,2002:str"

--- a/Sources/CYaml/src/emitter.c
+++ b/Sources/CYaml/src/emitter.c
@@ -1493,7 +1493,7 @@ yaml_emitter_analyze_scalar(yaml_emitter_t *emitter,
     int break_space = 0;
     int space_break = 0;
 
-    int preceeded_by_whitespace = 0;
+    int preceded_by_whitespace = 0;
     int followed_by_whitespace = 0;
     int previous_space = 0;
     int previous_break = 0;
@@ -1524,7 +1524,7 @@ yaml_emitter_analyze_scalar(yaml_emitter_t *emitter,
         flow_indicators = 1;
     }
 
-    preceeded_by_whitespace = 1;
+    preceded_by_whitespace = 1;
     followed_by_whitespace = IS_BLANKZ_AT(string, WIDTH(string));
 
     while (string.pointer != string.end)
@@ -1570,7 +1570,7 @@ yaml_emitter_analyze_scalar(yaml_emitter_t *emitter,
                 }
             }
 
-            if (CHECK(string, '#') && preceeded_by_whitespace) {
+            if (CHECK(string, '#') && preceded_by_whitespace) {
                 flow_indicators = 1;
                 block_indicators = 1;
             }
@@ -1619,7 +1619,7 @@ yaml_emitter_analyze_scalar(yaml_emitter_t *emitter,
             previous_break = 0;
         }
 
-        preceeded_by_whitespace = IS_BLANKZ(string);
+        preceded_by_whitespace = IS_BLANKZ(string);
         MOVE(string);
         if (string.pointer != string.end) {
             followed_by_whitespace = IS_BLANKZ_AT(string, WIDTH(string));

--- a/Sources/CYaml/src/emitter.c
+++ b/Sources/CYaml/src/emitter.c
@@ -1946,10 +1946,6 @@ yaml_emitter_write_plain_scalar(yaml_emitter_t *emitter,
 
     emitter->whitespace = 0;
     emitter->indention = 0;
-    if (emitter->root_context)
-    {
-        emitter->open_ended = 1;
-    }
 
     return 1;
 }

--- a/Sources/CYaml/src/emitter.c
+++ b/Sources/CYaml/src/emitter.c
@@ -517,7 +517,7 @@ yaml_emitter_emit_stream_start(yaml_emitter_t *emitter,
         if (emitter->best_width < 0) {
             emitter->best_width = INT_MAX;
         }
-        
+
         if (!emitter->line_break) {
             emitter->line_break = YAML_LN_BREAK;
         }
@@ -607,7 +607,7 @@ yaml_emitter_emit_document_start(yaml_emitter_t *emitter,
             if (!yaml_emitter_write_indent(emitter))
                 return 0;
         }
-        
+
         if (event->data.document_start.tag_directives.start
                 != event->data.document_start.tag_directives.end) {
             implicit = 0;
@@ -721,7 +721,7 @@ yaml_emitter_emit_document_end(yaml_emitter_t *emitter,
 }
 
 /*
- * 
+ *
  * Expect a flow item node.
  */
 
@@ -1402,7 +1402,7 @@ yaml_emitter_analyze_anchor(yaml_emitter_t *emitter,
 {
     size_t anchor_length;
     yaml_string_t string;
-    
+
     anchor_length = strlen((char *)anchor);
     STRING_ASSIGN(string, anchor, anchor_length);
 
@@ -2326,4 +2326,3 @@ yaml_emitter_write_folded_scalar(yaml_emitter_t *emitter,
 
     return 1;
 }
-

--- a/Sources/CYaml/src/parser.c
+++ b/Sources/CYaml/src/parser.c
@@ -1291,7 +1291,7 @@ yaml_parser_process_directives(yaml_parser_t *parser,
         token = PEEK_TOKEN(parser);
         if (!token) goto error;
     }
-    
+
     for (default_tag_directive = default_tag_directives;
             default_tag_directive->handle; default_tag_directive++) {
         if (!yaml_parser_append_tag_directive(parser, *default_tag_directive, 1,

--- a/Sources/CYaml/src/reader.c
+++ b/Sources/CYaml/src/reader.c
@@ -52,7 +52,7 @@ yaml_parser_determine_encoding(yaml_parser_t *parser)
 {
     /* Ensure that we had enough bytes in the raw buffer. */
 
-    while (!parser->eof 
+    while (!parser->eof
             && parser->raw_buffer.last - parser->raw_buffer.pointer < 3) {
         if (!yaml_parser_update_raw_buffer(parser)) {
             return 0;
@@ -295,7 +295,7 @@ yaml_parser_update_buffer(yaml_parser_t *parser, size_t length)
                                 parser->offset, value);
 
                     break;
-                
+
                 case YAML_UTF16LE_ENCODING:
                 case YAML_UTF16BE_ENCODING:
 
@@ -318,7 +318,7 @@ yaml_parser_update_buffer(yaml_parser_t *parser, size_t length)
                      *
                      * The following formulas are used for decoding
                      * and encoding characters using surrogate pairs:
-                     * 
+                     *
                      *  U  = U' + 0x10000   (0x01 00 00 <= U <= 0x10 FF FF)
                      *  U' = yyyyyyyyyyxxxxxxxxxx   (0 <= U' <= 0x0F FF FF)
                      *  W1 = 110110yyyyyyyyyy

--- a/Sources/CYaml/src/scanner.c
+++ b/Sources/CYaml/src/scanner.c
@@ -70,7 +70,7 @@
  *      %TAG    !yaml!  tag:yaml.org,2002:
  *      ---
  *
- * The correspoding sequence of tokens:
+ * The corresponding sequence of tokens:
  *
  *      STREAM-START(utf-8)
  *      VERSION-DIRECTIVE(1,1)
@@ -1252,7 +1252,7 @@ yaml_parser_roll_indent(yaml_parser_t *parser, ptrdiff_t column,
 
 /*
  * Pop indentation levels from the indents stack until the current level
- * becomes less or equal to the column.  For each intendation level, append
+ * becomes less or equal to the column.  For each indentation level, append
  * the BLOCK-END token.
  */
 
@@ -1267,7 +1267,7 @@ yaml_parser_unroll_indent(yaml_parser_t *parser, ptrdiff_t column)
     if (parser->flow_level)
         return 1;
 
-    /* Loop through the intendation levels in the stack. */
+    /* Loop through the indentation levels in the stack. */
 
     while (parser->indent > column)
     {
@@ -1939,7 +1939,7 @@ yaml_parser_scan_to_next_token(yaml_parser_t *parser)
          *
          *  - in the flow context;
          *  - in the block context, but not at the beginning of the line or
-         *  after '-', '?', or ':' (complex value).  
+         *  after '-', '?', or ':' (complex value).
          */
 
         if (!CACHE(parser, 1)) return 0;
@@ -2054,7 +2054,7 @@ yaml_parser_scan_directive(yaml_parser_t *parser, yaml_token_t *token)
     else
     {
         yaml_parser_set_scanner_error(parser, "while scanning a directive",
-                start_mark, "found uknown directive name");
+                start_mark, "found unknown directive name");
         goto error;
     }
 
@@ -2776,15 +2776,15 @@ yaml_parser_scan_block_scalar(yaml_parser_t *parser, yaml_token_t *token,
 
         if (IS_DIGIT(parser->buffer))
         {
-            /* Check that the intendation is greater than 0. */
+            /* Check that the indentation is greater than 0. */
 
             if (CHECK(parser->buffer, '0')) {
                 yaml_parser_set_scanner_error(parser, "while scanning a block scalar",
-                        start_mark, "found an intendation indicator equal to 0");
+                        start_mark, "found an indentation indicator equal to 0");
                 goto error;
             }
 
-            /* Get the intendation level and eat the indicator. */
+            /* Get the indentation level and eat the indicator. */
 
             increment = AS_DIGIT(parser->buffer);
 
@@ -2798,7 +2798,7 @@ yaml_parser_scan_block_scalar(yaml_parser_t *parser, yaml_token_t *token,
     {
         if (CHECK(parser->buffer, '0')) {
             yaml_parser_set_scanner_error(parser, "while scanning a block scalar",
-                    start_mark, "found an intendation indicator equal to 0");
+                    start_mark, "found an indentation indicator equal to 0");
             goto error;
         }
 
@@ -2848,7 +2848,7 @@ yaml_parser_scan_block_scalar(yaml_parser_t *parser, yaml_token_t *token,
 
     end_mark = parser->mark;
 
-    /* Set the intendation level if it was specified. */
+    /* Set the indentation level if it was specified. */
 
     if (increment) {
         indent = parser->indent >= 0 ? parser->indent+increment : increment;
@@ -2914,7 +2914,7 @@ yaml_parser_scan_block_scalar(yaml_parser_t *parser, yaml_token_t *token,
 
         if (!READ_LINE(parser, leading_break)) goto error;
 
-        /* Eat the following intendation spaces and line breaks. */
+        /* Eat the following indentation spaces and line breaks. */
 
         if (!yaml_parser_scan_block_scalar_breaks(parser,
                     &indent, &trailing_breaks, start_mark, &end_mark)) goto error;
@@ -2949,8 +2949,8 @@ error:
 }
 
 /*
- * Scan intendation spaces and line breaks for a block scalar.  Determine the
- * intendation level if needed.
+ * Scan indentation spaces and line breaks for a block scalar.  Determine the
+ * indentation level if needed.
  */
 
 static int
@@ -2962,11 +2962,11 @@ yaml_parser_scan_block_scalar_breaks(yaml_parser_t *parser,
 
     *end_mark = parser->mark;
 
-    /* Eat the intendation spaces and line breaks. */
+    /* Eat the indentation spaces and line breaks. */
 
     while (1)
     {
-        /* Eat the intendation spaces. */
+        /* Eat the indentation spaces. */
 
         if (!CACHE(parser, 1)) return 0;
 
@@ -2979,12 +2979,12 @@ yaml_parser_scan_block_scalar_breaks(yaml_parser_t *parser,
         if ((int)parser->mark.column > max_indent)
             max_indent = (int)parser->mark.column;
 
-        /* Check for a tab character messing the intendation. */
+        /* Check for a tab character messing the indentation. */
 
         if ((!*indent || (int)parser->mark.column < *indent)
                 && IS_TAB(parser->buffer)) {
             return yaml_parser_set_scanner_error(parser, "while scanning a block scalar",
-                    start_mark, "found a tab character where an intendation space is expected");
+                    start_mark, "found a tab character where an indentation space is expected");
         }
 
         /* Have we found a non-empty line? */
@@ -3505,12 +3505,12 @@ yaml_parser_scan_plain_scalar(yaml_parser_t *parser, yaml_token_t *token)
         {
             if (IS_BLANK(parser->buffer))
             {
-                /* Check for tab character that abuse intendation. */
+                /* Check for tab character that abuse indentation. */
 
                 if (leading_blanks && (int)parser->mark.column < indent
                         && IS_TAB(parser->buffer)) {
                     yaml_parser_set_scanner_error(parser, "while scanning a plain scalar",
-                            start_mark, "found a tab character that violate intendation");
+                            start_mark, "found a tab character that violate indentation");
                     goto error;
                 }
 
@@ -3543,7 +3543,7 @@ yaml_parser_scan_plain_scalar(yaml_parser_t *parser, yaml_token_t *token)
             if (!CACHE(parser, 1)) goto error;
         }
 
-        /* Check intendation level. */
+        /* Check indentation level. */
 
         if (!parser->flow_level && (int)parser->mark.column < indent)
             break;

--- a/Sources/CYaml/src/scanner.c
+++ b/Sources/CYaml/src/scanner.c
@@ -3163,6 +3163,10 @@ yaml_parser_scan_flow_scalar(yaml_parser_t *parser, yaml_token_t *token,
                         *(string.pointer++) = '"';
                         break;
 
+                    case '/':
+                        *(string.pointer++) = '/';
+                        break;
+
                     case '\'':
                         *(string.pointer++) = '\'';
                         break;

--- a/Sources/CYaml/src/scanner.c
+++ b/Sources/CYaml/src/scanner.c
@@ -3285,6 +3285,11 @@ yaml_parser_scan_flow_scalar(yaml_parser_t *parser, yaml_token_t *token,
 
         /* Check if we are at the end of the scalar. */
 
+        /* Fix for crash unitialized value crash
+         * Credit for the bug and input is to OSS Fuzz
+         * Credit for the fix to Alex Gaynor
+         */
+        if (!CACHE(parser, 1)) goto error;
         if (CHECK(parser->buffer, single ? '\'' : '"'))
             break;
 

--- a/Sources/CYaml/src/scanner.c
+++ b/Sources/CYaml/src/scanner.c
@@ -762,7 +762,7 @@ yaml_parser_scan(yaml_parser_t *parser, yaml_token_t *token)
     }
 
     /* Fetch the next token from the queue. */
-    
+
     *token = DEQUEUE(parser, parser->tokens);
     parser->token_available = 0;
     parser->tokens_parsed ++;
@@ -1114,7 +1114,7 @@ yaml_parser_save_simple_key(yaml_parser_t *parser)
         yaml_simple_key_t simple_key;
         simple_key.possible = 1;
         simple_key.required = required;
-        simple_key.token_number = 
+        simple_key.token_number =
             parser->tokens_parsed + (parser->tokens.tail - parser->tokens.head);
         simple_key.mark = parser->mark;
 
@@ -1198,7 +1198,7 @@ yaml_parser_decrease_flow_level(yaml_parser_t *parser)
  * Push the current indentation level to the stack and set the new level
  * the current column is greater than the indentation level.  In this case,
  * append or insert the specified token into the token queue.
- * 
+ *
  */
 
 static int
@@ -3008,7 +3008,7 @@ yaml_parser_scan_block_scalar_breaks(yaml_parser_t *parser,
             *indent = 1;
     }
 
-   return 1; 
+   return 1;
 }
 
 /*
@@ -3574,4 +3574,3 @@ error:
 
     return 0;
 }
-

--- a/Sources/CYaml/src/writer.c
+++ b/Sources/CYaml/src/writer.c
@@ -74,7 +74,7 @@ yaml_emitter_flush(yaml_emitter_t *emitter)
         unsigned int value;
         size_t k;
 
-        /* 
+        /*
          * See the "reader.c" code for more details on UTF-8 encoding.  Note
          * that we assume that the buffer contains a valid UTF-8 sequence.
          */

--- a/Sources/CYaml/src/yaml_private.h
+++ b/Sources/CYaml/src/yaml_private.h
@@ -1,4 +1,3 @@
-
 #if HAVE_CONFIG_H
 #include <config.h>
 #endif
@@ -242,9 +241,9 @@ yaml_string_join(
         (string).pointer[offset] <= (yaml_char_t) 'f') ?                        \
        ((string).pointer[offset] - (yaml_char_t) 'a' + 10) :                    \
        ((string).pointer[offset] - (yaml_char_t) '0'))
- 
+
 #define AS_HEX(string)  AS_HEX_AT((string),0)
- 
+
 /*
  * Check if the character is ASCII.
  */
@@ -657,4 +656,3 @@ yaml_queue_extend(void **start, void **head, void **tail, void **end);
      (node).data.mapping.pairs.end = (node_pairs_end),                          \
      (node).data.mapping.pairs.top = (node_pairs_start),                        \
      (node).data.mapping.style = (node_style))
-

--- a/Tests/YamsTests/EmitterTests.swift
+++ b/Tests/YamsTests/EmitterTests.swift
@@ -14,7 +14,7 @@ class EmitterTests: XCTestCase {
     func testScalar() throws {
         var node: Node = "key"
 
-        let expectedAnyAndPlain = "key\n...\n"
+        let expectedAnyAndPlain = "key\n"
         node.scalar?.style = .any
         XCTAssertEqual(try Yams.serialize(node: node), expectedAnyAndPlain)
         node.scalar?.style = .plain
@@ -69,7 +69,6 @@ class EmitterTests: XCTestCase {
         let node: Node = "key"
         let expected = [
             "key",
-            "...",
             ""
         ]
         XCTAssertEqual(try Yams.serialize(node: node, lineBreak: .ln),
@@ -90,7 +89,7 @@ class EmitterTests: XCTestCase {
             }
             do {
                 let yaml = try Yams.serialize(node: node, allowUnicode: true)
-                let expected = "あ\n...\n"
+                let expected = "あ\n"
                 XCTAssertEqual(yaml, expected)
             }
         }

--- a/Tests/YamsTests/EncoderTests.swift
+++ b/Tests/YamsTests/EncoderTests.swift
@@ -28,16 +28,16 @@ class EncoderTests: XCTestCase {
 
     // MARK: - Encoding Top-Level Single-Value Types
     func testEncodingTopLevelSingleValueEnum() {
-        _testRoundTrip(of: Switch.off, expectedYAML: "false\n...\n")
-        _testRoundTrip(of: Switch.on, expectedYAML: "true\n...\n")
+        _testRoundTrip(of: Switch.off, expectedYAML: "false\n")
+        _testRoundTrip(of: Switch.on, expectedYAML: "true\n")
     }
 
     func testEncodingTopLevelSingleValueStruct() {
-        _testRoundTrip(of: Timestamp(3141592653), expectedYAML: "3.141592653e+9\n...\n")
+        _testRoundTrip(of: Timestamp(3141592653), expectedYAML: "3.141592653e+9\n")
     }
 
     func testEncodingTopLevelSingleValueClass() {
-        _testRoundTrip(of: Counter(), expectedYAML: "0\n...\n")
+        _testRoundTrip(of: Counter(), expectedYAML: "0\n")
     }
 
     // MARK: - Encoding Top-Level Structured Types
@@ -113,9 +113,9 @@ class EncoderTests: XCTestCase {
 
     func testEncodingTopLevelNullableType() {
         // EnhancedBool is a type which encodes either as a Bool or as nil.
-        _testRoundTrip(of: EnhancedBool.true, expectedYAML: "true\n...\n")
-        _testRoundTrip(of: EnhancedBool.false, expectedYAML: "false\n...\n")
-        _testRoundTrip(of: EnhancedBool.fileNotFound, expectedYAML: "null\n...\n")
+        _testRoundTrip(of: EnhancedBool.true, expectedYAML: "true\n")
+        _testRoundTrip(of: EnhancedBool.false, expectedYAML: "false\n")
+        _testRoundTrip(of: EnhancedBool.fileNotFound, expectedYAML: "null\n")
     }
 
     // MARK: - Date Strategy Tests
@@ -131,13 +131,13 @@ class EncoderTests: XCTestCase {
     #if os(Linux)
         print("Decoding 'Date' has issue on Linux with nanoseconds. https://bugs.swift.org/browse/SR-6223")
     #else
-        _testRoundTrip(of: Date(timeIntervalSince1970: 1000.0), expectedYAML: "1970-01-01T00:16:40Z\n...\n")
+        _testRoundTrip(of: Date(timeIntervalSince1970: 1000.0), expectedYAML: "1970-01-01T00:16:40Z\n")
     #endif
     }
 
     // MARK: - Data Tests
     func testEncodingBase64Data() {
-        _testRoundTrip(of: Data(bytes: [0xDE, 0xAD, 0xBE, 0xEF]), expectedYAML: "3q2+7w==\n...\n")
+        _testRoundTrip(of: Data(bytes: [0xDE, 0xAD, 0xBE, 0xEF]), expectedYAML: "3q2+7w==\n")
     }
 
     // MARK: - Encoder Features

--- a/Tests/YamsTests/SpecTests.swift
+++ b/Tests/YamsTests/SpecTests.swift
@@ -476,11 +476,7 @@ class SpecTests: XCTestCase { // swiftlint:disable:this type_body_length
         YamsAssertEqual(object, expectedObject)
 
         let yaml = try Yams.dump(object: object)
-        let expectedYaml = [
-            "Mark McGwire's year was crippled by a knee injury.",
-            "...",
-            ""
-        ].joined(separator: "\n")
+        let expectedYaml = "Mark McGwire's year was crippled by a knee injury.\n"
         XCTAssertEqual(yaml, expectedYaml)
     }
 


### PR DESCRIPTION
Notable changes:
- The behavior of `yaml_emitter_write_plain_scalar()` changed by c92e72df1c5fe6e090198ad14bb06b2f5b678577.
The end of document indicator no longer attached when emmitting a single scalar.