### PR TITLE
Run CI jobs with Swift 5.2

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,3 +1,2 @@
-ignore:
-  - Sources/CYaml
-  - Tests
+paths:
+  - Sources/Yams

--- a/.github/workflows/jazzy.yml
+++ b/.github/workflows/jazzy.yml
@@ -25,7 +25,7 @@ jobs:
   Jazzy:
     runs-on: ubuntu-latest
     container:
-      image: norionomura/jazzy:0.11.2_swift-5.1.1
+      image: norionomura/jazzy:0.13.2_swift-5.2.1
     steps:
       - uses: actions/checkout@v1
       - run: bundle install --path vendor/bundle

--- a/.github/workflows/pod_lib_lint.yml
+++ b/.github/workflows/pod_lib_lint.yml
@@ -22,7 +22,7 @@ jobs:
     name: pod lib lint
     runs-on: macos-latest
     env:
-      DEVELOPER_DIR: /Applications/Xcode_11.2.app
+      DEVELOPER_DIR: /Applications/Xcode_11.4.app
     steps:
       - uses: actions/checkout@v1
       - run: bundle install --path vendor/bundle

--- a/.github/workflows/swiftlint.yml
+++ b/.github/workflows/swiftlint.yml
@@ -13,4 +13,4 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: GitHub Action for SwiftLint
-        uses: norio-nomura/action-swiftlint@3.0.1
+        uses: norio-nomura/action-swiftlint@3.1.0

--- a/.github/workflows/swiftlint_analyze.yml
+++ b/.github/workflows/swiftlint_analyze.yml
@@ -23,7 +23,7 @@ jobs:
   Analyze:
     runs-on: macos-latest
     env:
-      DEVELOPER_DIR: /Applications/Xcode_11.2.app
+      DEVELOPER_DIR: /Applications/Xcode_11.4.app
     steps:
       - uses: actions/checkout@v1
       - name: Generate xcodebuild.log

--- a/.github/workflows/swiftpm.yml
+++ b/.github/workflows/swiftpm.yml
@@ -25,7 +25,7 @@ jobs:
   Xcode:
     strategy:
       matrix:
-        xcode_version: ['11', '11.1', '11.2']
+        xcode_version: ['11', '11.1', '11.2', '11.3', '11.4']
     runs-on: macos-latest
     env:
       DEVELOPER_DIR: /Applications/Xcode_${{ matrix.xcode_version }}.app
@@ -38,7 +38,7 @@ jobs:
   Linux:
     strategy:
       matrix:
-        tag: ['4.1', '4.2', '5.0', '5.1']
+        tag: ['4.1', '4.2', '5.0', '5.1', '5.2']
     runs-on: ubuntu-latest
     container:
       image: swift:${{ matrix.tag }}

--- a/.github/workflows/xcodebuild.yml
+++ b/.github/workflows/xcodebuild.yml
@@ -31,7 +31,11 @@ jobs:
           - version: '11.1'
             flags_for_test: -parallel-testing-enabled NO
           - version: '11.2'
-            flags_for_test: -parallel-testing-enabled NO -enableCodeCoverage YES 
+            flags_for_test: -parallel-testing-enabled NO -enableCodeCoverage YES
+          - version: '11.3'
+            flags_for_test: -parallel-testing-enabled NO -enableCodeCoverage YES
+          - version: '11.4'
+            flags_for_test: -parallel-testing-enabled NO -enableCodeCoverage YES
         xcode_flags: ['-scheme Yams -project Yams.xcodeproj']
     runs-on: macos-latest
     env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,10 @@
 * Support `UUID` scalars.  
   [Ondrej Rafaj](https://github.com/rafiki270)
 
-* Get Yams building for Windows.
+* Get Yams building for Windows.  
   [Saleem Abdulrasool](https://github.com/compnerd)
 
-* Add support for CMake based builds.
+* Add support for CMake based builds.  
   [Saleem Abdulrasool](https://github.com/compnerd)
 
 * Merge anchors in `YAMLDecoder` by default.  
@@ -34,6 +34,9 @@
   values with a `nanosecond` component greater than 999499997.  
   [Norio Nomura](https://github.com/norio-nomura)
   [#192](https://github.com/jpsim/Yams/issues/192)
+
+* Fix dangling pointer warning with Swift 5.2.  
+  [JP Simard](https://github.com/jpsim)
 
 ## 2.0.0
 

--- a/Sources/Yams/Emitter.swift
+++ b/Sources/Yams/Emitter.swift
@@ -330,15 +330,15 @@ public final class Emitter {
             throw YamlError.emitter(problem: "serializer is closed")
         }
         var event = yaml_event_t()
-        var versionDirective: UnsafeMutablePointer<yaml_version_directive_t>?
-        var versionDirectiveValue = yaml_version_directive_t()
         if let (major, minor) = options.version {
-            versionDirectiveValue.major = Int32(major)
-            versionDirectiveValue.minor = Int32(minor)
-            versionDirective = UnsafeMutablePointer(&versionDirectiveValue)
+            var versionDirective = yaml_version_directive_t(major: Int32(major), minor: Int32(minor))
+            // TODO: Support tags
+            yaml_document_start_event_initialize(&event, &versionDirective, nil, nil, options.explicitStart ? 0 : 1)
+        } else {
+            // TODO: Support tags
+            yaml_document_start_event_initialize(&event, nil, nil, nil, options.explicitStart ? 0 : 1)
         }
-        // TODO: Support tags
-        yaml_document_start_event_initialize(&event, versionDirective, nil, nil, options.explicitStart ? 0 : 1)
+
         try emit(&event)
         try serializeNode(node)
         yaml_document_end_event_initialize(&event, options.explicitEnd ? 0 : 1)


### PR DESCRIPTION
Also:

* Fix dangling pointer warning with Swift 5.2
* Only check code coverage in Sources/Yams