### PR TITLE
Fix mark for sequences and mappings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@
 
 ##### Bug Fixes
 
-* None.
+* Fix mark for sequences and mappings.
+  [Brentley Jones](https://github.com/brentleyjones)
 
 ## 4.0.3
 

--- a/Sources/Yams/Parser.swift
+++ b/Sources/Yams/Parser.swift
@@ -336,7 +336,7 @@ private extension Parser {
             array.append(try loadNode(from: event))
             event = try parse()
         }
-        let node = Node.sequence(.init(array, tag(firstEvent.sequenceTag), event.sequenceStyle, event.startMark))
+        let node = Node.sequence(.init(array, tag(firstEvent.sequenceTag), event.sequenceStyle, firstEvent.startMark))
         if let anchor = firstEvent.sequenceAnchor {
             anchors[anchor] = node
         }
@@ -353,7 +353,7 @@ private extension Parser {
             pairs.append((key, value))
             event = try parse()
         }
-        let node = Node.mapping(.init(pairs, tag(firstEvent.mappingTag), event.mappingStyle, event.startMark))
+        let node = Node.mapping(.init(pairs, tag(firstEvent.mappingTag), event.mappingStyle, firstEvent.startMark))
         if let anchor = firstEvent.mappingAnchor {
             anchors[anchor] = node
         }

--- a/Tests/YamsTests/MarkTests.swift
+++ b/Tests/YamsTests/MarkTests.swift
@@ -39,12 +39,31 @@ class MarkTests: XCTestCase {
                 "'identifier_name' and will be completely removed in a future release."
             ])
     }
+
+    func testMappingMarkIsCorrect() throws {
+        let yaml = """
+            values:
+              sequence:
+                - Hello
+                - World
+            """
+        let root = try Yams.compose(yaml: yaml)
+        let values = root?.mapping?["values"]
+        let sequence = values?.mapping?["sequence"]
+        let firstElement = sequence?.sequence?[0]
+
+        XCTAssertEqual(root?.mark?.description, "1:1")
+        XCTAssertEqual(values?.mark?.description, "2:3")
+        XCTAssertEqual(sequence?.mark?.description, "3:5")
+        XCTAssertEqual(firstElement?.mark?.description, "3:7")
+    }
 }
 
 extension MarkTests {
     static var allTests: [(String, (MarkTests) -> () throws -> Void)] {
         return [
-            ("testLocatableDeprecationMessageForSwiftLint", testLocatableDeprecationMessageForSwiftLint)
+            ("testLocatableDeprecationMessageForSwiftLint", testLocatableDeprecationMessageForSwiftLint),
+            ("testMappingMarkIsCorrect", testMappingMarkIsCorrect),
         ]
     }
 }


### PR DESCRIPTION
Instead of the start mark for the sequence or map we were capturing the start mark of the _next_ element.