### PR TITLE
Change access level of `compactMap()` from `public` to `internal`

### DIFF
--- a/Sources/Yams/shim.swift
+++ b/Sources/Yams/shim.swift
@@ -8,18 +8,6 @@
 
 #if (!swift(>=4.1) && swift(>=4.0)) || !swift(>=3.3)
 
-    extension Array {
-        func compactMap(_ transform: (Element) throws -> String?) rethrows -> [String] {
-            return try flatMap(transform)
-        }
-    }
-
-    extension LazyMapCollection {
-        func compactMap(_ transform: (Element) throws -> String?) rethrows -> [String] {
-            return try flatMap(transform)
-        }
-    }
-
     extension Sequence {
         func compactMap<ElementOfResult>(
             _ transform: (Self.Element

--- a/Sources/Yams/shim.swift
+++ b/Sources/Yams/shim.swift
@@ -9,19 +9,19 @@
 #if !swift(>=4.1)
 
     extension Array {
-        public func compactMap(_ transform: (Element) throws -> String?) rethrows -> [String] {
+        func compactMap(_ transform: (Element) throws -> String?) rethrows -> [String] {
             return try flatMap(transform)
         }
     }
 
     extension LazyMapCollection {
-        public func compactMap(_ transform: (Element) throws -> String?) rethrows -> [String] {
+        func compactMap(_ transform: (Element) throws -> String?) rethrows -> [String] {
             return try flatMap(transform)
         }
     }
 
     extension Sequence {
-        public func compactMap<ElementOfResult>(
+        func compactMap<ElementOfResult>(
             _ transform: (Self.Element
             ) throws -> ElementOfResult?) rethrows -> [ElementOfResult] {
             return try flatMap(transform)

--- a/Sources/Yams/shim.swift
+++ b/Sources/Yams/shim.swift
@@ -6,7 +6,7 @@
 //  Copyright (c) 2018 Yams. All rights reserved.
 //
 
-#if !swift(>=4.1)
+#if (!swift(>=4.1) && swift(>=4.0)) || !swift(>=3.3)
 
     extension Array {
         func compactMap(_ transform: (Element) throws -> String?) rethrows -> [String] {


### PR DESCRIPTION
It will avoid interfering with the `compactMap` definition in the dependent packages such as SourceKitten.