### PR TITLE
Use new features in Xcode 11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ##### Breaking
 
-* None.
+* Swift 4.1 or later is now required to build Yams.  
+  [Norio Nomura](https://github.com/norio-nomura)
 
 ##### Enhancements
 

--- a/Sources/Yams/Constructor.swift
+++ b/Sources/Yams/Constructor.swift
@@ -516,15 +516,9 @@ private extension String {
 }
 
 private extension StringProtocol {
-#if swift(>=4.1)
     func substring(from offset: Int) -> SubSequence {
         return self[index(startIndex, offsetBy: offset)...]
     }
-#else
-    func substring(from offset: IndexDistance) -> SubSequence {
-        return self[index(startIndex, offsetBy: offset)...]
-    }
-#endif
 }
 
 // MARK: - SexagesimalConvertible

--- a/Sources/Yams/shim.swift
+++ b/Sources/Yams/shim.swift
@@ -6,16 +6,6 @@
 //  Copyright (c) 2018 Yams. All rights reserved.
 //
 
-#if !swift(>=4.1)
-extension Sequence {
-    func compactMap<ElementOfResult>(
-        _ transform: (Self.Element
-    ) throws -> ElementOfResult?) rethrows -> [ElementOfResult] {
-        return try flatMap(transform)
-    }
-}
-#endif
-
 #if !_runtime(_ObjC) && !swift(>=4.2)
 extension Substring {
     func hasPrefix(_ prefix: String) -> Bool {

--- a/Tests/YamsTests/EncoderTests.swift
+++ b/Tests/YamsTests/EncoderTests.swift
@@ -68,22 +68,11 @@ class EncoderTests: XCTestCase { // swiftlint:disable:this type_body_length
     func testEncodingTopLevelStructuredSingleClass() {
         // Mapping is a class which encodes as a dictionary through a single value container.
         let mapping = Mapping.testValue
-    #if swift(>=4.0.3)
-        // fixing https://bugs.swift.org/browse/SR-5206 changes result.
         _testRoundTrip(of: mapping, with: YAMLEncoder.Options(sortKeys: true), expectedYAML: """
             Apple: http://apple.com
             localhost: http://127.0.0.1
 
             """)
-    #else
-        _testRoundTrip(of: mapping, with: YAMLEncoder.Options(sortKeys: true), expectedYAML: """
-            Apple:
-              relative: http://apple.com
-            localhost:
-              relative: http://127.0.0.1
-
-            """)
-    #endif
     }
 
     func testEncodingTopLevelDeepStructuredType() {
@@ -163,10 +152,7 @@ class EncoderTests: XCTestCase { // swiftlint:disable:this type_body_length
         _testRoundTrip(of: TopLevelWrapper(decimal), expectedYAML: expectedYAML)
 
         // Optional Decimals should encode the same way.
-    #if swift(>=4.0.3)
-        // following test requires that https://bugs.swift.org/browse/SR-5206 is fixed.
         _testRoundTrip(of: OptionalTopLevelWrapper(decimal), expectedYAML: expectedYAML)
-    #endif
     }
 
     func testInterceptURL() {
@@ -176,10 +162,7 @@ class EncoderTests: XCTestCase { // swiftlint:disable:this type_body_length
         _testRoundTrip(of: TopLevelWrapper(url), expectedYAML: expectedYAML)
 
         // Optional URLs should encode the same way.
-    #if swift(>=4.0.3)
-        // following test requires that https://bugs.swift.org/browse/SR-5206 is fixed.
         _testRoundTrip(of: OptionalTopLevelWrapper(url), expectedYAML: expectedYAML)
-    #endif
     }
 
     func testValuesInSingleValueContainer() throws {

--- a/Tests/YamsTests/MarkTests.swift
+++ b/Tests/YamsTests/MarkTests.swift
@@ -54,13 +54,3 @@ extension MarkTests {
         ]
     }
 }
-
-#if !swift(>=4.1)
-
-    extension Array {
-        public func compactMap(_ transform: (Element) throws -> String?) rethrows -> [String] {
-            return try flatMap(transform)
-        }
-    }
-
-#endif

--- a/Tests/YamsTests/PerformanceTests.swift
+++ b/Tests/YamsTests/PerformanceTests.swift
@@ -116,6 +116,17 @@ class PerformanceTests: XCTestCase {
         }
     }
 
+#if canImport(Combine)
+    override func measure(_ block: () -> Void) {
+        if #available(macOS 10.15, iOS 13, tvOS 13, *) {
+            let metrics: [XCTMetric] = [XCTClockMetric(), XCTCPUMetric(), XCTMemoryMetric(), XCTStorageMetric()]
+            super.measure(metrics: metrics, block: block)
+        } else {
+            super.measure(block)
+        }
+    }
+#endif
+
     func testUsingComposeWithUTF16() throws {
         let yaml = try loadYAML()
         self.measure {

--- a/Yams.xcodeproj/Yams.xctestplan
+++ b/Yams.xcodeproj/Yams.xctestplan
@@ -1,0 +1,40 @@
+{
+  "configurations" : [
+    {
+      "name" : "UTF16",
+      "options" : {
+        "environmentVariableEntries" : [
+          {
+            "key" : "YAMS_DEFAULT_ENCODING",
+            "value" : "UTF16"
+          }
+        ]
+      }
+    },
+    {
+      "name" : "UTF8",
+      "options" : {
+        "environmentVariableEntries" : [
+          {
+            "key" : "YAMS_DEFAULT_ENCODING",
+            "value" : "UTF8"
+          }
+        ]
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "codeCoverage" : false
+  },
+  "testTargets" : [
+    {
+      "parallelizable" : true,
+      "target" : {
+        "containerPath" : "container:Yams.xcodeproj",
+        "identifier" : "OBJ_54",
+        "name" : "YamsTests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/Yams.xcodeproj/Yams.xctestplan
+++ b/Yams.xcodeproj/Yams.xctestplan
@@ -24,7 +24,7 @@
     }
   ],
   "defaultOptions" : {
-    "codeCoverage" : false
+
   },
   "testTargets" : [
     {

--- a/Yams.xcodeproj/project.pbxproj
+++ b/Yams.xcodeproj/project.pbxproj
@@ -293,7 +293,7 @@
 		OBJ_1 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0930;
+				LastUpgradeCheck = 1100;
 				TargetAttributes = {
 					OBJ_45 = {
 						LastSwiftMigration = 0900;
@@ -305,10 +305,11 @@
 			};
 			buildConfigurationList = OBJ_2 /* Build configuration list for PBXProject "Yams" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
+				Base,
 			);
 			mainGroup = OBJ_5;
 			productRefGroup = OBJ_26 /* Products */;
@@ -402,6 +403,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_COMMA = YES;
@@ -452,6 +454,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_COMMA = YES;

--- a/Yams.xcodeproj/project.pbxproj
+++ b/Yams.xcodeproj/project.pbxproj
@@ -296,10 +296,10 @@
 				LastUpgradeCheck = 1100;
 				TargetAttributes = {
 					OBJ_45 = {
-						LastSwiftMigration = 0900;
+						LastSwiftMigration = 1100;
 					};
 					OBJ_54 = {
-						LastSwiftMigration = 0900;
+						LastSwiftMigration = 1100;
 					};
 				};
 			};

--- a/Yams.xcodeproj/project.pbxproj
+++ b/Yams.xcodeproj/project.pbxproj
@@ -81,6 +81,7 @@
 		6C788A001EB87232005386F0 /* EncoderTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EncoderTests.swift; sourceTree = "<group>"; };
 		6C788A021EB876C4005386F0 /* Encoder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Encoder.swift; sourceTree = "<group>"; };
 		6C78C5631E29B1CE0096215F /* RepresenterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RepresenterTests.swift; sourceTree = "<group>"; };
+		6C9B503E22B6362B00D82F94 /* Yams.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; name = Yams.xctestplan; path = Yams.xcodeproj/Yams.xctestplan; sourceTree = "<group>"; };
 		6CBAEE191E3839500021BF87 /* Yams.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Yams.h; sourceTree = "<group>"; };
 		6CC2E33E1E22347B00F62269 /* Representer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Representer.swift; sourceTree = "<group>"; };
 		6CE603971E13502E00A13D8D /* Emitter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Emitter.swift; sourceTree = "<group>"; };
@@ -196,6 +197,7 @@
 		OBJ_5 = {
 			isa = PBXGroup;
 			children = (
+				6C9B503E22B6362B00D82F94 /* Yams.xctestplan */,
 				OBJ_6 /* Package.swift */,
 				6C48A76421D1B013007DB7B9 /* Package@swift-4.2.swift */,
 				6C48A76521D1B013007DB7B9 /* Package@swift-5.swift */,

--- a/Yams.xcodeproj/xcshareddata/xcschemes/Yams.xcscheme
+++ b/Yams.xcodeproj/xcshareddata/xcschemes/Yams.xcscheme
@@ -26,7 +26,8 @@
       buildConfiguration = "Release"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
       <TestPlans>
          <TestPlanReference
             reference = "container:Yams.xcodeproj/Yams.xctestplan"

--- a/Yams.xcodeproj/xcshareddata/xcschemes/Yams.xcscheme
+++ b/Yams.xcodeproj/xcshareddata/xcschemes/Yams.xcscheme
@@ -1,25 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0930"
-   version = "1.3">
+   LastUpgradeVersion = "1100"
+   version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
       <BuildActionEntries>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "OBJ_30"
-               BuildableName = "CYaml.framework"
-               BlueprintName = "CYaml"
-               ReferencedContainer = "container:Yams.xcodeproj">
-            </BuildableReference>
-         </BuildActionEntry>
          <BuildActionEntry
             buildForTesting = "YES"
             buildForRunning = "YES"
@@ -53,8 +39,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -66,17 +50,6 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "OBJ_30"
-            BuildableName = "CYaml.framework"
-            BlueprintName = "CYaml"
-            ReferencedContainer = "container:Yams.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Yams.xcodeproj/xcshareddata/xcschemes/Yams.xcscheme
+++ b/Yams.xcodeproj/xcshareddata/xcschemes/Yams.xcscheme
@@ -23,10 +23,16 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
-      buildConfiguration = "Debug"
+      buildConfiguration = "Release"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
+      <TestPlans>
+         <TestPlanReference
+            reference = "container:Yams.xcodeproj/Yams.xctestplan"
+            default = "YES">
+         </TestPlanReference>
+      </TestPlans>
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,8 +8,6 @@ jobs:
   strategy:
     maxParallel: 10
     matrix:
-      swift40:
-        containerImage: norionomura/swiftlint:swift-4.0
       swift41:
         containerImage: norionomura/swiftlint:swift-4.1
       swift42:
@@ -45,12 +43,6 @@ jobs:
   strategy:
     maxParallel: 10
     matrix:
-      xcode901:
-        DEVELOPER_DIR: /Applications/Xcode_9.0.1.app
-      xcode91:
-        DEVELOPER_DIR: /Applications/Xcode_9.1.app
-      xcode92:
-        DEVELOPER_DIR: /Applications/Xcode_9.2.app
       xcode931:
         DEVELOPER_DIR: /Applications/Xcode_9.3.1.app
       xcode941:


### PR DESCRIPTION
- Use Test Plan
- Use `XCTMetric`. ([WWDC19 417](https://developer.apple.com/videos/play/wwdc2019/417/))
- Drop Swift 4.0.x since `canImport` is required