### PR TITLE
Add .swiftpm/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ playground.xcworkspace
 # Add this line if you want to avoid checking in source code from Swift Package Manager dependencies.
 Packages/
 .build/
+.swiftpm/
 
 # CocoaPods
 #


### PR DESCRIPTION
Since this is autogenerated and the SwiftPM itself also ignores this directory: https://github.com/apple/swift-package-manager/blob/master/.gitignore