### PR TITLE
Fix conversion of string to float

### DIFF
--- a/Sources/Yams/Representer.swift
+++ b/Sources/Yams/Representer.swift
@@ -57,6 +57,9 @@ extension Dictionary: NodeRepresentable {
 
 private func represent(_ value: Any) throws -> Node {
     if let string = value as? String {
+        if value is String && string.canBecomeNumber {
+            return Node(string, .implicit, .singleQuoted)
+        }
         return Node(string)
     } else if let representable = value as? NodeRepresentable {
         return try representable.represented()

--- a/Sources/Yams/String+Yams.swift
+++ b/Sources/Yams/String+Yams.swift
@@ -78,4 +78,8 @@ extension String {
             return self + "\n"
         }
     }
+    
+    var canBecomeNumber: Bool {
+        return Double(self) != nil
+    }
 }


### PR DESCRIPTION
I don't think this fixes the case when you do `Node("4.2")`, this will still be turned into `4.2` instead of `"4.2"`.