### PR TITLE
Change `subscript(string:)` to create `Node` from string using their own resolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,23 @@
+## master
+
+##### Breaking
+
+* None.
+
+##### Enhancements
+
+* None.
+
+##### Bug Fixes
+
+* `subscript(string:)` fails to lookup value if `Node` has non default `Resolver`.  
+  [Norio Nomura](https://github.com/norio-nomura)
+  [#100](https://github.com/jpsim/Yams/issues/100)
+
+* Removed asserts in Constructor that were stopping the YAMLDecoder from returning correct errors.  
+  [David Hart](https://github.com/hartbit)
+  [#94](https://github.com/jpsim/Yams/pull/94)
+
 ## 0.5.0
 
 ##### Breaking

--- a/Sources/Yams/Node.Mapping.swift
+++ b/Sources/Yams/Node.Mapping.swift
@@ -115,10 +115,10 @@ extension Node.Mapping {
 
     public subscript(string: String) -> Node? {
         get {
-            return self[Node(string)]
+            return self[Node(string, tag.copy(with: .implicit))]
         }
         set {
-            self[Node(string)] = newValue
+            self[Node(string, tag.copy(with: .implicit))] = newValue
         }
     }
 

--- a/Sources/Yams/Node.swift
+++ b/Sources/Yams/Node.swift
@@ -140,10 +140,10 @@ extension Node {
 
     public subscript(string: String) -> Node? {
         get {
-            return self[Node(string)]
+            return self[Node(string, tag.copy(with: .implicit))]
         }
         set {
-            self[Node(string)] = newValue
+            self[Node(string, tag.copy(with: .implicit))] = newValue
         }
     }
 }

--- a/Sources/Yams/Tag.swift
+++ b/Sources/Yams/Tag.swift
@@ -23,10 +23,6 @@ public final class Tag {
         return Tag(.implicit)
     }
 
-    // internal
-    let constructor: Constructor
-    var name: Name
-
     public init(_ name: Name,
                 _ resolver: Resolver = .default,
                 _ constructor: Constructor = .default) {
@@ -34,6 +30,14 @@ public final class Tag {
         self.constructor = constructor
         self.name = name
     }
+
+    public func copy(with name: Name? = nil, resolver: Resolver? = nil, constructor: Constructor? = nil) -> Tag {
+        return .init(name ?? self.name, resolver ?? self.resolver, constructor ?? self.constructor)
+    }
+
+    // internal
+    let constructor: Constructor
+    var name: Name
 
     func resolved<T>(with value: T) -> Tag where T: TagResolvable {
         if name == .implicit {

--- a/Tests/YamsTests/EncoderTests.swift
+++ b/Tests/YamsTests/EncoderTests.swift
@@ -232,6 +232,13 @@ class EncoderTests: XCTestCase {
         ))
     }
 
+    func testDictionary() throws {
+        // https://github.com/jpsim/Yams/issues/99
+        let yaml = "'200': ok"
+        let decodedYaml = try YAMLDecoder().decode([String: String].self, from: yaml)
+        XCTAssertEqual(decodedYaml, ["200": "ok"])
+    }
+
     // MARK: - Helper Functions
     private func _testEncodeFailure<T: Encodable>(of value: T) {
         do {
@@ -999,7 +1006,8 @@ extension EncoderTests {
             ("testInterceptURL", testInterceptURL),
             ("testValuesInSingleValueContainer", testValuesInSingleValueContainer),
             ("testValuesInKeyedContainer", testValuesInKeyedContainer),
-            ("testValuesInUnkeyedContainer", testValuesInUnkeyedContainer)
+            ("testValuesInUnkeyedContainer", testValuesInUnkeyedContainer),
+            ("testDictionary", testDictionary)
         ]
     }
 }

--- a/Tests/YamsTests/NodeTests.swift
+++ b/Tests/YamsTests/NodeTests.swift
@@ -123,6 +123,12 @@ class NodeTests: XCTestCase {
         XCTAssertEqual(mapping[Int(2)]?.string, "value3")    // Int
     }
 
+    func testSubscriptWithNonDefaultResolver() {
+        let yaml = "200: value"
+        XCTAssertEqual(try Yams.compose(yaml: yaml)?["200"]?.string, "value")
+        XCTAssertEqual(try Yams.compose(yaml: yaml, .basic)?["200"]?.string, "value")
+    }
+
     func testMappingBehavesLikeADictionary() {
         let node: Node = ["key1": "value1", "key2": "value2"]
         let mapping = node.mapping!
@@ -207,6 +213,7 @@ extension NodeTests {
             ("testArray", testArray),
             ("testSubscriptMapping", testSubscriptMapping),
             ("testSubscriptSequence", testSubscriptSequence),
+            ("testSubscriptWithNonDefaultResolver", testSubscriptWithNonDefaultResolver),
             ("testMappingBehavesLikeADictionary", testMappingBehavesLikeADictionary),
             ("testSequenceBehavesLikeAnArray", testSequenceBehavesLikeAnArray),
             ("testScalar", testScalar)


### PR DESCRIPTION
fixes #100 