### PR TITLE
Support 32-bit target

### DIFF
--- a/Sources/Yams/Constructor.swift
+++ b/Sources/Yams/Constructor.swift
@@ -310,6 +310,32 @@ extension UInt: ScalarConstructible {
     }
 }
 
+// MARK: - ScalarConstructible Int64 Conformance
+
+extension Int64: ScalarConstructible {
+    /// Construct an instance of `Int64`, if possible, from the specified scalar.
+    ///
+    /// - parameter scalar: The `Node.Scalar` from which to extract a value of type `Int64`, if possible.
+    ///
+    /// - returns: An instance of `Int64`, if one was successfully extracted from the scalar.
+    public static func construct(from scalar: Node.Scalar) -> Int64? {
+        return _construct(from: scalar)
+    }
+}
+
+// MARK: - ScalarConstructible UInt64 Conformance
+
+extension UInt64: ScalarConstructible {
+    /// Construct an instance of `UInt64`, if possible, from the specified scalar.
+    ///
+    /// - parameter scalar: The `Node.Scalar` from which to extract a value of type `UInt64`, if possible.
+    ///
+    /// - returns: An instance of `UInt64`, if one was successfully extracted from the scalar.
+    public static func construct(from scalar: Node.Scalar) -> UInt64? {
+        return _construct(from: scalar)
+    }
+}
+
 // MARK: - ScalarConstructible String Conformance
 
 extension String: ScalarConstructible {
@@ -561,8 +587,12 @@ extension Double: SexagesimalConvertible {}
 extension Float: SexagesimalConvertible {}
 // MARK: - SexagesimalConvertible Int Conformance
 extension Int: SexagesimalConvertible {}
-// MARK: - SexagesimalConvertible Int Conformance
+// MARK: - SexagesimalConvertible UInt Conformance
 extension UInt: SexagesimalConvertible {}
+// MARK: - SexagesimalConvertible Int64 Conformance
+extension Int64: SexagesimalConvertible {}
+// MARK: - SexagesimalConvertible UInt64 Conformance
+extension UInt64: SexagesimalConvertible {}
 
 private extension String {
     func sexagesimal<T>() -> T where T: SexagesimalConvertible {

--- a/Sources/Yams/Constructor.swift
+++ b/Sources/Yams/Constructor.swift
@@ -76,7 +76,7 @@ extension Constructor {
         .bool: Bool.construct,
         .float: Double.construct,
         .null: NSNull.construct,
-        .int: Int.construct,
+        .int: MemoryLayout<Int>.size == 8 ? Int.construct : { Int.construct(from: $0) ?? Int64.construct(from: $0) },
         // http://yaml.org/type/index.html
         .binary: Data.construct,
         .timestamp: Date.construct

--- a/Sources/Yams/Decoder.swift
+++ b/Sources/Yams/Decoder.swift
@@ -269,7 +269,7 @@ extension FixedWidthInteger where Self: SignedInteger {
     ///
     /// - returns: An instance of `Self`, if one was successfully extracted from the scalar.
     public static func construct(from scalar: Node.Scalar) -> Self? {
-        return Int.construct(from: scalar).flatMap(Self.init(exactly:))
+        return Int64.construct(from: scalar).flatMap(Self.init(exactly:))
     }
 }
 
@@ -282,7 +282,7 @@ extension FixedWidthInteger where Self: UnsignedInteger {
     ///
     /// - returns: An instance of `Self`, if one was successfully extracted from the scalar.
     public static func construct(from scalar: Node.Scalar) -> Self? {
-        return UInt.construct(from: scalar).flatMap(Self.init(exactly:))
+        return UInt64.construct(from: scalar).flatMap(Self.init(exactly:))
     }
 }
 
@@ -292,16 +292,12 @@ extension Int8: ScalarConstructible {}
 extension Int16: ScalarConstructible {}
 // MARK: - ScalarConstructible Int32 Conformance
 extension Int32: ScalarConstructible {}
-// MARK: - ScalarConstructible Int64 Conformance
-extension Int64: ScalarConstructible {}
 // MARK: - ScalarConstructible UInt8 Conformance
 extension UInt8: ScalarConstructible {}
 // MARK: - ScalarConstructible UInt16 Conformance
 extension UInt16: ScalarConstructible {}
 // MARK: - ScalarConstructible UInt32 Conformance
 extension UInt32: ScalarConstructible {}
-// MARK: - ScalarConstructible UInt64 Conformance
-extension UInt64: ScalarConstructible {}
 
 // MARK: - ScalarConstructible Decimal Conformance
 

--- a/Tests/YamsTests/ConstructorTests.swift
+++ b/Tests/YamsTests/ConstructorTests.swift
@@ -110,6 +110,8 @@ class ConstructorTests: XCTestCase { // swiftlint:disable:this type_body_length
 
             """
         let objects = try Yams.load(yaml: example)
+        /// returns value as Int64, if arch is 32 bits. Otherwise it returns Int.
+        let int64IfArchIs32Bit: (_ value: Int64) -> Any = { MemoryLayout<Int>.size == 8 ? Int($0) : $0 }
         let expected: [String: Any] = [
             "canonical": 685230,
             "decimal": 685230,
@@ -123,8 +125,8 @@ class ConstructorTests: XCTestCase { // swiftlint:disable:this type_body_length
             "negativeHexadecimal": -685230,
             "negativeBinary": -685230,
             "negativeSexagesimal": -685230,
-            "canonicalMin": -9223372036854775808,
-            "canonicalMax": 9223372036854775807
+            "canonicalMin": int64IfArchIs32Bit(-9223372036854775808),
+            "canonicalMax": int64IfArchIs32Bit(9223372036854775807)
         ]
         YamsAssertEqual(objects, expected)
     }

--- a/Tests/YamsTests/RepresenterTests.swift
+++ b/Tests/YamsTests/RepresenterTests.swift
@@ -63,17 +63,15 @@ class RepresenterTests: XCTestCase {
     }
 
     func testInteger() throws {
-        #if arch(i386) || arch(arm)
+        if MemoryLayout<Int>.size == 4 {
             XCTAssertEqual(try Node(Int.max), "2147483647")
             XCTAssertEqual(try Node(Int.min), "-2147483648")
             XCTAssertEqual(try Node(UInt.max), "4294967295")
-        #elseif arch(x86_64) || arch(arm64) || arch(powerpc64) || arch(powerpc64le) || arch(s390x)
+        } else if MemoryLayout<Int>.size == 8 {
             XCTAssertEqual(try Node(Int.max), "9223372036854775807")
             XCTAssertEqual(try Node(Int.min), "-9223372036854775808")
             XCTAssertEqual(try Node(UInt.max), "18446744073709551615")
-        #else
-            XCTFail("Unknown architecture")
-        #endif
+        }
         XCTAssertEqual(try Node(Int(0)), "0")
         XCTAssertEqual(try Node(UInt(0)), "0")
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -109,6 +109,12 @@ jobs:
       condition: succeededOrFailed()
     - script: >
         set -o pipefail &&
+        xcodebuild $XCODE_FLAGS test -sdk iphonesimulator -destination "name=iPhone 5" |
+        xcpretty -r junit -o build/reports/xcodebuild-iOS.xml
+      displayName: tests on iOS (32-bit)
+      condition: succeededOrFailed()
+    - script: >
+        set -o pipefail &&
         xcodebuild $XCODE_FLAGS test -sdk appletvsimulator -destination "name=Apple TV 4K" |
         xcpretty -r junit -o build/reports/xcodebuild-tvOS.xml
       displayName: tests on tvOS


### PR DESCRIPTION
On 32-bit target, if the number does not fit in 32-bits, Yams treated them as `Int64` or `UInt64`.