### PR TITLE
[GitHub Actions] Update `norio-nomura/action-swiftlint` to 3.0.1

### DIFF
--- a/.github/workflows/swiftlint.yml
+++ b/.github/workflows/swiftlint.yml
@@ -13,4 +13,4 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: GitHub Action for SwiftLint
-        uses: norio-nomura/action-swiftlint@3.0.0
+        uses: norio-nomura/action-swiftlint@3.0.1

--- a/.github/workflows/swiftlint.yml
+++ b/.github/workflows/swiftlint.yml
@@ -13,8 +13,4 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: GitHub Action for SwiftLint
-        # Avoid failing with "server error status: 403" on PR from forked repository
-        if: github.event.pull_request.base.repo.id == github.event.pull_request.head.repo.id
-        uses: norio-nomura/action-swiftlint@2.2.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: norio-nomura/action-swiftlint@3.0.0


### PR DESCRIPTION
- It changed to use [GitHub Actions Logging commands](https://help.github.com/en/github/automating-your-workflow-with-github-actions/development-tools-for-github-actions#logging-commands) instead of GitHub Checks APIs
-  `GITHUB_TOKEN` is no longer needed
- Supports PR from forked repository