### PR TITLE
build: add CMake based build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@
 * Support `UUID` scalars.  
   [Ondrej Rafaj](https://github.com/rafiki270)
 
+* Get Yams building for Windows.
+  [Saleem Abdulrasool](https://github.com/compnerd)
+
+* Add support for CMake based builds.
+  [Saleem Abdulrasool](https://github.com/compnerd)
+
 ##### Bug Fixes
 
 * Fix a bug where `YAMLEncoder` would delay `Date`s by 1 second when encoding

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,16 @@
+
+cmake_minimum_required(VERSION 3.15.1)
+
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules)
+
+project(Yams
+  LANGUAGES C Swift)
+
+option(BUILD_SHARED_LIBS "build shared libraries" ON)
+
+find_package(Foundation CONFIG REQUIRED)
+
+include(SwiftSupport)
+
+add_subdirectory(Sources)
+add_subdirectory(cmake/modules)

--- a/README.md
+++ b/README.md
@@ -14,7 +14,21 @@ A sweet and swifty [YAML](http://yaml.org/) parser built on
 ## Installation
 
 Building Yams requires Xcode 10.x or a Swift 4.1+/5.x toolchain with the
-Swift Package Manager.
+Swift Package Manager or CMake and Ninja.
+
+### CMake
+
+CMake 3.15.1 or newer is required.
+
+```
+cmake -H /path/to/build -G Ninja -S /path/to/yams -DCMAKE_BUILD_TYPE=Release -DFoundation_DIR=/path/to/foundation/build/cmake/modules
+cmake --build /path/to/build
+```
+
+To build for macOS, iOS, tvOS, watchOS, additional flags specifying the SDK need
+to be passed to the compiler.  You can do that by adding the
+`-DCMAKE_Swift_FLAGS="-sdk $(xcrun --sdk macosx --show-sdk-path)"` to the CMake
+invocation when configuring.
 
 ### Swift Package Manager
 

--- a/Sources/CMakeLists.txt
+++ b/Sources/CMakeLists.txt
@@ -1,0 +1,2 @@
+add_subdirectory(CYaml)
+add_subdirectory(Yams)

--- a/Sources/CYaml/CMakeLists.txt
+++ b/Sources/CYaml/CMakeLists.txt
@@ -1,0 +1,27 @@
+
+add_library(CYaml
+  src/api.c
+  src/emitter.c
+  src/parser.c
+  src/reader.c
+  src/scanner.c
+  src/writer.c)
+if(NOT BUILD_SHARED_LIBS)
+  target_compile_definitions(CYaml PRIVATE
+    YAML_DECLARE_STATIC)
+endif()
+target_compile_definitions(CYaml PRIVATE
+  YAML_DECLARE_EXPORT)
+target_include_directories(CYaml PUBLIC
+  include)
+
+set_property(GLOBAL APPEND PROPERTY YAMS_EXPORTS CYaml)
+install(TARGETS CYaml
+  EXPORT YamsExports
+  RUNTIME DESTINATION bin
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
+install(FILES
+  include/module.modulemap
+  include/yaml.h
+  DESTINATION include/cyaml)

--- a/Sources/Yams/CMakeLists.txt
+++ b/Sources/Yams/CMakeLists.txt
@@ -1,0 +1,39 @@
+
+add_library(Yams
+  Constructor.swift
+  Decoder.swift
+  Emitter.swift
+  Encoder.swift
+  Mark.swift
+  Node.Mapping.swift
+  Node.Scalar.swift
+  Node.Sequence.swift
+  Node.swift
+  Parser.swift
+  Representer.swift
+  Resolver.swift
+  shim.swift
+  String+Yams.swift
+  Tag.swift
+  YamlError.swift)
+target_compile_definitions(Yams PRIVATE
+  SWIFT_PACKAGE)
+target_link_libraries(Yams PRIVATE
+  CYaml
+  Foundation)
+set_target_properties(Yams PROPERTIES
+  Swift_MODULE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/swift
+  INTERFACE_COMPILE_OPTIONS "SHELL:-Xcc -I$<TARGET_PROPERTY:CYaml,INCLUDE_DIRECTORIES>"
+  INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_CURRENT_BINARY_DIR}/swift)
+
+set_property(GLOBAL APPEND PROPERTY YAMS_EXPORTS Yams)
+get_swift_host_arch(swift_arch)
+install(FILES
+  ${CMAKE_CURRENT_BINARY_DIR}/swift/Yams.swiftmodule
+  ${CMAKE_CURRENT_BINARY_DIR}/swift/Yams.swiftdoc
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/${swift_arch})
+install(TARGETS Yams
+  EXPORT YamsExports
+  RUNTIME DESTINATION bin
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})

--- a/cmake/modules/CMakeLists.txt
+++ b/cmake/modules/CMakeLists.txt
@@ -1,0 +1,9 @@
+
+set(YAMS_EXPORTS_FILE ${CMAKE_CURRENT_BINARY_DIR}/YamsExports.cmake)
+
+configure_file(YamsConfig.cmake.in
+  ${CMAKE_CURRENT_BINARY_DIR}/YamsConfig.cmake)
+
+get_property(YAMS_EXPORTS GLOBAL PROPERTY YAMS_EXPORTS)
+export(TARGETS ${YAMS_EXPORTS}
+  FILE ${YAMS_EXPORTS_FILE})

--- a/cmake/modules/SwiftSupport.cmake
+++ b/cmake/modules/SwiftSupport.cmake
@@ -1,0 +1,37 @@
+
+# Returns the current achitecture name in a variable
+#
+# Usage:
+#   get_swift_host_arch(result_var_name)
+#
+# If the current architecture is supported by Swift, sets ${result_var_name}
+# with the sanitized host architecture name derived from CMAKE_SYSTEM_PROCESSOR.
+function(get_swift_host_arch result_var_name)
+  if("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "x86_64")
+    set("${result_var_name}" "x86_64" PARENT_SCOPE)
+  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "aarch64")
+    set("${result_var_name}" "aarch64" PARENT_SCOPE)
+  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "ppc64")
+    set("${result_var_name}" "powerpc64" PARENT_SCOPE)
+  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "ppc64le")
+    set("${result_var_name}" "powerpc64le" PARENT_SCOPE)
+  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "s390x")
+    set("${result_var_name}" "s390x" PARENT_SCOPE)
+  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "armv6l")
+    set("${result_var_name}" "armv6" PARENT_SCOPE)
+  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "armv7-a")
+    set("${result_var_name}" "armv7" PARENT_SCOPE)
+  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "armv7l")
+    set("${result_var_name}" "armv7" PARENT_SCOPE)
+  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "AMD64")
+    set("${result_var_name}" "x86_64" PARENT_SCOPE)
+  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "IA64")
+    set("${result_var_name}" "itanium" PARENT_SCOPE)
+  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "x86")
+    set("${result_var_name}" "i686" PARENT_SCOPE)
+  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "i686")
+    set("${result_var_name}" "i686" PARENT_SCOPE)
+  else()
+    message(FATAL_ERROR "Unrecognized architecture on host system: ${CMAKE_SYSTEM_PROCESSOR}")
+  endif()
+endfunction()

--- a/cmake/modules/YamsConfig.cmake.in
+++ b/cmake/modules/YamsConfig.cmake.in
@@ -1,0 +1,3 @@
+if(NOT TARGET Yams)
+  include(@YAMS_EXPORTS_FILE@)
+endif()


### PR DESCRIPTION
This adds a CMake (3.15.1) based build to enable building Yams on
platforms where s-p-m does not yet function.  It also enables
cross-compilation of Yams.  This is sufficient to be able to build for
Windows with the following command line:

```
cmake -H build\debug -G Ninja -DFoundation_DIR=... -DCMAKE_Swift_COMPILER=...
cmake --build build\debug
```