### PR TITLE
Add swift_binary build target

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -40,6 +40,10 @@ jobs:
         if: always()
         run: bazelisk test //Tests:tvOSBuildTest
         shell: bash
+      - name: swift_binary build test
+        if: always()
+        run: bazelisk test //Tests:SwiftBinaryBuildTest
+        shell: bash
       - name: Yams tests
         if: always()
         run: bazelisk test //Tests:YamsTests
@@ -64,7 +68,7 @@ jobs:
         if: always()
         run: |
              build_workspace_directory=$(bazelisk info workspace)
-             CC=clang bazelisk test //Tests:YamsTests --action_env=PATH --test_env=BUILD_WORKSPACE_DIRECTORY=$build_workspace_directory
+             CC=clang bazelisk test //Tests:SwiftBinaryBuildTest //Tests:YamsTests --action_env=PATH --test_env=BUILD_WORKSPACE_DIRECTORY=$build_workspace_directory
         shell: bash
       - name: Yams tests logs
         if: always()

--- a/Tests/BUILD
+++ b/Tests/BUILD
@@ -2,7 +2,7 @@ load("@build_bazel_rules_apple//apple:macos.bzl", "macos_build_test")
 load("@build_bazel_rules_apple//apple:watchos.bzl", "watchos_build_test")
 load("@build_bazel_rules_apple//apple:tvos.bzl", "tvos_build_test")
 load("@build_bazel_rules_apple//apple:ios.bzl", "ios_build_test")
-load("@build_bazel_rules_swift//swift:swift.bzl", "swift_test")
+load("@build_bazel_rules_swift//swift:swift.bzl", "swift_binary", "swift_test")
 
 config_setting(
     name = "linux",
@@ -63,4 +63,16 @@ ios_build_test(
         "//:Yams",
         "//:CYaml",
     ],
+)
+
+genrule(
+    name = "EmptyMain",
+    outs = ["EmptyMain.swift"],
+    cmd = "touch $(OUTS)",
+)
+
+swift_binary(
+    name = "SwiftBinaryBuildTest",
+    srcs = [":EmptyMain"],
+    deps = ["//:Yams"],
 )


### PR DESCRIPTION
This target is a bit different from the others that already exist
because it supports building on macOS and Linux, but it also has some
different semantics because of that so I think it's worth testing here.