### PR TITLE
Release 4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Master
+## 4.0.0
 
 ##### Breaking
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ cmake --build /path/to/build
 
 ### Swift Package Manager
 
-Add `.package(url: "https://github.com/jpsim/Yams.git", from: "3.0.1")` to your
+Add `.package(url: "https://github.com/jpsim/Yams.git", from: "4.0.0")` to your
 `Package.swift` file's `dependencies`.
 
 ### CocoaPods

--- a/Yams.podspec
+++ b/Yams.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name                      = 'Yams'
-  s.version                   = '3.0.1'
+  s.version                   = '4.0.0'
   s.summary                   = 'A sweet and swifty YAML parser.'
   s.homepage                  = 'https://github.com/jpsim/Yams'
   s.source                    = { :git => s.homepage + '.git', :tag => s.version }

--- a/Yams.xcodeproj/Yams_Info.plist
+++ b/Yams.xcodeproj/Yams_Info.plist
@@ -14,7 +14,7 @@
   <key>CFBundlePackageType</key>
   <string>FMWK</string>
   <key>CFBundleShortVersionString</key>
-  <string>3.0.1</string>
+  <string>4.0.0</string>
   <key>CFBundleSignature</key>
   <string>????</string>
   <key>CFBundleVersion</key>


### PR DESCRIPTION
Bumping major version number because we're increasing the minimum required Swift version from 4.1 to 5.1.