### PR TITLE
Update BUILD configuration

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,3 +1,1 @@
-# Force the tests to not run in sandboxed mode, since it can introduce
-# errors and flakes.
 build --macos_minimum_os=10.9

--- a/.bazelrc
+++ b/.bazelrc
@@ -1,4 +1,3 @@
 # Force the tests to not run in sandboxed mode, since it can introduce
 # errors and flakes.
-test --spawn_strategy=local
 build --macos_minimum_os=10.9

--- a/BUILD
+++ b/BUILD
@@ -1,31 +1,26 @@
-load(
-    "@rules_cc//cc:defs.bzl",
-    "cc_library"
-)
-load(
-    "@build_bazel_rules_swift//swift:swift.bzl",
-    "swift_library"
-)
+load("@rules_cc//cc:defs.bzl", "cc_library")
+load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
 
 cc_library(
     name = "CYaml",
-    srcs = glob(["Sources/CYaml/src/*.c", "Sources/CYaml/src/*.h"]),
+    srcs = glob([
+        "Sources/CYaml/src/*.c",
+        "Sources/CYaml/src/*.h",
+    ]),
     hdrs = ["Sources/CYaml/include/yaml.h"],
+    # Requires because of https://github.com/bazelbuild/bazel/pull/10143 otherwise host transition builds fail
+    copts = ["-fPIC"],
     includes = ["Sources/CYaml/include"],
-    visibility = [
-        "//Tests:__subpackages__",
-    ],
+    linkstatic = True,
+    tags = ["swift_module"],
+    visibility = ["//Tests:__subpackages__"],
 )
 
 swift_library(
     name = "Yams",
-    module_name = "Yams",
     srcs = glob(["Sources/Yams/*.swift"]),
-    copts = [
-        "-DSWIFT_PACKAGE",
-    ],
-    visibility = [
-        "//visibility:public"
-    ],
+    copts = ["-DSWIFT_PACKAGE"],
+    module_name = "Yams",
+    visibility = ["//visibility:public"],
     deps = ["//:CYaml"],
 )

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 * Update Bazel config to allow targets to be directly consumed.  
   [Maxwell Elliott](https://github.com/maxwellE)
+* Fix some Bazel integration issues
+  [Keith Smiley](https://github.com/keith)
 
 ##### Bug Fixes
 


### PR DESCRIPTION
This has 3 important fixes from Lyft's internal config:

1. The `cc_library` is now tagged with `swift_module` which is a special
   tag that tells rules_swift to generate a module map for the library.
   This is likely why sandboxing had to be disabled.
2. This adds `-fPIC` to the `cc_library` compilation. This is required
   for C libraries that Swift depends on, but there's an outstanding bug
   in bazel where this isn't handled correctly when you use the target
   through the host transition.
3. Force CYaml to be statically linked

This also formats this file using buildifier