### PR TITLE
build: build libyaml as a shared module on Windows

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,7 @@ let package = Package(
         .library(name: "Yams", targets: ["Yams"])
     ],
     targets: [
-        .target(name: "CYaml"),
+        .target(name: "CYaml", cSettings: [.define("YAML_DECLARE_EXPORT")]),
         .target(name: "Yams", dependencies: ["CYaml"]),
         .testTarget(name: "YamsTests", dependencies: ["Yams"])
     ]


### PR DESCRIPTION
The libyaml setup is currently configured improperly, not selecting
either shared nor static builds, resulting in libyaml being built
assuming that it is a user of libyaml, which is incorrect.  Adjust the
build to build libyaml as a shared library.

This change is not exactly precise, over generalizing the application of
the `YAML_DECLARE_EXPORT` to avoid bumping the minimum version of SPM to
5.4, which is the first version to include support for
`.platform(.windows)`.  This should not impact the other targets, as the
macro is not consulted for other targets.

This should allow us to enable testing on Windows again which was
disabled with #304.