### PR TITLE
Fix CMake

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -31,6 +31,7 @@ jobs:
       DEVELOPER_DIR: /Applications/Xcode_${{ matrix.xcode_version }}.app
     steps:
       - uses: actions/checkout@v1
+      - run: brew install cmake ninja
       - run: swift -version
       - run: cmake -B build -G Ninja -S . -DCMAKE_BUILD_TYPE=Release
       - run: cmake --build build

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -31,7 +31,6 @@ jobs:
       DEVELOPER_DIR: /Applications/Xcode_${{ matrix.xcode_version }}.app
     steps:
       - uses: actions/checkout@v1
-      - run: brew install cmake ninja realpath
       - run: swift -version
-      - run: cmake -B `realpath .`/build -G Ninja -S `realpath .` -DCMAKE_BUILD_TYPE=Release
-      - run: cmake --build `realpath .`/build
+      - run: cmake -B build -G Ninja -S . -DCMAKE_BUILD_TYPE=Release
+      - run: cmake --build build

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -1,4 +1,4 @@
-name: SwiftPM
+name: CMake
 
 on:
   push:

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -1,0 +1,37 @@
+name: SwiftPM
+
+on:
+  push:
+    branches: [master]
+    paths: 
+      - '.github/workflows/cmake.yml'
+      - '**/CMakeLists.txt'
+      - '**/*.cmake'
+      - '**/*.cmake.in'
+      - 'Sources/**/*.[ch]'
+      - 'Sources/**/*.swift'
+      - 'Sources/**/module.modulemap'
+  pull_request:
+    paths: 
+      - '.github/workflows/cmake.yml'
+      - '**/CMakeLists.txt'
+      - '**/*.cmake'
+      - '**/*.cmake.in'
+      - 'Sources/**/*.[ch]'
+      - 'Sources/**/*.swift'
+      - 'Sources/**/module.modulemap'
+
+jobs:
+  Xcode:
+    strategy:
+      matrix:
+        xcode_version: ['11', '11.1', '11.2', '11.3', '11.4']
+    runs-on: macos-latest
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_${{ matrix.xcode_version }}.app
+    steps:
+      - uses: actions/checkout@v1
+      - run: brew install cmake ninja
+      - run: swift -version
+      - run: cmake -B `realpath .`/build -G Ninja -S `realpath .` -DCMAKE_BUILD_TYPE=Release
+      - run: cmake --build `realpath .`/build

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -31,7 +31,7 @@ jobs:
       DEVELOPER_DIR: /Applications/Xcode_${{ matrix.xcode_version }}.app
     steps:
       - uses: actions/checkout@v1
-      - run: brew install cmake ninja
+      - run: brew install cmake ninja realpath
       - run: swift -version
       - run: cmake -B `realpath .`/build -G Ninja -S `realpath .` -DCMAKE_BUILD_TYPE=Release
       - run: cmake --build `realpath .`/build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@
 
 ##### Bug Fixes
 
-* None.
+* Fix CMake support.  
+  [JP Simard](https://github.com/jpsim)
 
 ## 3.0.0
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,18 @@ project(Yams
 
 option(BUILD_SHARED_LIBS "build shared libraries" ON)
 
-find_package(Foundation CONFIG REQUIRED)
+if (CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+  set(USE_CORELIBS_FOUNDATION FALSE)
+else()
+  set(USE_CORELIBS_FOUNDATION TRUE)
+endif()
+
+if(USE_CORELIBS_FOUNDATION)
+  find_package(Foundation CONFIG REQUIRED)
+  set(CORELIBS_FOUNDATION "Foundation")
+else()
+  set(CORELIBS_FOUNDATION "")
+endif()
 
 include(SwiftSupport)
 

--- a/README.md
+++ b/README.md
@@ -18,17 +18,23 @@ Swift Package Manager or CMake and Ninja.
 
 ### CMake
 
-CMake 3.15.1 or newer is required.
+CMake 3.17.2 or newer is required, along with Ninja 1.9.0 or newer.
+
+When building for non-Apple platforms:
 
 ```
-cmake -H /path/to/build -G Ninja -S /path/to/yams -DCMAKE_BUILD_TYPE=Release -DFoundation_DIR=/path/to/foundation/build/cmake/modules
+cmake -B /path/to/build -G Ninja -S /path/to/yams -DCMAKE_BUILD_TYPE=Release -DFoundation_DIR=/path/to/foundation/build/cmake/modules
 cmake --build /path/to/build
 ```
 
-To build for macOS, iOS, tvOS, watchOS, additional flags specifying the SDK need
-to be passed to the compiler.  You can do that by adding the
-`-DCMAKE_Swift_FLAGS="-sdk $(xcrun --sdk macosx --show-sdk-path)"` to the CMake
-invocation when configuring.
+To build for Apple platforms (macOS, iOS, tvOS, watchOS), there is no
+need to spearately build Foundation because it is included as part of
+the SDK:
+
+```
+cmake -B /path/to/build -G Ninja -S /path/to/yams -DCMAKE_BUILD_TYPE=Release
+cmake --build /path/to/build
+```
 
 ### Swift Package Manager
 

--- a/Sources/Yams/CMakeLists.txt
+++ b/Sources/Yams/CMakeLists.txt
@@ -12,15 +12,15 @@ add_library(Yams
   Parser.swift
   Representer.swift
   Resolver.swift
-  shim.swift
   String+Yams.swift
   Tag.swift
   YamlError.swift)
 target_compile_definitions(Yams PRIVATE
   SWIFT_PACKAGE)
+
 target_link_libraries(Yams PRIVATE
   CYaml
-  Foundation)
+  ${CORELIBS_FOUNDATION})
 set_target_properties(Yams PROPERTIES
   Swift_MODULE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/swift
   INTERFACE_COMPILE_OPTIONS "SHELL:-Xcc -I$<TARGET_PROPERTY:CYaml,INCLUDE_DIRECTORIES>"


### PR DESCRIPTION
The CMake instructions in the readme didn't quite work when I tried them on macOS today.

This patch includes a few changes to `CMakeLists.txt` and the `README.md` instructions to reflect the latest steps to build.

Also add a CI job to validate that this keeps working moving forward.