### PR TITLE
Changed dump function parameter requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 4.0.7
+
+##### Breaking
+- The `dump` functions now requires `NodeRepresentable` values rather than `Any?` (or any `Sequence`) [#299]
+
 ## 4.0.6
 
 ##### Breaking

--- a/Sources/Yams/Emitter.swift
+++ b/Sources/Yams/Emitter.swift
@@ -13,9 +13,9 @@ import Foundation
 
 /// Produce a YAML string from objects.
 ///
-/// - parameter objects:       Sequence of Objects.
+/// - parameter objects:       Sequence of `NodeRepresentable` values.
 /// - parameter canonical:     Output should be the "canonical" format as in the YAML specification.
-/// - parameter indent:        The intendation increment.
+/// - parameter indent:        The indentation increment.
 /// - parameter width:         The preferred line width. @c -1 means unlimited.
 /// - parameter allowUnicode:  Unescaped non-ASCII characters are allowed if true.
 /// - parameter lineBreak:     Preferred line break.
@@ -38,14 +38,8 @@ public func dump<Objects>(
     explicitEnd: Bool = false,
     version: (major: Int, minor: Int)? = nil,
     sortKeys: Bool = false) throws -> String
-    where Objects: Sequence {
-    func representable(from object: Any) throws -> NodeRepresentable {
-        if let representable = object as? NodeRepresentable {
-            return representable
-        }
-        throw YamlError.emitter(problem: "\(object) does not conform to NodeRepresentable!")
-    }
-    let nodes = try objects.map(representable(from:)).map { try $0.represented() }
+where Objects: Sequence, Objects.Element: NodeRepresentable {
+    let nodes = try objects.map { try $0.represented() }
     return try serialize(
         nodes: nodes,
         canonical: canonical,
@@ -62,9 +56,9 @@ public func dump<Objects>(
 
 /// Produce a YAML string from an object.
 ///
-/// - parameter object:        Object.
+/// - parameter object:        The object to dump. Should conform to `NodeRepresentable`
 /// - parameter canonical:     Output should be the "canonical" format as in the YAML specification.
-/// - parameter indent:        The intendation increment.
+/// - parameter indent:        The indentation increment.
 /// - parameter width:         The preferred line width. @c -1 means unlimited.
 /// - parameter allowUnicode:  Unescaped non-ASCII characters are allowed if true.
 /// - parameter lineBreak:     Preferred line break.
@@ -77,7 +71,7 @@ public func dump<Objects>(
 ///
 /// - throws: `YamlError`.
 public func dump(
-    object: Any?,
+    object: NodeRepresentable,
     canonical: Bool = false,
     indent: Int = 0,
     width: Int = 0,
@@ -105,7 +99,7 @@ public func dump(
 ///
 /// - parameter nodes:         Sequence of `Node`s.
 /// - parameter canonical:     Output should be the "canonical" format as in the YAML specification.
-/// - parameter indent:        The intendation increment.
+/// - parameter indent:        The indentation increment.
 /// - parameter width:         The preferred line width. @c -1 means unlimited.
 /// - parameter allowUnicode:  Unescaped non-ASCII characters are allowed if true.
 /// - parameter lineBreak:     Preferred line break.
@@ -150,7 +144,7 @@ public func serialize<Nodes>(
 ///
 /// - parameter node:          `Node`.
 /// - parameter canonical:     Output should be the "canonical" format as in the YAML specification.
-/// - parameter indent:        The intendation increment.
+/// - parameter indent:        The indentation increment.
 /// - parameter width:         The preferred line width. @c -1 means unlimited.
 /// - parameter allowUnicode:  Unescaped non-ASCII characters are allowed if true.
 /// - parameter lineBreak:     Preferred line break.

--- a/Sources/Yams/Representer.swift
+++ b/Sources/Yams/Representer.swift
@@ -53,7 +53,25 @@ extension Array: NodeRepresentable {
     }
 }
 
+/// Useful when dealing with data serialized with JSONSerialization or PropertyListSerialization
+extension NSArray: NodeRepresentable {
+    /// This value's `Node` representation.
+    public func represented() throws -> Node {
+        let nodes = try map(represent)
+        return Node(nodes, Tag(.seq))
+    }
+}
+
 extension Dictionary: NodeRepresentable {
+    /// This value's `Node` representation.
+    public func represented() throws -> Node {
+        let pairs = try map { (key: try represent($0.0), value: try represent($0.1)) }
+        return Node(pairs.sorted { $0.key < $1.key }, Tag(.map))
+    }
+}
+
+/// Useful when dealing with data serialized with JSONSerialization or PropertyListSerialization
+extension NSDictionary: NodeRepresentable {
     /// This value's `Node` representation.
     public func represented() throws -> Node {
         let pairs = try map { (key: try represent($0.0), value: try represent($0.1)) }


### PR DESCRIPTION
## Summary
The `dump` functions now require a `NodeRepresentable` value to be passed rather than `Any`. 

### Context
- This makes the caller responsible for ensuring the provided value can be represented by a node, while default implementations for common types is provided.
- Also fixed some typos