### PR TITLE
build: add the ability to run the test suite from CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,11 @@ project(Yams
   LANGUAGES C Swift)
 
 option(BUILD_SHARED_LIBS "build shared libraries" ON)
+if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
+  option(BUILD_TESTING "build tests by default" NO)
+else()
+  option(BUILD_TESTING "build tests by default" YES)
+endif()
 
 if (CMAKE_SYSTEM_NAME STREQUAL "Darwin")
   set(USE_CORELIBS_FOUNDATION FALSE)
@@ -32,6 +37,10 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 set(CMAKE_Swift_MODULE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/swift)
 
 include(SwiftSupport)
+include(CTest)
 
 add_subdirectory(Sources)
+if(BUILD_TESTING)
+  add_subdirectory(Tests)
+endif()
 add_subdirectory(cmake/modules)

--- a/Sources/Yams/CMakeLists.txt
+++ b/Sources/Yams/CMakeLists.txt
@@ -17,6 +17,8 @@ add_library(Yams
   YamlError.swift)
 target_compile_definitions(Yams PRIVATE
   SWIFT_PACKAGE)
+target_compile_options(Yams PRIVATE
+  $<$<BOOL:${BUILD_TESTING}>:-enable-testing>)
 
 target_link_libraries(Yams PRIVATE
   CYaml

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -1,0 +1,12 @@
+find_package(XCTest CONFIG QUIET)
+
+add_subdirectory(YamsTests)
+
+add_executable(YamsTestRunner
+  LinuxMain.swift)
+target_link_libraries(YamsTestRunner PRIVATE
+  YamsTests
+  XCTest)
+
+add_test(NAME YamsTests
+  COMMAND YamsTestRunner)

--- a/Tests/YamsTests/CMakeLists.txt
+++ b/Tests/YamsTests/CMakeLists.txt
@@ -1,0 +1,21 @@
+add_library(YamsTests
+  ConstructorTests.swift
+  EmitterTests.swift
+  EncoderTests.swift
+  MarkTests.swift
+  NodeTests.swift
+  PerformanceTests.swift
+  RepresenterTests.swift
+  ResolverTests.swift
+  SpecTests.swift
+  StringTests.swift
+  TestHelper.swift
+  YamlErrorTests.swift)
+set_target_properties(YamsTests PROPERTIES
+  INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
+target_link_libraries(YamsTests PUBLIC
+  Foundation
+  XCTest
+  Yams)
+target_compile_options(YamsTests PRIVATE
+  -enable-testing)


### PR DESCRIPTION
Expand the CMake based build to support running the test suite.  This
allows testing on Windows as well.  Although the test suite does not
fully pass on Windows yet, this brings us closer.

With this on Windows, the following is the result:

```
  Test Suite 'All tests' failed at 2020-05-14 12:11:08.871
           Executed 120 tests, with 9 failures (0 unexpected) in 0.505 (0.505) seconds
```

The failures in the test suite correspond to the conversion of floating
point values in the infinity and NaN cases (either converting to
`-infe+0`, `infe+0`, or `nane+0` instead of `-inf`, `inf`, `nan`, or
converting to `NaN` instead of `nan`).