### PR TITLE
Fix build with tensorflow toolchain

### DIFF
--- a/Sources/Yams/Representer.swift
+++ b/Sources/Yams/Representer.swift
@@ -130,7 +130,13 @@ private extension TimeInterval {
     func separateFractionalSecond(withPrecision precision: Int) -> (integral: TimeInterval, fractional: Int) {
         var integral = 0.0
         let fractional = modf(self, &integral)
+        // Can't use `pow` free function due to https://bugs.swift.org/browse/TF-1203.
+        // TODO: Remove condition after that bug is fixed.
+        #if canImport(TensorFlow)
+        let radix = Double.pow(10.0, Double(precision))
+        #else
         let radix = pow(10.0, Double(precision))
+        #endif
         let rounded = Int((fractional * radix).rounded())
         let quotient = rounded / Int(radix)
         return quotient != 0 ? // carry-up?


### PR DESCRIPTION
Due to https://bugs.swift.org/browse/TF-1203, there's a build failure
without this patch:

```
error: static member 'pow' cannot be used on instance of type 'Double'
```

I believe this was the intent of 70140a180ae63292c5189815d35480269087c306, but it didn't seem to actually fix it.