### PR TITLE
Fix identifier_name violations and re-enable rule

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -3,8 +3,6 @@ included:
   - Tests
 analyzer_rules:
   - unused_import
-disabled_rules:
-  - identifier_name
 line_length: 120
 identifier_name:
   excluded:

--- a/Sources/Yams/Emitter.swift
+++ b/Sources/Yams/Emitter.swift
@@ -411,7 +411,7 @@ extension Emitter {
 
     private func serializeScalar(_ scalar: Node.Scalar) throws {
         var value = scalar.string.utf8CString, tag = scalar.resolvedTag.name.rawValue.utf8CString
-        let scalar_style = yaml_scalar_style_t(rawValue: scalar.style.rawValue)
+        let scalarStyle = yaml_scalar_style_t(rawValue: scalar.style.rawValue)
         var event = yaml_event_t()
         _ = value.withUnsafeMutableBytes { value in
             tag.withUnsafeMutableBytes { tag in
@@ -423,7 +423,7 @@ extension Emitter {
                     Int32(value.count - 1),
                     1,
                     1,
-                    scalar_style)
+                    scalarStyle)
             }
         }
         try emit(&event)
@@ -432,7 +432,7 @@ extension Emitter {
     private func serializeSequence(_ sequence: Node.Sequence) throws {
         var tag = sequence.resolvedTag.name.rawValue.utf8CString
         let implicit: Int32 = sequence.tag.name == .seq ? 1 : 0
-        let sequence_style = yaml_sequence_style_t(rawValue: sequence.style.rawValue)
+        let sequenceStyle = yaml_sequence_style_t(rawValue: sequence.style.rawValue)
         var event = yaml_event_t()
         _ = tag.withUnsafeMutableBytes { tag in
             yaml_sequence_start_event_initialize(
@@ -440,7 +440,7 @@ extension Emitter {
                 nil,
                 tag.baseAddress?.assumingMemoryBound(to: UInt8.self),
                 implicit,
-                sequence_style)
+                sequenceStyle)
         }
         try emit(&event)
         try sequence.forEach(self.serializeNode)
@@ -451,7 +451,7 @@ extension Emitter {
     private func serializeMapping(_ mapping: Node.Mapping) throws {
         var tag = mapping.resolvedTag.name.rawValue.utf8CString
         let implicit: Int32 = mapping.tag.name == .map ? 1 : 0
-        let mapping_style = yaml_mapping_style_t(rawValue: mapping.style.rawValue)
+        let mappingStyle = yaml_mapping_style_t(rawValue: mapping.style.rawValue)
         var event = yaml_event_t()
         _ = tag.withUnsafeMutableBytes { tag in
             yaml_mapping_start_event_initialize(
@@ -459,7 +459,7 @@ extension Emitter {
                 nil,
                 tag.baseAddress?.assumingMemoryBound(to: UInt8.self),
                 implicit,
-                mapping_style)
+                mappingStyle)
         }
         try emit(&event)
         if options.sortKeys {

--- a/Tests/YamsTests/MarkTests.swift
+++ b/Tests/YamsTests/MarkTests.swift
@@ -35,9 +35,9 @@ class MarkTests: XCTestCase {
               min_length: 2
             """
         let configuration = try Yams.compose(yaml: yaml)
-        let disabled_rules = configuration?.mapping?["disabled_rules"]?.array() ?? []
-        let configured_rules = configuration?.mapping?.keys.filter({ $0 != "disabled_rules" }) ?? []
-        let deprecatedMessages = (disabled_rules + configured_rules).compactMap(deprecatedMessage(from:))
+        let disabledRules = configuration?.mapping?["disabled_rules"]?.array() ?? []
+        let configuredRules = configuration?.mapping?.keys.filter({ $0 != "disabled_rules" }) ?? []
+        let deprecatedMessages = (disabledRules + configuredRules).compactMap(deprecatedMessage(from:))
         XCTAssertEqual(deprecatedMessages, [
             "2:5: warning: 'variable_name' has been renamed to " +
                 "'identifier_name' and will be completely removed in a future release.",

--- a/Tests/YamsTests/TestHelper.swift
+++ b/Tests/YamsTests/TestHelper.swift
@@ -65,11 +65,11 @@ func timestamp(_ timeZoneHour: Int = 0,
 /// - parameter line: line number
 ///
 /// - returns: true if lhs is equal to rhs
-
-@discardableResult func YamsAssertEqual(_ lhs: Any?, _ rhs: Any?,
-                                        // swiftlint:disable:previous function_body_length
-                                        _ context: @autoclosure @escaping () -> String = "",
-                                        file: StaticString = #file, line: UInt = #line) -> Bool {
+@discardableResult
+func YamsAssertEqual(_ lhs: Any?, _ rhs: Any?,
+                     // swiftlint:disable:previous function_body_length identifier_name
+                     _ context: @autoclosure @escaping () -> String = "",
+                     file: StaticString = #file, line: UInt = #line) -> Bool {
     // use inner function for capturing `file` and `line`
     // swiftlint:disable:next cyclomatic_complexity function_body_length
     @discardableResult func equal(_ lhs: Any?, _ rhs: Any?,


### PR DESCRIPTION
Ideally it'd be nice to fail CI if any SwiftLint violations are added other than FIXME/TODO. After this PR, there's just one other violation (file length in `Parser.swift`).