### PR TITLE
Apply `.singleQuoted` on representing `Node.Scalar` from `String` if `Resolver.default` resolves that to other than `.str`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@
 * Accurately represent `Date`s with nanosecond components in Swift 4.x.  
   [Norio Nomura](https://github.com/norio-nomura)
 
+* Change to apply single quoted style to YAML representation of `String`, if 
+  that contents will be resolved to other than `.str` by default `Resolver`.  
+  [Norio Nomura](https://github.com/norio-nomura)
+  [#197](https://github.com/jpsim/Yams/issues/197)
+
 ##### Bug Fixes
 
 * Fix a bug where `YAMLEncoder` would delay `Date`s by 1 second when encoding

--- a/Sources/Yams/Representer.swift
+++ b/Sources/Yams/Representer.swift
@@ -228,8 +228,8 @@ extension URL: ScalarRepresentable {
 extension String: ScalarRepresentable {
     /// This value's `Node.scalar` representation.
     public func represented() -> Node.Scalar {
-        let node = Node.Scalar.init(self, .init(.implicit, .default))
-        return node.resolvedTag.name == .str ? node : .init(self, .init(.str), .singleQuoted)
+        let scalar = Node.Scalar(self)
+        return scalar.resolvedTag.name == .str ? scalar : .init(self, Tag(.str), .singleQuoted)
     }
 }
 

--- a/Sources/Yams/Representer.swift
+++ b/Sources/Yams/Representer.swift
@@ -56,9 +56,7 @@ extension Dictionary: NodeRepresentable {
 }
 
 private func represent(_ value: Any) throws -> Node {
-    if let string = value as? String {
-        return Node(string)
-    } else if let representable = value as? NodeRepresentable {
+    if let representable = value as? NodeRepresentable {
         return try representable.represented()
     }
     throw YamlError.representer(problem: "Failed to represent \(value)")
@@ -230,7 +228,8 @@ extension URL: ScalarRepresentable {
 extension String: ScalarRepresentable {
     /// This value's `Node.scalar` representation.
     public func represented() -> Node.Scalar {
-        return .init(self)
+        let node = Node.Scalar.init(self, .init(.implicit, .default))
+        return node.resolvedTag.name == .str ? node : .init(self, .init(.str), .singleQuoted)
     }
 }
 

--- a/Tests/YamsTests/EmitterTests.swift
+++ b/Tests/YamsTests/EmitterTests.swift
@@ -122,6 +122,24 @@ class EmitterTests: XCTestCase {
         let expectedSorted = "key1: value1\nkey2: value2\nkey3: value3\n"
         XCTAssertEqual(yamlSorted, expectedSorted)
     }
+
+    func testSmartQuotedString() throws {
+        let samples: [(string: String, tag: Tag.Name, expected: String, line: UInt)] = [
+            ("string", .str, "string", #line),
+            ("true", .bool, "'true'", #line),
+            ("1", .int, "'1'", #line),
+            ("1.0", .float, "'1.0'", #line),
+            ("null", .null, "'null'", #line),
+            ("2019-07-06", .timestamp, "'2019-07-06'", #line),
+        ]
+        let resolver = Resolver.default
+        for (string, tag, expected, line) in samples {
+            let resolvedTag = resolver.resolveTag(of: Node(string))
+            XCTAssertEqual(resolvedTag, tag, "Resolver resolves unexpected tag", line: line)
+            let yaml = try Yams.dump(object: string)
+            XCTAssertEqual(yaml, "\(expected)\n", line: line)
+        }
+    }
 }
 
 extension EmitterTests {
@@ -132,7 +150,8 @@ extension EmitterTests {
             ("testMapping", testMapping),
             ("testLineBreaks", testLineBreaks),
             ("testAllowUnicode", testAllowUnicode),
-            ("testSortKeys", testSortKeys)
+            ("testSortKeys", testSortKeys),
+            ("testSmartQuotedString", testSmartQuotedString)
         ]
     }
 }

--- a/Tests/YamsTests/SpecTests.swift
+++ b/Tests/YamsTests/SpecTests.swift
@@ -703,7 +703,7 @@ class SpecTests: XCTestCase { // swiftlint:disable:this type_body_length
               different documents.
 
               '
-            not-date: 2002-04-28
+            not-date: '2002-04-28'
             picture: R0lGODlhDAAMAIQAAP//9/X17unp5WZmZgAAAOfn515eXvPz7Y6OjuDg4J+fn5OTk6enp56enmleECcgggoBADs=
 
             """


### PR DESCRIPTION
Fixes #197 