### PR TITLE
Yams: remove conditional cases for Windows

### DIFF
--- a/Sources/Yams/Emitter.swift
+++ b/Sources/Yams/Emitter.swift
@@ -411,11 +411,7 @@ extension Emitter {
 
     private func serializeScalar(_ scalar: Node.Scalar) throws {
         var value = scalar.string.utf8CString, tag = scalar.resolvedTag.name.rawValue.utf8CString
-#if os(Windows)
-        let scalarStyle = yaml_scalar_style_t(rawValue: Int32(scalar.style.rawValue))
-#else
-        let scalarStyle = yaml_scalar_style_t(rawValue: scalar.style.rawValue)
-#endif
+        let scalarStyle = yaml_scalar_style_t(rawValue: numericCast(scalar.style.rawValue))
         var event = yaml_event_t()
         _ = value.withUnsafeMutableBytes { value in
             tag.withUnsafeMutableBytes { tag in
@@ -436,11 +432,7 @@ extension Emitter {
     private func serializeSequence(_ sequence: Node.Sequence) throws {
         var tag = sequence.resolvedTag.name.rawValue.utf8CString
         let implicit: Int32 = sequence.tag.name == .seq ? 1 : 0
-#if os(Windows)
-        let sequenceStyle = yaml_sequence_style_t(rawValue: Int32(sequence.style.rawValue))
-#else
-        let sequenceStyle = yaml_sequence_style_t(rawValue: sequence.style.rawValue)
-#endif
+        let sequenceStyle = yaml_sequence_style_t(rawValue: numericCast(sequence.style.rawValue))
         var event = yaml_event_t()
         _ = tag.withUnsafeMutableBytes { tag in
             yaml_sequence_start_event_initialize(
@@ -459,11 +451,7 @@ extension Emitter {
     private func serializeMapping(_ mapping: Node.Mapping) throws {
         var tag = mapping.resolvedTag.name.rawValue.utf8CString
         let implicit: Int32 = mapping.tag.name == .map ? 1 : 0
-#if os(Windows)
-        let mappingStyle = yaml_mapping_style_t(rawValue: Int32(mapping.style.rawValue))
-#else
-        let mappingStyle = yaml_mapping_style_t(rawValue: mapping.style.rawValue)
-#endif
+        let mappingStyle = yaml_mapping_style_t(rawValue: numericCast(mapping.style.rawValue))
         var event = yaml_event_t()
         _ = tag.withUnsafeMutableBytes { tag in
             yaml_mapping_start_event_initialize(

--- a/Sources/Yams/Parser.swift
+++ b/Sources/Yams/Parser.swift
@@ -351,13 +351,8 @@ private class Event {
         return string(from: event.data.scalar.anchor)
     }
     var scalarStyle: Node.Scalar.Style {
-#if os(Windows)
         // swiftlint:disable:next force_unwrapping
-        return Node.Scalar.Style(rawValue: UInt32(event.data.scalar.style.rawValue))!
-#else
-        // swiftlint:disable:next force_unwrapping
-        return Node.Scalar.Style(rawValue: event.data.scalar.style.rawValue)!
-#endif
+        return Node.Scalar.Style(rawValue: numericCast(event.data.scalar.style.rawValue))!
     }
     var scalarTag: String? {
         if event.data.scalar.quoted_implicit == 1 {
@@ -378,13 +373,8 @@ private class Event {
         return string(from: event.data.sequence_start.anchor)
     }
     var sequenceStyle: Node.Sequence.Style {
-#if os(Windows)
         // swiftlint:disable:next force_unwrapping
-        return Node.Sequence.Style(rawValue: UInt32(event.data.sequence_start.style.rawValue))!
-#else
-        // swiftlint:disable:next force_unwrapping
-        return Node.Sequence.Style(rawValue: event.data.sequence_start.style.rawValue)!
-#endif
+        return Node.Sequence.Style(rawValue: numericCast(event.data.sequence_start.style.rawValue))!
     }
     var sequenceTag: String? {
         return event.data.sequence_start.implicit != 0
@@ -396,13 +386,8 @@ private class Event {
         return string(from: event.data.scalar.anchor)
     }
     var mappingStyle: Node.Mapping.Style {
-#if os(Windows)
         // swiftlint:disable:next force_unwrapping
-        return Node.Mapping.Style(rawValue: UInt32(event.data.mapping_start.style.rawValue))!
-#else
-        // swiftlint:disable:next force_unwrapping
-        return Node.Mapping.Style(rawValue: event.data.mapping_start.style.rawValue)!
-#endif
+        return Node.Mapping.Style(rawValue: numericCast(event.data.mapping_start.style.rawValue))!
     }
     var mappingTag: String? {
         return event.data.mapping_start.implicit != 0


### PR DESCRIPTION
Unify the non-Windows and Windows paths.  The full codebase now builds
without any special case for Windows.