### PR TITLE
Touch cmake.yml

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -35,6 +35,7 @@ jobs:
       - uses: actions/checkout@v2
       - run: brew install cmake ninja
       - run: swift -version
+      - run: rm -rf build
       - run: cmake -B build -G Ninja -S . -DCMAKE_BUILD_TYPE=Release
       - run: cmake --build build
       - run: cmake --build build --target install

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -1,5 +1,7 @@
 name: CMake
 
+# Touch
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Investigating CMake CI failures in this PR.

Passed in 409e565756cfdf50642a59c8f4290a6961fe7f1d ([CI job](https://github.com/jpsim/Yams/runs/2169124798?check_suite_focus=true))
Failed in 24ff618842ecf0f0c8bea119ca97ff9c45b4e85a ([CI job](https://github.com/jpsim/Yams/actions/runs/699258087))

Both jobs were using CMake 3.19.6 / Ninja 1.10.2 so that's not the issue.

Both jobs used the same GitHub Actions virtual environment:

```
Current runner version: '2.277.1'
Operating System
  Mac OS X
  10.15.7
  19H524
Virtual Environment
  Environment: macos-10.15
  Version: 20210314.1
  Included Software: https://github.com/actions/virtual-environments/blob/macOS-10.15/20210314.1/images/macos/macos-10.15-Readme.md
  Image Release: https://github.com/actions/virtual-environments/releases/tag/macOS-10.15%2F20210314.1
GITHUB_TOKEN Permissions
  Actions: write
  Checks: write
  Contents: write
  Deployments: write
  Issues: write
  Metadata: read
  OrganizationPackages: write
  Packages: write
  PullRequests: write
  RepositoryProjects: write
  SecurityEvents: write
  Statuses: write
Prepare workflow directory
Prepare all required actions
Getting action download info
Download action repository 'actions/checkout@v2'
```