### PR TITLE
Run Linux CI jobs with Swift 5.4

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -47,7 +47,7 @@ jobs:
   Linux:
     strategy:
       matrix:
-        tag: ['5.1', '5.2', '5.3']
+        tag: ['5.1', '5.2', '5.3', '5.4']
     runs-on: ubuntu-latest
     container:
       image: swift:${{ matrix.tag }}

--- a/.github/workflows/swiftpm.yml
+++ b/.github/workflows/swiftpm.yml
@@ -46,19 +46,6 @@ jobs:
           fi
         env: { 'CODECOV_TOKEN': '${{ secrets.CODECOV_TOKEN }}' }
 
-  Xcode_Big_Sur:
-    strategy:
-      matrix:
-        xcode_version: ['12.5']
-    runs-on: macos-11
-    env:
-      DEVELOPER_DIR: /Applications/Xcode_${{ matrix.xcode_version }}.app
-    steps:
-      - uses: actions/checkout@v2
-      - run: swift -version
-      - run: YAMS_DEFAULT_ENCODING=UTF16 swift test --parallel
-      - run: YAMS_DEFAULT_ENCODING=UTF8 swift test --parallel
-
   Linux:
     strategy:
       matrix:

--- a/.github/workflows/swiftpm.yml
+++ b/.github/workflows/swiftpm.yml
@@ -46,6 +46,19 @@ jobs:
           fi
         env: { 'CODECOV_TOKEN': '${{ secrets.CODECOV_TOKEN }}' }
 
+  Xcode_Big_Sur:
+    strategy:
+      matrix:
+        xcode_version: ['12.5']
+    runs-on: macos-11
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_${{ matrix.xcode_version }}.app
+    steps:
+      - uses: actions/checkout@v2
+      - run: swift -version
+      - run: YAMS_DEFAULT_ENCODING=UTF16 swift test --parallel
+      - run: YAMS_DEFAULT_ENCODING=UTF8 swift test --parallel
+
   Linux:
     strategy:
       matrix:

--- a/.github/workflows/swiftpm.yml
+++ b/.github/workflows/swiftpm.yml
@@ -49,7 +49,7 @@ jobs:
   Linux:
     strategy:
       matrix:
-        tag: ['5.1', '5.2', '5.3']
+        tag: ['5.1', '5.2', '5.3', '5.4']
     runs-on: ubuntu-latest
     container:
       image: swift:${{ matrix.tag }}

--- a/Yams.podspec
+++ b/Yams.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   s.authors                   = { 'JP Simard' => 'jp@jpsim.com',
                                   'Norio Nomura' => 'norio.nomura@gmail.com' }
   s.source_files              = 'Sources/**/*.{h,c,swift}'
-  s.swift_versions            = ['5.1', '5.2', '5.3']
+  s.swift_versions            = ['5.1', '5.2', '5.3', '5.4']
   s.pod_target_xcconfig       = { 'APPLICATION_EXTENSION_API_ONLY' => 'YES' }
   s.ios.deployment_target     = '8.0'
   s.osx.deployment_target     = '10.9'


### PR DESCRIPTION
~Looks like GitHub Actions added publicly available macOS 11 images earlier today: https://github.com/actions/virtual-environments/issues/2486#issuecomment-852906007~ Edit: not working

Update CI to run with Swift 5.4 on Linux. Swift 5.4 ships with Xcode 12.5, which requires macOS 11, which GitHub Actions don't support yet.

Also add Swift 5.4 to the podspec's swift versions.