### PR TITLE
[yams-1.0-branch] Remove codes detecting SR-9454

### DIFF
--- a/Tests/YamsTests/StringTests.swift
+++ b/Tests/YamsTests/StringTests.swift
@@ -18,8 +18,6 @@ class StringTests: XCTestCase {
 
     // Confirm behavior of Standard Library API
     func testConfirmBehaviorOfStandardLibraryAPI() {
-        guard !doesSR9454Affect() else { return }
-
         let rangeOfFirstLine = string.lineRange(for: string.startIndex..<string.startIndex)
         let firstLine = string[rangeOfFirstLine]
         XCTAssertEqual(firstLine, "LINE1_67あ\n")
@@ -27,8 +25,6 @@ class StringTests: XCTestCase {
 
     // `String.utf8LineNumberColumnAndContents(at:)`
     func testUTF8LineNumberColumnAndContentsAtOffset() {
-        guard !doesSR9454Affect() else { return }
-
         // offset     0 1 2 3 4 5 6 7 8 9 10 11
         // line 1     L I N E 1 _ 6 7 あ     \n
         // line 2     L I N E 2 _ 7 8 9 0 \n
@@ -55,8 +51,6 @@ class StringTests: XCTestCase {
 
     // `String.utf16LineNumberColumnAndContents(at:)`
     func testUTF16LineNumberColumnAndContentsAtOffset() {
-        guard !doesSR9454Affect() else { return }
-
         // offset     0 1 2 3 4 5 6 7 8 9 10
         // line 1     L I N E 1 _ 6 7 あ \n
         // line 2     L I N E 2 _ 7 8 9 0 \n
@@ -83,8 +77,6 @@ class StringTests: XCTestCase {
 
     // `String.substring(at:)`
     func testSubstringAtLine() {
-        guard !doesSR9454Affect() else { return }
-
         let scecondLine = string.substring(at: 1)
         XCTAssertEqual(scecondLine, "LINE2_7890\n")
     }

--- a/Tests/YamsTests/TestHelper.swift
+++ b/Tests/YamsTests/TestHelper.swift
@@ -12,29 +12,6 @@ import CDispatch
 import Foundation
 import XCTest
 
-/// https://bugs.swift.org/browse/SR-9454
-func doesSR9454Affect(to name: String = #function) -> Bool {
-#if swift(>=4.1.50)
-#if compiler(>=5) && !_runtime(_ObjC)
-    let string = "LINE1_67あ\nLINE2_7890\nLINE3_8901\n"
-    let rangeOfFirstLine = string.lineRange(for: string.startIndex..<string.startIndex)
-    let result = "\(rangeOfFirstLine)"
-    let expected = "Index(_rawBits: 0)..<Index(_rawBits: 786432)"
-    XCTAssertNotEqual(result, expected, "https://bugs.swift.org/browse/SR-9454 seems to be fixed")
-    if result != expected {
-        print("Skip `\(name)` since that is affected by https://bugs.swift.org/browse/SR-9454")
-        return true
-    } else {
-        return false
-    }
-#else
-    return false
-#endif
-#else
-    return false
-#endif
-}
-
 func timestamp(_ timeZoneHour: Int = 0,
                _ year: Int? = nil,
                _ month: Int? = nil,

--- a/Tests/YamsTests/YamlErrorTests.swift
+++ b/Tests/YamsTests/YamlErrorTests.swift
@@ -18,8 +18,6 @@ class YamlErrorTests: XCTestCase {
     }
 
     func testYamlErrorReader() throws {
-        guard !doesSR9454Affect() else { return }
-
         // reader
         let yaml = "test: 'テスト\u{12}'"
         XCTAssertThrowsError(_ = try Parser(yaml: yaml).nextRoot()) { error in
@@ -34,8 +32,6 @@ class YamlErrorTests: XCTestCase {
     }
 
     func testYamlErrorScanner() throws {
-        guard !doesSR9454Affect() else { return }
-
         let yaml = "test: 'テスト"
         XCTAssertThrowsError(_ = try Parser(yaml: yaml).nextRoot()) { error in
             XCTAssertTrue(error is YamlError)
@@ -50,8 +46,6 @@ class YamlErrorTests: XCTestCase {
     }
 
     func testYamlErrorParser() throws {
-        guard !doesSR9454Affect() else { return }
-
         let yaml = "- [キー1: 値1]\n- [key1: value1, key2: ,"
         XCTAssertThrowsError(_ = try Parser(yaml: yaml).nextRoot()) { error in
             XCTAssertTrue(error is YamlError)


### PR DESCRIPTION
This reverts commit 584a2bc2ff03b1f1848637d73df1fc47ba36deed.
Since [SR-9454](https://bugs.swift.org/browse/SR-9454) has been fixed on `swift-5.0-DEVELOPMENT-SNAPSHOT-2019-02-02-a`.