### PR TITLE
Fix caching in Xcode jobs on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,10 +15,10 @@ aliases:
           path: build/reports/
       - run: echo "ruby-2.3" > ~/.ruby-version
       - restore_cache:
-          key: 1-gems-{{ checksum "Gemfile.lock" }}
+          key: 1-gems-{{ .Environment.CIRCLE_JOB }}-{{ checksum "Gemfile.lock" }}
       - run: bundle check --path vendor/bundle || bundle install --path vendor/bundle
       - save_cache:
-          key: 1-gems-{{ checksum "Gemfile.lock" }}
+          key: 1-gems-{{ .Environment.CIRCLE_JOB }}-{{ checksum "Gemfile.lock" }}
           paths:
             - vendor/bundle
       - run: bundle exec pod lib lint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ aliases:
       - run: echo "ruby-2.3" > ~/.ruby-version
       - restore_cache:
           key: 1-gems-{{ checksum "Gemfile.lock" }}
-      - run: bundle check || bundle install --path vendor/bundle
+      - run: bundle check --path vendor/bundle || bundle install --path vendor/bundle
       - save_cache:
           key: 1-gems-{{ checksum "Gemfile.lock" }}
           paths:


### PR DESCRIPTION
- Add option to `bundle check` in Xcode job  
  This caused executing `bundle install` even if the Gemfile's dependencies are satisfied.
- Use job name to cache key in Xcode job  
  Ruby Native Extensions are built and placed at path `vendor/bundle/ruby/<ruby version>/extensions/<arch>-<platform>`.
On macOS, `<platform>` includes darwin version number, e.g. High Sierra is `darwin-17`, Sierra is `darwin-16`.
So, when cache is saved on High Sierra, `bundle install` causes rebuilding Native Extensions on Sierra, even if restored cache.
This reduces duration of `bundle install --path vendor/bundle` step about 38 seconds in each Xcode 9, Xcode 9.1 and Xcode 9.2 jobs.