### PR TITLE
Fix `Yams.dump` when object contains a keyed null value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@
 
 ##### Bug Fixes
 
+* Fix `Yams.dump` when object contains a keyed null value.  
+  [JP Simard](https://github.com/jpsim)
+  [#232](https://github.com/jpsim/Yams/issues/232)
+
 * Fix a bug where `YAMLEncoder` would delay `Date`s by 1 second when encoding
   values with a `nanosecond` component greater than 999499997.  
   [Norio Nomura](https://github.com/norio-nomura)

--- a/Sources/Yams/Representer.swift
+++ b/Sources/Yams/Representer.swift
@@ -73,6 +73,13 @@ extension ScalarRepresentable {
     }
 }
 
+extension NSNull: ScalarRepresentable {
+    /// This value's `Node.scalar` representation.
+    public func represented() -> Node.Scalar {
+        return .init("null", Tag(.null))
+    }
+}
+
 extension Bool: ScalarRepresentable {
     /// This value's `Node.scalar` representation.
     public func represented() -> Node.Scalar {

--- a/Tests/YamsTests/RepresenterTests.swift
+++ b/Tests/YamsTests/RepresenterTests.swift
@@ -106,7 +106,20 @@ class RepresenterTests: XCTestCase {
     }
 
     func testOptional() throws {
+        // Optional.none
         XCTAssertEqual(try Node(Int?.none), "null")
+
+        // Optional.some(.none)
+        XCTAssertEqual(try Node(Int??.some(nil)), "null")
+
+        // Keyed null - https://github.com/jpsim/Yams/issues/232
+        let keyedNullString = """
+            A: null
+
+            """
+        let keyedNullObject = try Yams.load(yaml: keyedNullString)
+        let keyedNullDump = try Yams.dump(object: keyedNullObject)
+        XCTAssertEqual(keyedNullDump, keyedNullString)
     }
 
     func testArray() throws {


### PR DESCRIPTION
Fixes https://github.com/jpsim/Yams/issues/232