### PR TITLE
Update `Data.withUnsafeBytes(_:)` taking `(UnsafeRawBufferPointer) throws -> Result`

### DIFF
--- a/Sources/Yams/Parser.swift
+++ b/Sources/Yams/Parser.swift
@@ -405,7 +405,7 @@ private func string(from pointer: UnsafePointer<UInt8>!) -> String? {
 }
 
 #if swift(>=4.2)
-#if !compiler(>=5) || !canImport(Darwin)
+#if !compiler(>=5) || (canImport(Darwin) && !canImport(SwiftLang)) // missing on Xcode 10.2 beta 1
 private extension Data {
     func withUnsafeBytes<Result>(_ apply: (UnsafeRawBufferPointer) throws -> Result) rethrows -> Result {
         return try withUnsafeBytes {


### PR DESCRIPTION
- Implemented on `swift-5.0-DEVELOPMENT-SNAPSHOT-2018-12-16-a` for macOS
- implemented on `swift-5.0-DEVELOPMENT-SNAPSHOT-2019-01-28-a` with swift-corelibs-foundation
- Not implemented on Xcode 10.2 beta 1 `(canImport(Darwin) && !canImport(SwiftLang))`

This makes it possible to build with Xcode 10.2 beta 1.