### PR TITLE
[yams-2.0-branch] Cherry picks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ playground.xcworkspace
 # Add this line if you want to avoid checking in source code from Swift Package Manager dependencies.
 Packages/
 .build/
+.swiftpm/
 
 # CocoaPods
 #

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 ##### Bug Fixes
 
 * Fix a bug where `YAMLEncoder` would delay `Date`s by 1 second when encoding
-  values with a `nanosecond` component greater than 999499997.    
+  values with a `nanosecond` component greater than 999499997.  
   [Norio Nomura](https://github.com/norio-nomura)
   [#192](https://github.com/jpsim/Yams/issues/192)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@
 * Accurately represent `Date`s with nanosecond components in Swift 4.x.  
   [Norio Nomura](https://github.com/norio-nomura)
 
+* Change to apply single quoted style to YAML representation of `String`, if 
+  that contents will be resolved to other than `.str` by default `Resolver`.  
+  [Norio Nomura](https://github.com/norio-nomura)
+  [#197](https://github.com/jpsim/Yams/issues/197)
+
 ##### Bug Fixes
 
 * Fix a bug where `YAMLEncoder` would delay `Date`s by 1 second when encoding

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,15 @@
 
 ##### Enhancements
 
-* None.
+* Accurately represent `Date`s with nanosecond components in Swift 4.x.  
+  [Norio Nomura](https://github.com/norio-nomura)
 
 ##### Bug Fixes
 
-* None.
+* Fix a bug where `YAMLEncoder` would delay `Date`s by 1 second when encoding
+  values with a `nanosecond` component greater than 999499997.    
+  [Norio Nomura](https://github.com/norio-nomura)
+  [#192](https://github.com/jpsim/Yams/issues/192)
 
 ## 2.0.0
 

--- a/Sources/Yams/Constructor.swift
+++ b/Sources/Yams/Constructor.swift
@@ -167,24 +167,24 @@ extension Date: ScalarConstructible {
         }
 
         var datecomponents = DateComponents()
-        datecomponents.calendar = Calendar(identifier: .gregorian)
+        datecomponents.calendar = gregorianCalendar
         datecomponents.year = components[0].flatMap { Int($0) }
         datecomponents.month = components[1].flatMap { Int($0) }
         datecomponents.day = components[2].flatMap { Int($0) }
         datecomponents.hour = components[3].flatMap { Int($0) }
         datecomponents.minute = components[4].flatMap { Int($0) }
         datecomponents.second = components[5].flatMap { Int($0) }
-        datecomponents.nanosecond = components[6].flatMap { fraction in
+        let nanoseconds: TimeInterval? = components[6].flatMap { fraction in
             let length = fraction.count
-            let nanosecond: Int?
+            let nanoseconds: Int?
             if length < 9 {
-                nanosecond = Int(fraction).map { number in
+                nanoseconds = Int(fraction).map { number in
                     repeatElement(10, count: 9 - length).reduce(number, *)
                 }
             } else {
-                nanosecond = Int(fraction[..<fraction.index(fraction.startIndex, offsetBy: 9)])
+                nanoseconds = Int(fraction.prefix(9))
             }
-            return nanosecond
+            return nanoseconds.map { Double($0) / 1_000_000_000.0 }
         }
         datecomponents.timeZone = {
             var seconds = 0
@@ -199,8 +199,10 @@ extension Date: ScalarConstructible {
             }
             return TimeZone(secondsFromGMT: seconds)
         }()
-        return datecomponents.date
+        return datecomponents.date.map { nanoseconds.map($0.addingTimeInterval) ?? $0 }
     }
+
+    private static let gregorianCalendar = Calendar(identifier: .gregorian)
 
     private static let timestampPattern: NSRegularExpression = pattern([
         "^([0-9][0-9][0-9][0-9])",          // year

--- a/Sources/Yams/Constructor.swift
+++ b/Sources/Yams/Constructor.swift
@@ -362,8 +362,7 @@ extension String: ScalarConstructible {
             }
         }
 
-        guard let string = node.scalar?.string else { return nil }
-        return string
+        return node.scalar?.string
     }
 }
 

--- a/Sources/Yams/Node.Mapping.swift
+++ b/Sources/Yams/Node.Mapping.swift
@@ -145,7 +145,7 @@ extension Node.Mapping {
         return lazy.map { $0.key }
     }
 
-    /// This mapping's keys. Similar to `Dictionary.keys`.
+    /// This mapping's values. Similar to `Dictionary.values`.
     public var values: LazyMapCollection<Node.Mapping, Node> {
         return lazy.map { $0.value }
     }

--- a/Sources/Yams/Representer.swift
+++ b/Sources/Yams/Representer.swift
@@ -56,9 +56,7 @@ extension Dictionary: NodeRepresentable {
 }
 
 private func represent(_ value: Any) throws -> Node {
-    if let string = value as? String {
-        return Node(string)
-    } else if let representable = value as? NodeRepresentable {
+    if let representable = value as? NodeRepresentable {
         return try representable.represented()
     }
     throw YamlError.representer(problem: "Failed to represent \(value)")
@@ -230,7 +228,8 @@ extension URL: ScalarRepresentable {
 extension String: ScalarRepresentable {
     /// This value's `Node.scalar` representation.
     public func represented() -> Node.Scalar {
-        return .init(self)
+        let scalar = Node.Scalar(self)
+        return scalar.resolvedTag.name == .str ? scalar : .init(self, Tag(.str), .singleQuoted)
     }
 }
 

--- a/Tests/YamsTests/ConstructorTests.swift
+++ b/Tests/YamsTests/ConstructorTests.swift
@@ -465,16 +465,12 @@ class ConstructorTests: XCTestCase { // swiftlint:disable:this type_body_length
     }
 
     func testTimestampWithNanosecond() throws {
-        #if !_runtime(_ObjC) && !swift(>=5.0)
-            // https://bugs.swift.org/browse/SR-3158
-        #else
-            let example = "nanosecond: 2001-12-15T02:59:43.123456789Z\n"
-            let objects = try Yams.load(yaml: example)
-            let expected: [String: Any] = [
-                "nanosecond": timestamp( 0, 2001, 12, 15, 02, 59, 43, 0.123456789)
-            ]
-            YamsAssertEqual(objects, expected)
-        #endif
+        let example = "nanosecond: 2001-12-15T02:59:43.123456789Z\n"
+        let objects = try Yams.load(yaml: example)
+        let expected: [String: Any] = [
+            "nanosecond": timestamp( 0, 2001, 12, 15, 02, 59, 43, 0.123456789)
+        ]
+        YamsAssertEqual(objects, expected)
     }
 
     func testValue() throws {

--- a/Tests/YamsTests/EmitterTests.swift
+++ b/Tests/YamsTests/EmitterTests.swift
@@ -122,6 +122,24 @@ class EmitterTests: XCTestCase {
         let expectedSorted = "key1: value1\nkey2: value2\nkey3: value3\n"
         XCTAssertEqual(yamlSorted, expectedSorted)
     }
+
+    func testSmartQuotedString() throws {
+        let samples: [(string: String, tag: Tag.Name, expected: String, line: UInt)] = [
+            ("string", .str, "string", #line),
+            ("true", .bool, "'true'", #line),
+            ("1", .int, "'1'", #line),
+            ("1.0", .float, "'1.0'", #line),
+            ("null", .null, "'null'", #line),
+            ("2019-07-06", .timestamp, "'2019-07-06'", #line),
+        ]
+        let resolver = Resolver.default
+        for (string, tag, expected, line) in samples {
+            let resolvedTag = resolver.resolveTag(of: Node(string))
+            XCTAssertEqual(resolvedTag, tag, "Resolver resolves unexpected tag", line: line)
+            let yaml = try Yams.dump(object: string)
+            XCTAssertEqual(yaml, "\(expected)\n", line: line)
+        }
+    }
 }
 
 extension EmitterTests {
@@ -132,7 +150,8 @@ extension EmitterTests {
             ("testMapping", testMapping),
             ("testLineBreaks", testLineBreaks),
             ("testAllowUnicode", testAllowUnicode),
-            ("testSortKeys", testSortKeys)
+            ("testSortKeys", testSortKeys),
+            ("testSmartQuotedString", testSmartQuotedString)
         ]
     }
 }

--- a/Tests/YamsTests/EncoderTests.swift
+++ b/Tests/YamsTests/EncoderTests.swift
@@ -119,25 +119,11 @@ class EncoderTests: XCTestCase { // swiftlint:disable:this type_body_length
 
     // MARK: - Date Strategy Tests
     func testEncodingDate() {
-    #if !_runtime(_ObjC) && !swift(>=5.0)
-        print("Decoding 'Date' has issue on Linux with nanoseconds. https://bugs.swift.org/browse/SR-6223")
-        XCTAssertNotEqual(timestamp( 0, 2001, 12, 15, 02, 59, 43, 0.12345678).timeIntervalSinceReferenceDate,
-                          30077983.12345678,
-                          "https://bugs.swift.org/browse/SR-6223 seems to be fixed")
-    #else
         _testRoundTrip(of: Date())
-    #endif
     }
 
     func testEncodingDateMillisecondsSince1970() {
-    #if !_runtime(_ObjC) && !swift(>=5.0)
-        print("Decoding 'Date' has issue on Linux with nanoseconds. https://bugs.swift.org/browse/SR-6223")
-        XCTAssertNotEqual(timestamp( 0, 2001, 12, 15, 02, 59, 43, 0.12345678).timeIntervalSinceReferenceDate,
-                          30077983.12345678,
-                          "https://bugs.swift.org/browse/SR-6223 seems to be fixed")
-    #else
         _testRoundTrip(of: Date(timeIntervalSince1970: 1000.0), expectedYAML: "1970-01-01T00:16:40Z\n")
-    #endif
     }
 
     // MARK: - Data Tests
@@ -337,6 +323,13 @@ class EncoderTests: XCTestCase { // swiftlint:disable:this type_body_length
         XCTAssertNil(t.n3)
         XCTAssertNil(t.n4)
         XCTAssertNil(t.n5)
+    }
+
+    func testEncodingDateWithNanosecondGreaterThan999499977() throws {
+        var timeInterval = 0.0
+        _ = modf(Date().timeIntervalSinceReferenceDate, &timeInterval)
+        let date = Date(timeIntervalSinceReferenceDate: timeInterval + 0.999_499_977)
+        _testRoundTrip(of: date)
     }
 
     // MARK: - Helper Functions
@@ -1113,7 +1106,8 @@ extension EncoderTests {
             ("testDictionary", testDictionary),
             ("testNodeTypeMismatch", testNodeTypeMismatch),
             ("testDecodingConcreteTypeParameter", testDecodingConcreteTypeParameter),
-            ("test_null_yml", test_null_yml)
+            ("test_null_yml", test_null_yml),
+            ("testEncodingDateWithNanosecondGreaterThan999499977", testEncodingDateWithNanosecondGreaterThan999499977)
         ]
     }
 }

--- a/Tests/YamsTests/RepresenterTests.swift
+++ b/Tests/YamsTests/RepresenterTests.swift
@@ -33,12 +33,8 @@ class RepresenterTests: XCTestCase {
             XCTAssertEqual(try Node(date), "2001-12-15T02:59:43Z")
         }
         do { // fractional seconds
-            #if !_runtime(_ObjC) && !swift(>=5.0)
-                // https://bugs.swift.org/browse/SR-3158
-            #else
-                let date = timestamp( 0, 2001, 12, 15, 02, 59, 43, 0.1)
-                XCTAssertEqual(try Node(date), "2001-12-15T02:59:43.1Z")
-            #endif
+            let date = timestamp( 0, 2001, 12, 15, 02, 59, 43, 0.1)
+            XCTAssertEqual(try Node(date), "2001-12-15T02:59:43.1Z")
         }
     }
 

--- a/Tests/YamsTests/SpecTests.swift
+++ b/Tests/YamsTests/SpecTests.swift
@@ -703,7 +703,7 @@ class SpecTests: XCTestCase { // swiftlint:disable:this type_body_length
               different documents.
 
               '
-            not-date: 2002-04-28
+            not-date: '2002-04-28'
             picture: R0lGODlhDAAMAIQAAP//9/X17unp5WZmZgAAAOfn515eXvPz7Y6OjuDg4J+fn5OTk6enp56enmleECcgggoBADs=
 
             """

--- a/Yams.xcodeproj/Yams.xctestplan
+++ b/Yams.xcodeproj/Yams.xctestplan
@@ -1,0 +1,40 @@
+{
+  "configurations" : [
+    {
+      "name" : "UTF16",
+      "options" : {
+        "environmentVariableEntries" : [
+          {
+            "key" : "YAMS_DEFAULT_ENCODING",
+            "value" : "UTF16"
+          }
+        ]
+      }
+    },
+    {
+      "name" : "UTF8",
+      "options" : {
+        "environmentVariableEntries" : [
+          {
+            "key" : "YAMS_DEFAULT_ENCODING",
+            "value" : "UTF8"
+          }
+        ]
+      }
+    }
+  ],
+  "defaultOptions" : {
+
+  },
+  "testTargets" : [
+    {
+      "parallelizable" : true,
+      "target" : {
+        "containerPath" : "container:Yams.xcodeproj",
+        "identifier" : "OBJ_54",
+        "name" : "YamsTests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/Yams.xcodeproj/project.pbxproj
+++ b/Yams.xcodeproj/project.pbxproj
@@ -81,6 +81,7 @@
 		6C788A001EB87232005386F0 /* EncoderTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EncoderTests.swift; sourceTree = "<group>"; };
 		6C788A021EB876C4005386F0 /* Encoder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Encoder.swift; sourceTree = "<group>"; };
 		6C78C5631E29B1CE0096215F /* RepresenterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RepresenterTests.swift; sourceTree = "<group>"; };
+		6C9B503E22B6362B00D82F94 /* Yams.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; name = Yams.xctestplan; path = Yams.xcodeproj/Yams.xctestplan; sourceTree = "<group>"; };
 		6CBAEE191E3839500021BF87 /* Yams.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Yams.h; sourceTree = "<group>"; };
 		6CC2E33E1E22347B00F62269 /* Representer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Representer.swift; sourceTree = "<group>"; };
 		6CE603971E13502E00A13D8D /* Emitter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Emitter.swift; sourceTree = "<group>"; };
@@ -196,6 +197,7 @@
 		OBJ_5 = {
 			isa = PBXGroup;
 			children = (
+				6C9B503E22B6362B00D82F94 /* Yams.xctestplan */,
 				OBJ_6 /* Package.swift */,
 				6C48A76421D1B013007DB7B9 /* Package@swift-4.2.swift */,
 				6C48A76521D1B013007DB7B9 /* Package@swift-5.swift */,
@@ -293,22 +295,23 @@
 		OBJ_1 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0930;
+				LastUpgradeCheck = 1100;
 				TargetAttributes = {
 					OBJ_45 = {
-						LastSwiftMigration = 0900;
+						LastSwiftMigration = 1100;
 					};
 					OBJ_54 = {
-						LastSwiftMigration = 0900;
+						LastSwiftMigration = 1100;
 					};
 				};
 			};
 			buildConfigurationList = OBJ_2 /* Build configuration list for PBXProject "Yams" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
+				Base,
 			);
 			mainGroup = OBJ_5;
 			productRefGroup = OBJ_26 /* Products */;
@@ -402,6 +405,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_COMMA = YES;
@@ -452,6 +456,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_COMMA = YES;

--- a/Yams.xcodeproj/xcshareddata/xcschemes/Yams.xcscheme
+++ b/Yams.xcodeproj/xcshareddata/xcschemes/Yams.xcscheme
@@ -1,25 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0930"
-   version = "1.3">
+   LastUpgradeVersion = "1100"
+   version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
       <BuildActionEntries>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "OBJ_30"
-               BuildableName = "CYaml.framework"
-               BlueprintName = "CYaml"
-               ReferencedContainer = "container:Yams.xcodeproj">
-            </BuildableReference>
-         </BuildActionEntry>
          <BuildActionEntry
             buildForTesting = "YES"
             buildForRunning = "YES"
@@ -37,10 +23,17 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
-      buildConfiguration = "Debug"
+      buildConfiguration = "Release"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
+      <TestPlans>
+         <TestPlanReference
+            reference = "container:Yams.xcodeproj/Yams.xctestplan"
+            default = "YES">
+         </TestPlanReference>
+      </TestPlans>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -53,8 +46,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -66,17 +57,6 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "OBJ_30"
-            BuildableName = "CYaml.framework"
-            BlueprintName = "CYaml"
-            ReferencedContainer = "container:Yams.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"


### PR DESCRIPTION
Cherry-picks:
- #187 Use new features in Xcode 11 (other than dropping Swift 4.0)
- #191 Fix typo
- #193 Enhance handling of `Date` with `nanosecond`
- 7971b0b Trim excess whitespace in changelog entry
- 9b6c777 Apply a very small simplification
- #195 Add .swiftpm/ to .gitignore
- #198 Apply `.singleQuoted` on representing `Node.Scalar` from `String` if `Resolver.default` resolves that to other than `.str`.