### PR TITLE
CI: improve CMake testing

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -35,4 +35,5 @@ jobs:
       - run: swift -version
       - run: cmake -B build -G Ninja -S . -DCMAKE_BUILD_TYPE=Release
       - run: cmake --build build
-      - run: file build/lib/libYams.dylib | grep "Mach-O 64-bit dynamically linked shared library x86_64"
+      - run: cmake --build build --target install
+      - run: file /usr/local/lib/swift/macosx/libYams.dylib | grep "Mach-O 64-bit dynamically linked shared library x86_64"


### PR DESCRIPTION
Improve the testing with CMake to exercise the installation path.  This
ensures that installation of the libraries works properly.