### PR TITLE
CYaml: correct platform check

### DIFF
--- a/Sources/CYaml/include/yaml.h
+++ b/Sources/CYaml/include/yaml.h
@@ -28,7 +28,7 @@ extern "C" {
 
 #if defined(__MINGW32__)
 #   define  YAML_DECLARE(type)  type
-#elif defined(WIN32)
+#elif defined(_WIN32)
 #   if defined(YAML_DECLARE_STATIC)
 #       define  YAML_DECLARE(type)  type
 #   elif defined(YAML_DECLARE_EXPORT)


### PR DESCRIPTION
The target macro for Windows `_WIN32`.  We would fail to build with CMake on Windows when building with shared libraries.