### PR TITLE
CYaml: add explicit modulemap

### DIFF
--- a/Sources/CYaml/include/module.modulemap
+++ b/Sources/CYaml/include/module.modulemap
@@ -1,0 +1,3 @@
+module CYaml {
+  header "yaml.h"
+}


### PR DESCRIPTION
Yams uses CYaml which requires a module.  s-p-m will implicitly
construct the modulemap for the module, but provide an explicit one for
better control and to enable building without s-p-m.