### PR TITLE
Simplify bazel CI configuration

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,1 +1,3 @@
 build --macos_minimum_os=10.9
+build --repo_env=CC=clang
+test --test_output=errors

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -42,7 +42,7 @@ jobs:
         shell: bash
       - name: Yams tests
         if: always()
-        run: bazelisk test //Tests:YamsTests
+        run: bazelisk test //Tests:UnitTests
         shell: bash
   Linux:
     strategy:
@@ -62,11 +62,9 @@ jobs:
         shell: bash
       - name: Yams tests
         if: always()
-        run: |
-             build_workspace_directory=$(bazelisk info workspace)
-             CC=clang bazelisk test //Tests:YamsTests --action_env=PATH --test_env=BUILD_WORKSPACE_DIRECTORY=$build_workspace_directory
+        run: bazelisk test //Tests:UnitTests
         shell: bash
       - name: Yams tests logs
         if: always()
-        run: cat bazel-out/k8-fastbuild/testlogs/Tests/YamsTests/test.log
+        run: cat bazel-out/k8-fastbuild/testlogs/Tests/UnitTests/test.log
         shell: bash

--- a/Tests/BUILD
+++ b/Tests/BUILD
@@ -13,17 +13,17 @@ genrule(
     name = "LinuxMain",
     srcs = ["LinuxMain.swift"],
     outs = ["main.swift"],
-    cmd = "cp $< $@"
+    cmd = "cp $< $@",
 )
 
 swift_test(
-    name = "YamsTests",
-    module_name = "YamsTests",
+    name = "UnitTests",
     srcs = glob(["YamsTests/*.swift"]) + select({
         ":linux": ["main.swift"],
         "//conditions:default": [],
     }),
     data = glob(["YamsTests/Fixtures/**/*.*"]),
+    module_name = "YamsTests",
     deps = [
         "//:Yams",
     ],

--- a/Tests/YamsTests/PerformanceTests.swift
+++ b/Tests/YamsTests/PerformanceTests.swift
@@ -12,8 +12,8 @@ import Yams
 
 class PerformanceTests: XCTestCase {
     private let fixturesDirectory: String = {
-        if let buildWorkspace = ProcessInfo.processInfo.environment["BUILD_WORKSPACE_DIRECTORY"] {
-            return "\(buildWorkspace)/Tests/YamsTests/Fixtures/"
+        if ProcessInfo.processInfo.environment["TEST_WORKSPACE"] != nil {
+            return "Tests/YamsTests/Fixtures/"
         }
         return URL(fileURLWithPath: #file).deletingLastPathComponent().path + "/Fixtures/"
     }()


### PR DESCRIPTION
This reduces the need to pass through some custom environment, and makes it work locally on Linux without copying this command. To do this I had to update the unit test target name because having a target named the same thing as a directory in your `data` results in a conflict where the `Tests/YamsTests` was actually a binary instead of a directory.