### PR TITLE
Yams: explicitly cast value for enums

### DIFF
--- a/Sources/Yams/Emitter.swift
+++ b/Sources/Yams/Emitter.swift
@@ -411,7 +411,11 @@ extension Emitter {
 
     private func serializeScalar(_ scalar: Node.Scalar) throws {
         var value = scalar.string.utf8CString, tag = scalar.resolvedTag.name.rawValue.utf8CString
+#if os(Windows)
+        let scalarStyle = yaml_scalar_style_t(rawValue: Int32(scalar.style.rawValue))
+#else
         let scalarStyle = yaml_scalar_style_t(rawValue: scalar.style.rawValue)
+#endif
         var event = yaml_event_t()
         _ = value.withUnsafeMutableBytes { value in
             tag.withUnsafeMutableBytes { tag in
@@ -432,7 +436,11 @@ extension Emitter {
     private func serializeSequence(_ sequence: Node.Sequence) throws {
         var tag = sequence.resolvedTag.name.rawValue.utf8CString
         let implicit: Int32 = sequence.tag.name == .seq ? 1 : 0
+#if os(Windows)
+        let sequenceStyle = yaml_sequence_style_t(rawValue: Int32(sequence.style.rawValue))
+#else
         let sequenceStyle = yaml_sequence_style_t(rawValue: sequence.style.rawValue)
+#endif
         var event = yaml_event_t()
         _ = tag.withUnsafeMutableBytes { tag in
             yaml_sequence_start_event_initialize(
@@ -451,7 +459,11 @@ extension Emitter {
     private func serializeMapping(_ mapping: Node.Mapping) throws {
         var tag = mapping.resolvedTag.name.rawValue.utf8CString
         let implicit: Int32 = mapping.tag.name == .map ? 1 : 0
+#if os(Windows)
+        let mappingStyle = yaml_mapping_style_t(rawValue: Int32(mapping.style.rawValue))
+#else
         let mappingStyle = yaml_mapping_style_t(rawValue: mapping.style.rawValue)
+#endif
         var event = yaml_event_t()
         _ = tag.withUnsafeMutableBytes { tag in
             yaml_mapping_start_event_initialize(

--- a/Sources/Yams/Parser.swift
+++ b/Sources/Yams/Parser.swift
@@ -351,8 +351,13 @@ private class Event {
         return string(from: event.data.scalar.anchor)
     }
     var scalarStyle: Node.Scalar.Style {
+#if os(Windows)
+        // swiftlint:disable:next force_unwrapping
+        return Node.Scalar.Style(rawValue: UInt32(event.data.scalar.style.rawValue))!
+#else
         // swiftlint:disable:next force_unwrapping
         return Node.Scalar.Style(rawValue: event.data.scalar.style.rawValue)!
+#endif
     }
     var scalarTag: String? {
         if event.data.scalar.quoted_implicit == 1 {
@@ -373,8 +378,13 @@ private class Event {
         return string(from: event.data.sequence_start.anchor)
     }
     var sequenceStyle: Node.Sequence.Style {
+#if os(Windows)
+        // swiftlint:disable:next force_unwrapping
+        return Node.Sequence.Style(rawValue: UInt32(event.data.sequence_start.style.rawValue))!
+#else
         // swiftlint:disable:next force_unwrapping
         return Node.Sequence.Style(rawValue: event.data.sequence_start.style.rawValue)!
+#endif
     }
     var sequenceTag: String? {
         return event.data.sequence_start.implicit != 0
@@ -386,8 +396,13 @@ private class Event {
         return string(from: event.data.scalar.anchor)
     }
     var mappingStyle: Node.Mapping.Style {
+#if os(Windows)
+        // swiftlint:disable:next force_unwrapping
+        return Node.Mapping.Style(rawValue: UInt32(event.data.mapping_start.style.rawValue))!
+#else
         // swiftlint:disable:next force_unwrapping
         return Node.Mapping.Style(rawValue: event.data.mapping_start.style.rawValue)!
+#endif
     }
     var mappingTag: String? {
         return event.data.mapping_start.implicit != 0


### PR DESCRIPTION
Enums on Windows are different from Linux and macOS.  Add explicit casts
for the values to be constructed.  This is needed for building YAMS on
Windows.