### PR TITLE
build: simplify Foundation handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,18 +8,8 @@ project(Yams
 
 option(BUILD_SHARED_LIBS "build shared libraries" ON)
 
-if (CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-  set(USE_CORELIBS_FOUNDATION FALSE)
-else()
-  set(USE_CORELIBS_FOUNDATION TRUE)
-endif()
-
-if(USE_CORELIBS_FOUNDATION)
-  find_package(Foundation CONFIG REQUIRED)
-  set(CORELIBS_FOUNDATION "Foundation")
-else()
-  set(CORELIBS_FOUNDATION "")
-endif()
+find_package(dispatch CONFIG QUIET)
+find_package(Foundation CONFIG QUIET)
 
 if(CMAKE_VERSION VERSION_LESS 3.16 AND CMAKE_SYSTEM_NAME STREQUAL Windows)
   set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)

--- a/Sources/Yams/CMakeLists.txt
+++ b/Sources/Yams/CMakeLists.txt
@@ -20,7 +20,8 @@ target_compile_definitions(Yams PRIVATE
 
 target_link_libraries(Yams PRIVATE
   CYaml
-  ${CORELIBS_FOUNDATION})
+  $<$<NOT:$<PLATFORM_ID:Darwin>>:dispatch>
+  $<$<NOT:$<PLATFORM_ID:Darwin>>:Foundation>)
 set_target_properties(Yams PROPERTIES
   INTERFACE_COMPILE_OPTIONS "SHELL:-Xcc -I$<TARGET_PROPERTY:CYaml,INCLUDE_DIRECTORIES>"
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})


### PR DESCRIPTION
Enable building against an uninstalled copy of Foundation but do not
require it.  This allows for a simpler build system.  If the user wishes
to build against an out-of-tree Foundation, they can simply specify
`Foundation_DIR` and `dispatch_DIR` when configuring and CMake will
handle the rest.