### PR TITLE
Enhance handling of `Date` with `nanosecond`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,8 @@
 
 ##### Bug Fixes
 
-* Fix `YAMLEncoder` outputted a result that is delayed by 1 second when encoding
-  `Date` with `nanosecond` greater than 999499997.  
+* Fix a bug where `YAMLEncoder` would delay `Date`s by 1 second when encoding
+  values with a `nanosecond` component greater than 999499997.    
   [Norio Nomura](https://github.com/norio-nomura)
   [#192](https://github.com/jpsim/Yams/issues/192)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,15 @@
 
 ##### Enhancements
 
-* None.
+* Support `Date` with `nanosecond` in Swift 4.x.  
+  [Norio Nomura](https://github.com/norio-nomura)
 
 ##### Bug Fixes
 
-* None.
+* Fix `YAMLEncoder` outputted a result that is delayed by 1 second when encoding
+  `Date` with `nanosecond` greater than 999499997.  
+  [Norio Nomura](https://github.com/norio-nomura)
+  [#192](https://github.com/jpsim/Yams/issues/192)
 
 ## 2.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 ##### Enhancements
 
-* Support `Date` with `nanosecond` in Swift 4.x.  
+* Accurately represent `Date`s with nanosecond components in Swift 4.x.  
   [Norio Nomura](https://github.com/norio-nomura)
 
 ##### Bug Fixes

--- a/Sources/Yams/Constructor.swift
+++ b/Sources/Yams/Constructor.swift
@@ -174,7 +174,7 @@ extension Date: ScalarConstructible {
         datecomponents.hour = components[3].flatMap { Int($0) }
         datecomponents.minute = components[4].flatMap { Int($0) }
         datecomponents.second = components[5].flatMap { Int($0) }
-        datecomponents.nanosecond = components[6].flatMap { fraction in
+        let optionalNanosecond: Int? = components[6].flatMap { fraction in
             let length = fraction.count
             let nanosecond: Int?
             if length < 9 {
@@ -199,7 +199,10 @@ extension Date: ScalarConstructible {
             }
             return TimeZone(secondsFromGMT: seconds)
         }()
-        return datecomponents.date
+        guard let date = datecomponents.date else { return nil }
+        guard let nanosecond = optionalNanosecond else { return date }
+        let timeInterval = date.timeIntervalSinceReferenceDate + TimeInterval(nanosecond) / 1_000_000_000.0
+        return Date(timeIntervalSinceReferenceDate: timeInterval)
     }
 
     private static let timestampPattern: NSRegularExpression = pattern([

--- a/Sources/Yams/Constructor.swift
+++ b/Sources/Yams/Constructor.swift
@@ -167,7 +167,7 @@ extension Date: ScalarConstructible {
         }
 
         var datecomponents = DateComponents()
-        datecomponents.calendar = Calendar(identifier: .gregorian)
+        datecomponents.calendar = gregorianCalendar
         datecomponents.year = components[0].flatMap { Int($0) }
         datecomponents.month = components[1].flatMap { Int($0) }
         datecomponents.day = components[2].flatMap { Int($0) }
@@ -204,6 +204,8 @@ extension Date: ScalarConstructible {
         let timeInterval = date.timeIntervalSinceReferenceDate + TimeInterval(nanosecond) / 1_000_000_000.0
         return Date(timeIntervalSinceReferenceDate: timeInterval)
     }
+
+    private static let gregorianCalendar = Calendar(identifier: .gregorian)
 
     private static let timestampPattern: NSRegularExpression = pattern([
         "^([0-9][0-9][0-9][0-9])",          // year

--- a/Sources/Yams/Representer.swift
+++ b/Sources/Yams/Representer.swift
@@ -119,11 +119,18 @@ extension Date: ScalarRepresentable {
         let calendar = Calendar(identifier: .gregorian)
         let nanosecond = calendar.component(.nanosecond, from: self)
         if nanosecond != 0 {
-            return iso8601WithoutZFormatter.string(from: self) +
+            return iso8601WithoutZFormatter.string(from: dateDroppingNanosecond) +
                 String(format: ".%09d", nanosecond).trimmingCharacters(in: characterSetZero) + "Z"
         } else {
             return iso8601Formatter.string(from: self)
         }
+    }
+
+    private var dateDroppingNanosecond: Date {
+        let calendar = Calendar(identifier: .gregorian)
+        var dateComponents = calendar.dateComponents(in: calendar.timeZone, from: self)
+        dateComponents.nanosecond = nil
+        return dateComponents.date!
     }
 }
 

--- a/Sources/Yams/Representer.swift
+++ b/Sources/Yams/Representer.swift
@@ -123,7 +123,7 @@ private extension TimeInterval {
     func separateFractionalSecond(with precision: Int) -> (integral: TimeInterval, fractional: Int) {
         var integral = 0.0
         let fractional = modf(self, &integral)
-        let radix = pow(10.0, TimeInterval(precision))
+        let radix = pow(10.0, Double(precision))
         let rounded = Int((fractional * radix).rounded())
         let quotient = rounded / Int(radix)
         return quotient != 0 ? // carry-up?

--- a/Sources/Yams/Representer.swift
+++ b/Sources/Yams/Representer.swift
@@ -119,18 +119,15 @@ extension Date: ScalarRepresentable {
         let calendar = Calendar(identifier: .gregorian)
         let nanosecond = calendar.component(.nanosecond, from: self)
         if nanosecond != 0 {
-            return iso8601WithoutZFormatter.string(from: dateDroppingNanosecond) +
+            return iso8601WithoutZFormatter.string(from: droppingNanosecond) +
                 String(format: ".%09d", nanosecond).trimmingCharacters(in: characterSetZero) + "Z"
         } else {
             return iso8601Formatter.string(from: self)
         }
     }
 
-    private var dateDroppingNanosecond: Date {
-        let calendar = Calendar(identifier: .gregorian)
-        var dateComponents = calendar.dateComponents(in: calendar.timeZone, from: self)
-        dateComponents.nanosecond = nil
-        return dateComponents.date!
+    private var droppingNanosecond: Date {
+        return Date(timeIntervalSinceReferenceDate: TimeInterval(Int64(timeIntervalSinceReferenceDate)))
     }
 }
 

--- a/Sources/Yams/Representer.swift
+++ b/Sources/Yams/Representer.swift
@@ -118,7 +118,7 @@ extension Date: ScalarRepresentable {
 }
 
 private extension TimeInterval {
-    /// Separates into integral and fractional, then round fractional to precision digits Int
+    /// Separates the time interval into integral and fractional components, then rounds the `fractional` component to `precision` number of digits.
     /// - returns: Tuple of integral part and converted fractional part
     func separateFractionalSecond(with precision: Int) -> (integral: TimeInterval, fractional: Int) {
         var integral = 0.0

--- a/Sources/Yams/Representer.swift
+++ b/Sources/Yams/Representer.swift
@@ -99,35 +99,36 @@ extension Date: ScalarRepresentable {
     }
 
     private var iso8601String: String {
-#if !_runtime(_ObjC) && !swift(>=5.0)
-        // swift-corelibs-foundation has bug with nanosecond.
-        // https://bugs.swift.org/browse/SR-3158
-        return iso8601Formatter.string(from: self)
-#else
-        let calendar = Calendar(identifier: .gregorian)
-        let nanosecond = calendar.component(.nanosecond, from: self)
-        if nanosecond != 0 {
-            return iso8601WithFractionalSecondFormatter.string(from: self)
-                .trimmingCharacters(in: characterSetZero) + "Z"
-        } else {
-            return iso8601Formatter.string(from: self)
-        }
-#endif
+        let (integral, millisecond) = timeIntervalSinceReferenceDate.separateFractionalSecond(with: 3)
+        guard millisecond != 0 else { return iso8601Formatter.string(from: self) }
+
+        let dateWithoutMillisecond = Date(timeIntervalSinceReferenceDate: integral)
+        return iso8601WithoutZFormatter.string(from: dateWithoutMillisecond) +
+            String(format: ".%03d", millisecond).trimmingCharacters(in: characterSetZero) + "Z"
     }
 
     private var iso8601StringWithFullNanosecond: String {
-        let calendar = Calendar(identifier: .gregorian)
-        let nanosecond = calendar.component(.nanosecond, from: self)
-        if nanosecond != 0 {
-            return iso8601WithoutZFormatter.string(from: droppingNanosecond) +
-                String(format: ".%09d", nanosecond).trimmingCharacters(in: characterSetZero) + "Z"
-        } else {
-            return iso8601Formatter.string(from: self)
-        }
-    }
+        let (integral, nanosecond) = timeIntervalSinceReferenceDate.separateFractionalSecond(with: 9)
+        guard nanosecond != 0 else { return iso8601Formatter.string(from: self) }
 
-    private var droppingNanosecond: Date {
-        return Date(timeIntervalSinceReferenceDate: TimeInterval(Int64(timeIntervalSinceReferenceDate)))
+        let dateWithoutNanosecond = Date(timeIntervalSinceReferenceDate: integral)
+        return iso8601WithoutZFormatter.string(from: dateWithoutNanosecond) +
+            String(format: ".%09d", nanosecond).trimmingCharacters(in: characterSetZero) + "Z"
+    }
+}
+
+private extension TimeInterval {
+    /// Separates into integral and fractional, then round fractional to precision digits Int
+    /// - returns: Tuple of integral part and converted fractional part
+    func separateFractionalSecond(with precision: Int) -> (integral: TimeInterval, fractional: Int) {
+        var integral = 0.0
+        let fractional = modf(self, &integral)
+        let radix = pow(10.0, TimeInterval(precision))
+        let rounded = Int((fractional * radix).rounded())
+        let quotient = rounded / Int(radix)
+        return quotient != 0 ? // carry-up?
+            (integral + TimeInterval(quotient), rounded % Int(radix)) :
+            (integral, rounded)
     }
 }
 
@@ -145,15 +146,6 @@ private let iso8601WithoutZFormatter: DateFormatter = {
     var formatter = DateFormatter()
     formatter.locale = Locale(identifier: "en_US_POSIX")
     formatter.dateFormat = "yyyy'-'MM'-'dd'T'HH':'mm':'ss"
-    formatter.timeZone = TimeZone(secondsFromGMT: 0)
-    return formatter
-}()
-
-// DateFormatter truncates Fractional Second to 10^-4
-private let iso8601WithFractionalSecondFormatter: DateFormatter = {
-    var formatter = DateFormatter()
-    formatter.locale = Locale(identifier: "en_US_POSIX")
-    formatter.dateFormat = "yyyy'-'MM'-'dd'T'HH':'mm':'ss.SSSS"
     formatter.timeZone = TimeZone(secondsFromGMT: 0)
     return formatter
 }()

--- a/Sources/Yams/Representer.swift
+++ b/Sources/Yams/Representer.swift
@@ -99,7 +99,7 @@ extension Date: ScalarRepresentable {
     }
 
     private var iso8601String: String {
-        let (integral, millisecond) = timeIntervalSinceReferenceDate.separateFractionalSecond(with: 3)
+        let (integral, millisecond) = timeIntervalSinceReferenceDate.separateFractionalSecond(withPrecision: 3)
         guard millisecond != 0 else { return iso8601Formatter.string(from: self) }
 
         let dateWithoutMillisecond = Date(timeIntervalSinceReferenceDate: integral)
@@ -108,7 +108,7 @@ extension Date: ScalarRepresentable {
     }
 
     private var iso8601StringWithFullNanosecond: String {
-        let (integral, nanosecond) = timeIntervalSinceReferenceDate.separateFractionalSecond(with: 9)
+        let (integral, nanosecond) = timeIntervalSinceReferenceDate.separateFractionalSecond(withPrecision: 9)
         guard nanosecond != 0 else { return iso8601Formatter.string(from: self) }
 
         let dateWithoutNanosecond = Date(timeIntervalSinceReferenceDate: integral)
@@ -120,7 +120,7 @@ extension Date: ScalarRepresentable {
 private extension TimeInterval {
     /// Separates the time interval into integral and fractional components, then rounds the `fractional` component to `precision` number of digits.
     /// - returns: Tuple of integral part and converted fractional part
-    func separateFractionalSecond(with precision: Int) -> (integral: TimeInterval, fractional: Int) {
+    func separateFractionalSecond(withPrecision precision: Int) -> (integral: TimeInterval, fractional: Int) {
         var integral = 0.0
         let fractional = modf(self, &integral)
         let radix = pow(10.0, Double(precision))

--- a/Tests/YamsTests/ConstructorTests.swift
+++ b/Tests/YamsTests/ConstructorTests.swift
@@ -465,16 +465,12 @@ class ConstructorTests: XCTestCase { // swiftlint:disable:this type_body_length
     }
 
     func testTimestampWithNanosecond() throws {
-        #if !_runtime(_ObjC) && !swift(>=5.0)
-            // https://bugs.swift.org/browse/SR-3158
-        #else
-            let example = "nanosecond: 2001-12-15T02:59:43.123456789Z\n"
-            let objects = try Yams.load(yaml: example)
-            let expected: [String: Any] = [
-                "nanosecond": timestamp( 0, 2001, 12, 15, 02, 59, 43, 0.123456789)
-            ]
-            YamsAssertEqual(objects, expected)
-        #endif
+        let example = "nanosecond: 2001-12-15T02:59:43.123456789Z\n"
+        let objects = try Yams.load(yaml: example)
+        let expected: [String: Any] = [
+            "nanosecond": timestamp( 0, 2001, 12, 15, 02, 59, 43, 0.123456789)
+        ]
+        YamsAssertEqual(objects, expected)
     }
 
     func testValue() throws {

--- a/Tests/YamsTests/EncoderTests.swift
+++ b/Tests/YamsTests/EncoderTests.swift
@@ -322,6 +322,19 @@ class EncoderTests: XCTestCase { // swiftlint:disable:this type_body_length
         XCTAssertNil(t.n5)
     }
 
+    func testEncodingDateWithNanosecondGreaterThan999499977() throws {
+    #if _runtime(_ObjC) || swift(>=5.0)
+        let gregorian = Calendar(identifier: .gregorian)
+        let utc = TimeZone(identifier: "UTC")!
+        var dateComponents = gregorian.dateComponents(in: utc, from: Date())
+        dateComponents.nanosecond = 999499977
+        let date = dateComponents.date!
+        _testRoundTrip(of: date)
+    #else
+        print("Decoding 'Date' has issue on Linux with nanoseconds. https://bugs.swift.org/browse/SR-6223")
+    #endif
+    }
+
     // MARK: - Helper Functions
 
     private func _testRoundTrip<T>(of value: T,
@@ -1096,7 +1109,8 @@ extension EncoderTests {
             ("testDictionary", testDictionary),
             ("testNodeTypeMismatch", testNodeTypeMismatch),
             ("testDecodingConcreteTypeParameter", testDecodingConcreteTypeParameter),
-            ("test_null_yml", test_null_yml)
+            ("test_null_yml", test_null_yml),
+            ("testEncodingDateWithNanosecondGreaterThan999499977", testEncodingDateWithNanosecondGreaterThan999499977)
         ]
     }
 }

--- a/Tests/YamsTests/EncoderTests.swift
+++ b/Tests/YamsTests/EncoderTests.swift
@@ -324,11 +324,9 @@ class EncoderTests: XCTestCase { // swiftlint:disable:this type_body_length
 
     func testEncodingDateWithNanosecondGreaterThan999499977() throws {
     #if _runtime(_ObjC) || swift(>=5.0)
-        let gregorian = Calendar(identifier: .gregorian)
-        let utc = TimeZone(identifier: "UTC")!
-        var dateComponents = gregorian.dateComponents(in: utc, from: Date())
-        dateComponents.nanosecond = 999499977
-        let date = dateComponents.date!
+        var timeInterval = 0.0
+        _ = modf(Date().timeIntervalSinceReferenceDate, &timeInterval)
+        let date = Date(timeIntervalSinceReferenceDate: timeInterval + 0.999_499_977)
         _testRoundTrip(of: date)
     #else
         print("Decoding 'Date' has issue on Linux with nanoseconds. https://bugs.swift.org/browse/SR-6223")

--- a/Tests/YamsTests/EncoderTests.swift
+++ b/Tests/YamsTests/EncoderTests.swift
@@ -108,25 +108,11 @@ class EncoderTests: XCTestCase { // swiftlint:disable:this type_body_length
 
     // MARK: - Date Strategy Tests
     func testEncodingDate() {
-    #if !_runtime(_ObjC) && !swift(>=5.0)
-        print("Decoding 'Date' has issue on Linux with nanoseconds. https://bugs.swift.org/browse/SR-6223")
-        XCTAssertNotEqual(timestamp( 0, 2001, 12, 15, 02, 59, 43, 0.12345678).timeIntervalSinceReferenceDate,
-                          30077983.12345678,
-                          "https://bugs.swift.org/browse/SR-6223 seems to be fixed")
-    #else
         _testRoundTrip(of: Date())
-    #endif
     }
 
     func testEncodingDateMillisecondsSince1970() {
-    #if !_runtime(_ObjC) && !swift(>=5.0)
-        print("Decoding 'Date' has issue on Linux with nanoseconds. https://bugs.swift.org/browse/SR-6223")
-        XCTAssertNotEqual(timestamp( 0, 2001, 12, 15, 02, 59, 43, 0.12345678).timeIntervalSinceReferenceDate,
-                          30077983.12345678,
-                          "https://bugs.swift.org/browse/SR-6223 seems to be fixed")
-    #else
         _testRoundTrip(of: Date(timeIntervalSince1970: 1000.0), expectedYAML: "1970-01-01T00:16:40Z\n")
-    #endif
     }
 
     // MARK: - Data Tests
@@ -323,14 +309,10 @@ class EncoderTests: XCTestCase { // swiftlint:disable:this type_body_length
     }
 
     func testEncodingDateWithNanosecondGreaterThan999499977() throws {
-    #if _runtime(_ObjC) || swift(>=5.0)
         var timeInterval = 0.0
         _ = modf(Date().timeIntervalSinceReferenceDate, &timeInterval)
         let date = Date(timeIntervalSinceReferenceDate: timeInterval + 0.999_499_977)
         _testRoundTrip(of: date)
-    #else
-        print("Decoding 'Date' has issue on Linux with nanoseconds. https://bugs.swift.org/browse/SR-6223")
-    #endif
     }
 
     // MARK: - Helper Functions

--- a/Tests/YamsTests/RepresenterTests.swift
+++ b/Tests/YamsTests/RepresenterTests.swift
@@ -33,12 +33,8 @@ class RepresenterTests: XCTestCase {
             XCTAssertEqual(try Node(date), "2001-12-15T02:59:43Z")
         }
         do { // fractional seconds
-            #if !_runtime(_ObjC) && !swift(>=5.0)
-                // https://bugs.swift.org/browse/SR-3158
-            #else
-                let date = timestamp( 0, 2001, 12, 15, 02, 59, 43, 0.1)
-                XCTAssertEqual(try Node(date), "2001-12-15T02:59:43.1Z")
-            #endif
+            let date = timestamp( 0, 2001, 12, 15, 02, 59, 43, 0.1)
+            XCTAssertEqual(try Node(date), "2001-12-15T02:59:43.1Z")
         }
     }
 

--- a/Tests/YamsTests/TestHelper.swift
+++ b/Tests/YamsTests/TestHelper.swift
@@ -6,9 +6,6 @@
 //  Copyright (c) 2016 Yams. All rights reserved.
 //
 
-#if !_runtime(_ObjC)
-import CDispatch
-#endif
 import Foundation
 import XCTest
 
@@ -22,15 +19,12 @@ func timestamp(_ timeZoneHour: Int = 0,
                _ fraction: Double? = nil ) -> Date {
     let calendar = Calendar(identifier: .gregorian)
     let timeZone = TimeZone(secondsFromGMT: timeZoneHour * 60 * 60)
-    let nanosecond = fraction.map { Int($0 * Double(NSEC_PER_SEC)) }
-    let datecomponents = DateComponents(calendar: calendar, timeZone: timeZone,
-                          year: year, month: month, day: day,
-                          hour: hour, minute: minute, second: second, nanosecond: nanosecond)
-    // Using `DateComponents.date` causes crash on Linux
-    guard let date = NSCalendar(identifier: .gregorian)?.date(from: datecomponents) else {
-        fatalError("Never happen this")
-    }
-    return date
+    let dateComponents = DateComponents(calendar: calendar, timeZone: timeZone,
+                                        year: year, month: month, day: day,
+                                        hour: hour, minute: minute, second: second)
+    guard let date = dateComponents.date else { fatalError("Never happen this") }
+    guard let fraction = fraction else { return date }
+    return Date(timeIntervalSinceReferenceDate: date.timeIntervalSinceReferenceDate + fraction)
 }
 
 /// AssertEqual for Any

--- a/Tests/YamsTests/TestHelper.swift
+++ b/Tests/YamsTests/TestHelper.swift
@@ -9,6 +9,8 @@
 import Foundation
 import XCTest
 
+let gregorianCalendar = Calendar(identifier: .gregorian)
+
 func timestamp(_ timeZoneHour: Int = 0,
                _ year: Int? = nil,
                _ month: Int? = nil,
@@ -17,9 +19,8 @@ func timestamp(_ timeZoneHour: Int = 0,
                _ minute: Int? = nil,
                _ second: Int? = nil,
                _ fraction: Double? = nil ) -> Date {
-    let calendar = Calendar(identifier: .gregorian)
     let timeZone = TimeZone(secondsFromGMT: timeZoneHour * 60 * 60)
-    let dateComponents = DateComponents(calendar: calendar, timeZone: timeZone,
+    let dateComponents = DateComponents(calendar: gregorianCalendar, timeZone: timeZone,
                                         year: year, month: month, day: day,
                                         hour: hour, minute: minute, second: second)
     guard let date = dateComponents.date else { fatalError("Never happen this") }

--- a/Tests/YamsTests/TestHelper.swift
+++ b/Tests/YamsTests/TestHelper.swift
@@ -97,16 +97,9 @@ func YamsAssertEqual(_ lhs: Any?, _ rhs: Any?,
 private func dumped<T>(_ value: T) -> String {
     var output = ""
     dump(value, to: &output)
-    var count = 0
-    var firstLine = ""
-    output.enumerateLines { line, stop in
-        count += 1
-        if count > 1 {
-            stop = true
-        } else {
-            firstLine = line
-        }
-    }
+    let outputs = output.components(separatedBy: .newlines)
+    let firstLine = outputs.first ?? ""
+    let count = outputs.count
     if count == 1 {
         // remove `- ` prefix if
         let index = firstLine.index(firstLine.startIndex, offsetBy: 2)

--- a/Tests/YamsTests/TestHelper.swift
+++ b/Tests/YamsTests/TestHelper.swift
@@ -23,7 +23,7 @@ func timestamp(_ timeZoneHour: Int = 0,
     let dateComponents = DateComponents(calendar: gregorianCalendar, timeZone: timeZone,
                                         year: year, month: month, day: day,
                                         hour: hour, minute: minute, second: second)
-    guard let date = dateComponents.date else { fatalError("Never happen this") }
+    guard let date = dateComponents.date else { fatalError("Tests shouldn't create timestamps for invalid dates") }
     guard let fraction = fraction else { return date }
     return Date(timeIntervalSinceReferenceDate: date.timeIntervalSinceReferenceDate + fraction)
 }

--- a/Tests/YamsTests/TestHelper.swift
+++ b/Tests/YamsTests/TestHelper.swift
@@ -24,8 +24,7 @@ func timestamp(_ timeZoneHour: Int = 0,
                                         year: year, month: month, day: day,
                                         hour: hour, minute: minute, second: second)
     guard let date = dateComponents.date else { fatalError("Tests shouldn't create timestamps for invalid dates") }
-    guard let fraction = fraction else { return date }
-    return Date(timeIntervalSinceReferenceDate: date.timeIntervalSinceReferenceDate + fraction)
+    return fraction.map(date.addingTimeInterval) ?? date
 }
 
 /// AssertEqual for Any


### PR DESCRIPTION
- Support `Date` with `nanosecond` in Swift 4.x.  
- Fix encoding `Date` with `nanosecond` greater than 999499977 (#192)
- Performance up on handling `Date`