### PR TITLE
Lint for unused private declarations

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -3,6 +3,7 @@ included:
   - Tests
 analyzer_rules:
   - unused_import
+  - unused_private_declaration
 line_length: 120
 identifier_name:
   excluded:

--- a/Sources/Yams/Emitter.swift
+++ b/Sources/Yams/Emitter.swift
@@ -478,5 +478,4 @@ extension Emitter {
     }
 }
 
-private let isLittleEndian = 1 == 1.littleEndian
 // swiftlint:disable:this file_length

--- a/Tests/YamsTests/EncoderTests.swift
+++ b/Tests/YamsTests/EncoderTests.swift
@@ -248,6 +248,8 @@ class EncoderTests: XCTestCase { // swiftlint:disable:this type_body_length
     func testNodeTypeMismatch() throws {
         // https://github.com/jpsim/Yams/pull/95
         struct Sample: Decodable {
+            // Used for its decodable behavior, even though it's not referenced directly.
+            // swiftlint:disable:next unused_private_declaration
             let values: [String]
         }
 
@@ -315,12 +317,6 @@ class EncoderTests: XCTestCase { // swiftlint:disable:this type_body_length
     }
 
     // MARK: - Helper Functions
-    private func _testEncodeFailure<T: Encodable>(of value: T) {
-        do {
-            _ = try JSONEncoder().encode(value)
-            expectUnreachable("Encode of top-level \(T.self) was expected to fail.")
-        } catch {}
-    }
 
     private func _testRoundTrip<T>(of value: T,
                                    with options: YAMLEncoder.Options = .init(),

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -178,7 +178,7 @@ jobs:
       displayName: xcode-select
     - script: xcodebuild -scheme Yams clean build-for-testing > xcodebuild.log
       displayName: Generate xcodebuild.log
-    - script: HOMEBREW_NO_AUTO_UPDATE=1 brew install https://raw.github.com/Homebrew/homebrew-core/master/Formula/swiftlint.rb
+    - script: HOMEBREW_NO_AUTO_UPDATE=1 brew install --HEAD https://raw.github.com/Homebrew/homebrew-core/master/Formula/swiftlint.rb
       displayName: Install SwiftLint
     - script: swiftlint analyze --strict --compiler-log-path xcodebuild.log
       displayName: Run SwiftLint Analyze

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -170,7 +170,7 @@ jobs:
     - script: pod lib lint
       displayName: pod lib lint
 
-- job: Unused_Imports
+- job: Analyze
   pool:
     vmImage: 'macOS 10.13'
   steps:


### PR DESCRIPTION
Remove two unused declarations and silence an intentional violation.

Also rename Unused_Imports CI job to Analyze to reflect its expanded
responsibilities.