### PR TITLE
Add make-xcframework.sh script

### DIFF
--- a/make-xcframework.sh
+++ b/make-xcframework.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+set -e
+set -o pipefail
+set -u
+
+name=Yams
+project=$name.xcodeproj
+output=build/$name.xcframework
+for sdk in watchos watchsimulator iphoneos iphonesimulator appletvos appletvsimulator macosx; do
+  xcodebuild \
+    -project $project \
+    -scheme $name \
+    archive \
+    SKIP_INSTALL=NO \
+    BUILD_LIBRARY_FOR_DISTRIBUTION=YES \
+    -archivePath tmp/xcframework/build/$name-$sdk.xcarchive \
+    -sdk $sdk
+done
+
+xcodebuild -create-xcframework \
+  -framework tmp/xcframework/build/$name-watchos.xcarchive/Products/Library/Frameworks/$name.framework \
+  -framework tmp/xcframework/build/$name-watchsimulator.xcarchive/Products/Library/Frameworks/$name.framework \
+  -framework tmp/xcframework/build/$name-iphoneos.xcarchive/Products/Library/Frameworks/$name.framework \
+  -framework tmp/xcframework/build/$name-iphonesimulator.xcarchive/Products/Library/Frameworks/$name.framework \
+  -framework tmp/xcframework/build/$name-appletvos.xcarchive/Products/Library/Frameworks/$name.framework \
+  -framework tmp/xcframework/build/$name-appletvsimulator.xcarchive/Products/Library/Frameworks/$name.framework \
+  -framework tmp/xcframework/build/$name-macosx.xcarchive/Products/Library/Frameworks/$name.framework \
+  -output $output


### PR DESCRIPTION
We can't run this on CI yet because Azure Pipelines still doesn't provide images with Xcode 11 betas installed. See https://github.com/microsoft/azure-pipelines-image-generation/issues/1028

To run this locally, run `DEVELOPER_DIR=/Applications/Xcode-11.app/Contents/Developer ./make-xcframework.sh`.

This produces an XCFramework in `build/Yams.xcframework`.