### PR TITLE
Fix and test string -> integer misstep upon decoding.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,9 @@
 
 ##### Bug Fixes
 
-* None.
+* String scalars containing numbers are no longer decoded as numbers.
+  [Matt Polzin](https://github.com/mattpolzin)
+  [#263](https://github.com/jpsim/Yams/issues/263)
 
 ## 3.0.1
 

--- a/Sources/Yams/Constructor.swift
+++ b/Sources/Yams/Constructor.swift
@@ -248,6 +248,10 @@ extension ScalarConstructible where Self: FloatingPoint & SexagesimalConvertible
     /// - returns: An instance of `FloatingPoint & SexagesimalConvertible`, if one was successfully extracted
     ///            from the scalar.
     public static func construct(from scalar: Node.Scalar) -> Self? {
+        guard scalar.style == .any || scalar.style == .plain else {
+            return nil
+        }
+
         switch scalar.string {
         case ".inf", ".Inf", ".INF", "+.inf", "+.Inf", "+.INF":
             return .infinity
@@ -267,6 +271,10 @@ extension ScalarConstructible where Self: FloatingPoint & SexagesimalConvertible
 
 private extension FixedWidthInteger where Self: SexagesimalConvertible {
     static func _construct(from scalar: Node.Scalar) -> Self? {
+        guard scalar.style == .any || scalar.style == .plain else {
+            return nil
+        }
+
         let scalarWithSign = scalar.string.replacingOccurrences(of: "_", with: "")
 
         if scalarWithSign == "0" {

--- a/Tests/YamsTests/EncoderTests.swift
+++ b/Tests/YamsTests/EncoderTests.swift
@@ -151,6 +151,17 @@ class EncoderTests: XCTestCase { // swiftlint:disable:this type_body_length
         _testRoundTrip(of: OptionalTopLevelWrapper(url), expectedYAML: expectedYAML)
     }
 
+    func testNumberInString() throws {
+        _testDecode(of: String.self, from: "'10'", expectedValue: "10")
+        _testDecode(of: String.self, from: "'10.5'", expectedValue: "10.5")
+
+        _testDecode(of: Int.self, from: "10", expectedValue: 10)
+        _testDecode(of: Double.self, from: "10.5", expectedValue: 10.5)
+
+        _testDecodeShouldFail(of: Int.self, from: "'10'")
+        _testDecodeShouldFail(of: Double.self, from: "'10.5'")
+    }
+
     func testValuesInSingleValueContainer() throws {
         _testRoundTrip(of: true)
         _testRoundTrip(of: false)
@@ -366,6 +377,39 @@ class EncoderTests: XCTestCase { // swiftlint:disable:this type_body_length
         } catch {
             XCTFail("Rout trip test of \(T.self) failed with error: \(error)", file: (file), line: line)
         }
+    }
+
+    private func _testDecode<T>(of type: T.Type,
+                                from string: String,
+                                expectedValue value: T?,
+                                file: StaticString = #file,
+                                line: UInt = #line) where T: Codable, T: Equatable {
+        do {
+            let decoder = YAMLDecoder()
+            let decoded = try decoder.decode(T.self, from: string)
+            XCTAssertEqual(decoded, value, "\(T.self) did not decode properly from expected value.",
+                file: (file), line: line)
+
+        } catch let error as DecodingError {
+            XCTFail("Failed to decode \(T.self) from YAML by error: \(error)", file: (file), line: line)
+        } catch {
+            XCTFail("Decode test of \(T.self) failed with error: \(error)", file: (file), line: line)
+        }
+    }
+
+    private func _testDecodeShouldFail<T>(of type: T.Type,
+                                       from string: String,
+                                       file: StaticString = #file,
+                                       line: UInt = #line) where T: Codable {
+        do {
+            let decoder = YAMLDecoder()
+            _ = try decoder.decode(T.self, from: string)
+        } catch _ as DecodingError {
+            return
+        } catch {
+            XCTFail("Decode test of \(T.self) failed in unexpected way with error: \(error)", file: (file), line: line)
+        }
+        XCTFail("Decode test of \(T.self) did not fail as expected.")
     }
 }
 


### PR DESCRIPTION
Fixes https://github.com/jpsim/Yams/issues/263 by only constructing integer and floating point values from scalars if those scalars are in the `plain` "flow" style. It additionally allows through scalars with no styling information (`any`).