### PR TITLE
Fix `YAMLDecoder` to support merging anchors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@
   [Norio Nomura](https://github.com/norio-nomura)
   [#192](https://github.com/jpsim/Yams/issues/192)
 
+* Fix `YAMLDecoder` to support merging anchors.
+  [Brentley Jones](https://github.com/brentleyjones)
+  [#238](https://github.com/jpsim/Yams/issues/238)
+
 ## 2.0.0
 
 ##### Breaking

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,16 +24,16 @@
 * Add support for CMake based builds.
   [Saleem Abdulrasool](https://github.com/compnerd)
 
+* Merge anchors in `YAMLDecoder` by default.  
+  [Brentley Jones](https://github.com/brentleyjones)
+  [#238](https://github.com/jpsim/Yams/issues/238)
+
 ##### Bug Fixes
 
 * Fix a bug where `YAMLEncoder` would delay `Date`s by 1 second when encoding
   values with a `nanosecond` component greater than 999499997.  
   [Norio Nomura](https://github.com/norio-nomura)
   [#192](https://github.com/jpsim/Yams/issues/192)
-
-* Fix `YAMLDecoder` to support merging anchors.
-  [Brentley Jones](https://github.com/brentleyjones)
-  [#238](https://github.com/jpsim/Yams/issues/238)
 
 ## 2.0.0
 

--- a/Sources/Yams/Constructor.swift
+++ b/Sources/Yams/Constructor.swift
@@ -412,7 +412,7 @@ extension Dictionary {
 
 private extension Dictionary {
     static func _construct_mapping(from mapping: Node.Mapping) -> [AnyHashable: Any] {
-        let mapping = flatten_mapping(mapping)
+        let mapping = mapping.flatten()
         // TODO: YAML supports keys other than str.
 #if swift(>=5.0)
         return [AnyHashable: Any](
@@ -426,37 +426,6 @@ private extension Dictionary {
         }
         return dictionary
 #endif
-    }
-
-    private static func flatten_mapping(_ mapping: Node.Mapping) -> Node.Mapping {
-        var pairs = Array(mapping)
-        var merge = [(key: Node, value: Node)]()
-        var index = pairs.startIndex
-        while index < pairs.count {
-            let pair = pairs[index]
-            if pair.key.tag.name == .merge {
-                pairs.remove(at: index)
-                switch pair.value {
-                case .mapping(let mapping):
-                    merge.append(contentsOf: flatten_mapping(mapping))
-                case let .sequence(sequence):
-                    let submerge = sequence
-                        .compactMap { $0.mapping.map(flatten_mapping) }
-                        .reversed()
-                    submerge.forEach {
-                        merge.append(contentsOf: $0)
-                    }
-                default:
-                    break // TODO: Should raise error on other than mapping or sequence
-                }
-            } else if pair.key.tag.name == .value {
-                pair.key.tag.name = .str
-                index += 1
-            } else {
-                index += 1
-            }
-        }
-        return Node.Mapping(merge + pairs, mapping.tag, mapping.style)
     }
 }
 

--- a/Sources/Yams/Decoder.swift
+++ b/Sources/Yams/Decoder.swift
@@ -31,7 +31,7 @@ public class YAMLDecoder {
                           from yaml: String,
                           userInfo: [CodingUserInfoKey: Any] = [:]) throws -> T where T: Swift.Decodable {
         do {
-            let node = try Parser(yaml: yaml, resolver: .basic, encoding: encoding).singleRoot() ?? ""
+            let node = try Parser(yaml: yaml, resolver: Resolver([.merge]), encoding: encoding).singleRoot() ?? ""
             let decoder = _Decoder(referencing: node, userInfo: userInfo)
             let container = try decoder.singleValueContainer()
             return try container.decode(type)
@@ -64,7 +64,7 @@ private struct _Decoder: Decoder {
     let userInfo: [CodingUserInfoKey: Any]
 
     func container<Key>(keyedBy type: Key.Type) throws -> KeyedDecodingContainer<Key> {
-        guard let mapping = node.mapping else {
+        guard let mapping = node.mapping?.flatten() else {
             throw _typeMismatch(at: codingPath, expectation: Node.Mapping.self, reality: node)
         }
         return .init(_KeyedDecodingContainer<Key>(decoder: self, wrapping: mapping))

--- a/Sources/Yams/Node.Mapping.swift
+++ b/Sources/Yams/Node.Mapping.swift
@@ -137,6 +137,41 @@ extension Node.Mapping: TagResolvable {
     static let defaultTagName = Tag.Name.map
 }
 
+// MARK: - Merge support
+
+extension Node.Mapping {
+    func flatten() -> Node.Mapping {
+        var pairs = Array(self)
+        var merge = [(key: Node, value: Node)]()
+        var index = pairs.startIndex
+        while index < pairs.count {
+            let pair = pairs[index]
+            if pair.key.tag.name == .merge {
+                pairs.remove(at: index)
+                switch pair.value {
+                case .mapping(let mapping):
+                    merge.append(contentsOf: mapping.flatten())
+                case let .sequence(sequence):
+                    let submerge = sequence
+                        .compactMap { $0.mapping.map { $0.flatten() } }
+                        .reversed()
+                    submerge.forEach {
+                        merge.append(contentsOf: $0)
+                    }
+                default:
+                    break // TODO: Should raise error on other than mapping or sequence
+                }
+            } else if pair.key.tag.name == .value {
+                pair.key.tag.name = .str
+                index += 1
+            } else {
+                index += 1
+            }
+        }
+        return Node.Mapping(merge + pairs, tag, style)
+    }
+}
+
 // MARK: - Dictionary-like APIs
 
 extension Node.Mapping {

--- a/Tests/YamsTests/EncoderTests.swift
+++ b/Tests/YamsTests/EncoderTests.swift
@@ -284,6 +284,28 @@ class EncoderTests: XCTestCase { // swiftlint:disable:this type_body_length
 
         expectEqual(type(of: decoded), Employee.self, "Expected decoded value to be of type Employee; got \(type(of: decoded)) instead.")
     }
+    
+    func testDecodingAnchors() throws {
+        struct AnchorSample: Decodable {
+            struct Host: Decodable {
+                let here: Bool
+            }
+            
+            let host: Host
+        }
+        
+        let yaml = """
+            z: &anchor
+              here: true
+            host:
+              <<: *anchor
+            """
+        
+        let decoder = YAMLDecoder()
+        let decoded = try decoder.decode(AnchorSample.self, from: yaml)
+        
+        XCTAssertTrue(decoded.host.here)
+    }
 
     func test_null_yml() throws {
         let s = """


### PR DESCRIPTION
Currently `YAMLDecoder` uses `Resolver.basic` instead of `Resolver.default`, since it doesn't need to resolve types. This has the side effect of not including `.merge` as an option, making `decode` fail to see anchored properties.