### PR TITLE
Yams: repair the build with the autodifferentiation toolchain

### DIFF
--- a/Sources/Yams/Representer.swift
+++ b/Sources/Yams/Representer.swift
@@ -10,6 +10,9 @@
 import CoreFoundation
 #endif
 import Foundation
+#if os(Windows)
+import MSVCRT
+#endif
 
 public extension Node {
     /// Initialize a `Node` with a value of `NodeRepresentable`.


### PR DESCRIPTION
```
error: static member 'pow' cannot be used on instance of type 'Double'
```

When building Yams with the TensorFlow toolchain, this crops us.  Simply
add the explicit type annotation.