### PR TITLE
Fix use of pow in separateFractionalSecond

### DIFF
--- a/Sources/Yams/Representer.swift
+++ b/Sources/Yams/Representer.swift
@@ -127,7 +127,11 @@ private extension TimeInterval {
     func separateFractionalSecond(withPrecision precision: Int) -> (integral: TimeInterval, fractional: Int) {
         var integral = 0.0
         let fractional = modf(self, &integral)
+#if os(Linux)
+        let radix = Glibc.pow(10.0, Double(precision))
+#else
         let radix = pow(10.0, Double(precision))
+#endif
         let rounded = Int((fractional * radix).rounded())
         let quotient = rounded / Int(radix)
         return quotient != 0 ? // carry-up?


### PR DESCRIPTION
Fixes the `Yams/Representer.swift:130:21: error: static member 'pow' cannot be used on instance of type 'Double'` we hit.