### PR TITLE
Tests: enable the full test suite on Windows with newer Swift

### DIFF
--- a/.github/workflows/swiftpm.yml
+++ b/.github/workflows/swiftpm.yml
@@ -84,7 +84,7 @@ jobs:
             tag: 5.5.1-RELEASE
 
           - branch: development
-            tag: DEVELOPMENT-SNAPSHOT-2021-06-12-a
+            tag: DEVELOPMENT-SNAPSHOT-2021-11-20-a
 
     steps:
       - uses: actions/checkout@v2

--- a/Tests/YamsTests/ConstructorTests.swift
+++ b/Tests/YamsTests/ConstructorTests.swift
@@ -514,7 +514,7 @@ class ConstructorTests: XCTestCase { // swiftlint:disable:this type_body_length
 
 extension ConstructorTests {
     static var allTests: [(String, (ConstructorTests) -> () throws -> Void)] {
-#if os(Windows)
+#if os(Windows) && swift(<5.6)
         // TODO: Fix these tests on Windows
         return [
             ("testBinary", testBinary),

--- a/Tests/YamsTests/EncoderTests.swift
+++ b/Tests/YamsTests/EncoderTests.swift
@@ -1142,7 +1142,7 @@ private struct Unkeyed: Codable, Equatable {
 
 extension EncoderTests {
     static var allTests: [(String, (EncoderTests) -> () throws -> Void)] {
-#if os(Windows)
+#if os(Windows) && swift(<5.6)
         // TODO: Fix these tests on Windows
         return [
             ("testEncodingTopLevelEmptyStruct", testEncodingTopLevelEmptyStruct),

--- a/Tests/YamsTests/NodeTests.swift
+++ b/Tests/YamsTests/NodeTests.swift
@@ -206,7 +206,7 @@ class NodeTests: XCTestCase {
 
 extension NodeTests {
     static var allTests: [(String, (NodeTests) -> () throws -> Void)] {
-#if os(Windows)
+#if os(Windows) && swift(<5.6)
         // TODO: Fix these tests on Windows
         return [
             ("testExpressibleByArrayLiteral", testExpressibleByArrayLiteral),

--- a/Tests/YamsTests/SpecTests.swift
+++ b/Tests/YamsTests/SpecTests.swift
@@ -916,7 +916,7 @@ class SpecTests: XCTestCase { // swiftlint:disable:this type_body_length
 
 extension SpecTests {
     static var allTests: [(String, (SpecTests) -> () throws -> Void)] {
-#if os(Windows)
+#if os(Windows) && swift(<5.6)
         // TODO: Fix these tests on Windows
         return [
             ("testEmptyString", testEmptyString),


### PR DESCRIPTION
The underlying compiler issue that was prenventing the test suite from complete
execution on Windows has been resolved.  Restrict the full test suite to newer
versions of Swift.  While technically the 11/10 snapshot should contain the fix,
another issue prevents its usage.  The 11/20 snapshot and newer should support
the full test suite on windows as well.

The Windows support should now be at complete parity with the other platforms.