### PR TITLE
[CI] Don't specify a destination for watchOS job

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -114,7 +114,7 @@ jobs:
       condition: succeededOrFailed()
     - script: >
         set -o pipefail &&
-        xcodebuild $XCODE_FLAGS build -sdk watchsimulator -destination "name=Apple Watch Series 3 - 38mm"
+        xcodebuild $XCODE_FLAGS build -sdk watchsimulator
       displayName: build on watchOS
       condition: succeededOrFailed()
     - script: >


### PR DESCRIPTION
Since there's no stable watch name for all supported Xcode versions