### PR TITLE
Add `sequenceStyle` and `mappingStyle` to `Emitter.Options`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+## 4.0.7
+
+##### Breaking
+
+* None.
+
+##### Enhancements
+
+* Adding `sequenceStyle` and `mappingStyle` to `Emitter.Options`
+  [Terence Grant](https://github.com/tatewake)
+
+##### Bug Fixes
+
+* None.
+
 ## 4.0.6
 
 ##### Breaking

--- a/Sources/Yams/Emitter.swift
+++ b/Sources/Yams/Emitter.swift
@@ -23,6 +23,7 @@ import Foundation
 /// - parameter explicitEnd:   Explicit document end `...`.
 /// - parameter version:       YAML version directive.
 /// - parameter sortKeys:      Whether or not to sort Mapping keys in lexicographic order.
+/// - parameter sequenceStyle: The style for sequences (arrays / lists)
 ///
 /// - returns: YAML string.
 ///
@@ -37,7 +38,8 @@ public func dump<Objects>(
     explicitStart: Bool = false,
     explicitEnd: Bool = false,
     version: (major: Int, minor: Int)? = nil,
-    sortKeys: Bool = false) throws -> String
+    sortKeys: Bool = false,
+    sequenceStyle: Node.Sequence.Style = .any) throws -> String
     where Objects: Sequence {
     func representable(from object: Any) throws -> NodeRepresentable {
         if let representable = object as? NodeRepresentable {
@@ -56,7 +58,8 @@ public func dump<Objects>(
         explicitStart: explicitStart,
         explicitEnd: explicitEnd,
         version: version,
-        sortKeys: sortKeys
+        sortKeys: sortKeys,
+        sequenceStyle: sequenceStyle
     )
 }
 
@@ -72,6 +75,7 @@ public func dump<Objects>(
 /// - parameter explicitEnd:   Explicit document end `...`.
 /// - parameter version:       YAML version directive.
 /// - parameter sortKeys:      Whether or not to sort Mapping keys in lexicographic order.
+/// - parameter sequenceStyle: The style for sequences (arrays / lists)
 ///
 /// - returns: YAML string.
 ///
@@ -86,7 +90,8 @@ public func dump(
     explicitStart: Bool = false,
     explicitEnd: Bool = false,
     version: (major: Int, minor: Int)? = nil,
-    sortKeys: Bool = false) throws -> String {
+    sortKeys: Bool = false,
+    sequenceStyle: Node.Sequence.Style = .any) throws -> String {
     return try serialize(
         node: object.represented(),
         canonical: canonical,
@@ -97,7 +102,8 @@ public func dump(
         explicitStart: explicitStart,
         explicitEnd: explicitEnd,
         version: version,
-        sortKeys: sortKeys
+        sortKeys: sortKeys,
+        sequenceStyle: sequenceStyle
     )
 }
 
@@ -113,6 +119,7 @@ public func dump(
 /// - parameter explicitEnd:   Explicit document end `...`.
 /// - parameter version:       YAML version directive.
 /// - parameter sortKeys:      Whether or not to sort Mapping keys in lexicographic order.
+/// - parameter sequenceStyle: The style for sequences (arrays / lists)
 ///
 /// - returns: YAML string.
 ///
@@ -127,7 +134,8 @@ public func serialize<Nodes>(
     explicitStart: Bool = false,
     explicitEnd: Bool = false,
     version: (major: Int, minor: Int)? = nil,
-    sortKeys: Bool = false) throws -> String
+    sortKeys: Bool = false,
+    sequenceStyle: Node.Sequence.Style = .any) throws -> String
     where Nodes: Sequence, Nodes.Iterator.Element == Node {
     let emitter = Emitter(
         canonical: canonical,
@@ -138,7 +146,8 @@ public func serialize<Nodes>(
         explicitStart: explicitStart,
         explicitEnd: explicitEnd,
         version: version,
-        sortKeys: sortKeys
+        sortKeys: sortKeys,
+        sequenceStyle: sequenceStyle
     )
     try emitter.open()
     try nodes.forEach(emitter.serialize)
@@ -158,6 +167,7 @@ public func serialize<Nodes>(
 /// - parameter explicitEnd:   Explicit document end `...`.
 /// - parameter version:       YAML version directive.
 /// - parameter sortKeys:      Whether or not to sort Mapping keys in lexicographic order.
+/// - parameter sequenceStyle: The style for sequences (arrays / lists)
 ///
 /// - returns: YAML string.
 ///
@@ -172,7 +182,8 @@ public func serialize(
     explicitStart: Bool = false,
     explicitEnd: Bool = false,
     version: (major: Int, minor: Int)? = nil,
-    sortKeys: Bool = false) throws -> String {
+    sortKeys: Bool = false,
+    sequenceStyle: Node.Sequence.Style = .any) throws -> String {
     return try serialize(
         nodes: [node],
         canonical: canonical,
@@ -183,7 +194,8 @@ public func serialize(
         explicitStart: explicitStart,
         explicitEnd: explicitEnd,
         version: version,
-        sortKeys: sortKeys
+        sortKeys: sortKeys,
+        sequenceStyle: sequenceStyle
     )
 }
 
@@ -224,6 +236,9 @@ public final class Emitter {
 
         /// Set if emitter should sort keys in lexicographic order.
         public var sortKeys: Bool = false
+
+        /// Set the style for sequences (arrays / lists)
+        public var sequenceStyle: Node.Sequence.Style = .any
     }
 
     /// Configuration options to use when emitting YAML.
@@ -245,6 +260,7 @@ public final class Emitter {
     /// - parameter explicitEnd:   Explicit document end `...`.
     /// - parameter version:       The `%YAML` directive value or nil.
     /// - parameter sortKeys:      Set if emitter should sort keys in lexicographic order.
+    /// - parameter sequenceStyle: Set the style for sequences (arrays / lists)
     public init(canonical: Bool = false,
                 indent: Int = 0,
                 width: Int = 0,
@@ -253,7 +269,8 @@ public final class Emitter {
                 explicitStart: Bool = false,
                 explicitEnd: Bool = false,
                 version: (major: Int, minor: Int)? = nil,
-                sortKeys: Bool = false) {
+                sortKeys: Bool = false,
+                sequenceStyle: Node.Sequence.Style = .any) {
         options = Options(canonical: canonical,
                           indent: indent,
                           width: width,
@@ -262,7 +279,8 @@ public final class Emitter {
                           explicitStart: explicitStart,
                           explicitEnd: explicitEnd,
                           version: version,
-                          sortKeys: sortKeys)
+                          sortKeys: sortKeys,
+                          sequenceStyle: sequenceStyle)
         // configure emitter
         yaml_emitter_initialize(&emitter)
         yaml_emitter_set_output(&self.emitter, { pointer, buffer, size in
@@ -379,9 +397,10 @@ extension Emitter.Options {
     /// - parameter explicitEnd:   Explicit document end `...`.
     /// - parameter version:       The `%YAML` directive value or nil.
     /// - parameter sortKeys:      Set if emitter should sort keys in lexicographic order.
+    /// - parameter sequenceStyle: Set the style for sequences (arrays / lists)
     public init(canonical: Bool = false, indent: Int = 0, width: Int = 0, allowUnicode: Bool = false,
                 lineBreak: Emitter.LineBreak = .ln, version: (major: Int, minor: Int)? = nil,
-                sortKeys: Bool = false) {
+                sortKeys: Bool = false, sequenceStyle: Node.Sequence.Style = .any) {
         self.canonical = canonical
         self.indent = indent
         self.width = width
@@ -389,6 +408,7 @@ extension Emitter.Options {
         self.lineBreak = lineBreak
         self.version = version
         self.sortKeys = sortKeys
+        self.sequenceStyle = sequenceStyle
     }
 }
 

--- a/Sources/Yams/Emitter.swift
+++ b/Sources/Yams/Emitter.swift
@@ -24,6 +24,7 @@ import Foundation
 /// - parameter version:       YAML version directive.
 /// - parameter sortKeys:      Whether or not to sort Mapping keys in lexicographic order.
 /// - parameter sequenceStyle: The style for sequences (arrays / lists)
+/// - parameter mappingStyle:  The style for mappings (dictionaries)
 ///
 /// - returns: YAML string.
 ///
@@ -39,7 +40,8 @@ public func dump<Objects>(
     explicitEnd: Bool = false,
     version: (major: Int, minor: Int)? = nil,
     sortKeys: Bool = false,
-    sequenceStyle: Node.Sequence.Style = .any) throws -> String
+    sequenceStyle: Node.Sequence.Style = .any,
+    mappingStyle: Node.Mapping.Style = .any) throws -> String
     where Objects: Sequence {
     func representable(from object: Any) throws -> NodeRepresentable {
         if let representable = object as? NodeRepresentable {
@@ -59,7 +61,8 @@ public func dump<Objects>(
         explicitEnd: explicitEnd,
         version: version,
         sortKeys: sortKeys,
-        sequenceStyle: sequenceStyle
+        sequenceStyle: sequenceStyle,
+        mappingStyle: mappingStyle
     )
 }
 
@@ -76,6 +79,7 @@ public func dump<Objects>(
 /// - parameter version:       YAML version directive.
 /// - parameter sortKeys:      Whether or not to sort Mapping keys in lexicographic order.
 /// - parameter sequenceStyle: The style for sequences (arrays / lists)
+/// - parameter mappingStyle:  The style for mappings (dictionaries)
 ///
 /// - returns: YAML string.
 ///
@@ -91,7 +95,8 @@ public func dump(
     explicitEnd: Bool = false,
     version: (major: Int, minor: Int)? = nil,
     sortKeys: Bool = false,
-    sequenceStyle: Node.Sequence.Style = .any) throws -> String {
+    sequenceStyle: Node.Sequence.Style = .any,
+    mappingStyle: Node.Mapping.Style = .any) throws -> String {
     return try serialize(
         node: object.represented(),
         canonical: canonical,
@@ -103,7 +108,8 @@ public func dump(
         explicitEnd: explicitEnd,
         version: version,
         sortKeys: sortKeys,
-        sequenceStyle: sequenceStyle
+        sequenceStyle: sequenceStyle,
+        mappingStyle: mappingStyle
     )
 }
 
@@ -120,6 +126,7 @@ public func dump(
 /// - parameter version:       YAML version directive.
 /// - parameter sortKeys:      Whether or not to sort Mapping keys in lexicographic order.
 /// - parameter sequenceStyle: The style for sequences (arrays / lists)
+/// - parameter mappingStyle:  The style for mappings (dictionaries)
 ///
 /// - returns: YAML string.
 ///
@@ -135,7 +142,8 @@ public func serialize<Nodes>(
     explicitEnd: Bool = false,
     version: (major: Int, minor: Int)? = nil,
     sortKeys: Bool = false,
-    sequenceStyle: Node.Sequence.Style = .any) throws -> String
+    sequenceStyle: Node.Sequence.Style = .any,
+    mappingStyle: Node.Mapping.Style = .any) throws -> String
     where Nodes: Sequence, Nodes.Iterator.Element == Node {
     let emitter = Emitter(
         canonical: canonical,
@@ -147,7 +155,8 @@ public func serialize<Nodes>(
         explicitEnd: explicitEnd,
         version: version,
         sortKeys: sortKeys,
-        sequenceStyle: sequenceStyle
+        sequenceStyle: sequenceStyle,
+        mappingStyle: mappingStyle
     )
     try emitter.open()
     try nodes.forEach(emitter.serialize)
@@ -168,6 +177,7 @@ public func serialize<Nodes>(
 /// - parameter version:       YAML version directive.
 /// - parameter sortKeys:      Whether or not to sort Mapping keys in lexicographic order.
 /// - parameter sequenceStyle: The style for sequences (arrays / lists)
+/// - parameter mappingStyle:  The style for mappings (dictionaries)
 ///
 /// - returns: YAML string.
 ///
@@ -183,7 +193,8 @@ public func serialize(
     explicitEnd: Bool = false,
     version: (major: Int, minor: Int)? = nil,
     sortKeys: Bool = false,
-    sequenceStyle: Node.Sequence.Style = .any) throws -> String {
+    sequenceStyle: Node.Sequence.Style = .any,
+    mappingStyle: Node.Mapping.Style = .any) throws -> String {
     return try serialize(
         nodes: [node],
         canonical: canonical,
@@ -195,7 +206,8 @@ public func serialize(
         explicitEnd: explicitEnd,
         version: version,
         sortKeys: sortKeys,
-        sequenceStyle: sequenceStyle
+        sequenceStyle: sequenceStyle,
+        mappingStyle: mappingStyle
     )
 }
 
@@ -239,6 +251,9 @@ public final class Emitter {
 
         /// Set the style for sequences (arrays / lists)
         public var sequenceStyle: Node.Sequence.Style = .any
+
+        /// Set the style for mappings (dictionaries)
+        public var mappingStyle: Node.Mapping.Style = .any
     }
 
     /// Configuration options to use when emitting YAML.
@@ -261,6 +276,7 @@ public final class Emitter {
     /// - parameter version:       The `%YAML` directive value or nil.
     /// - parameter sortKeys:      Set if emitter should sort keys in lexicographic order.
     /// - parameter sequenceStyle: Set the style for sequences (arrays / lists)
+    /// - parameter mappingStyle:  Set the style for mappings (dictionaries)
     public init(canonical: Bool = false,
                 indent: Int = 0,
                 width: Int = 0,
@@ -270,7 +286,8 @@ public final class Emitter {
                 explicitEnd: Bool = false,
                 version: (major: Int, minor: Int)? = nil,
                 sortKeys: Bool = false,
-                sequenceStyle: Node.Sequence.Style = .any) {
+                sequenceStyle: Node.Sequence.Style = .any,
+                mappingStyle: Node.Mapping.Style = .any) {
         options = Options(canonical: canonical,
                           indent: indent,
                           width: width,
@@ -280,7 +297,8 @@ public final class Emitter {
                           explicitEnd: explicitEnd,
                           version: version,
                           sortKeys: sortKeys,
-                          sequenceStyle: sequenceStyle)
+                          sequenceStyle: sequenceStyle,
+                          mappingStyle: mappingStyle)
         // configure emitter
         yaml_emitter_initialize(&emitter)
         yaml_emitter_set_output(&self.emitter, { pointer, buffer, size in
@@ -398,9 +416,11 @@ extension Emitter.Options {
     /// - parameter version:       The `%YAML` directive value or nil.
     /// - parameter sortKeys:      Set if emitter should sort keys in lexicographic order.
     /// - parameter sequenceStyle: Set the style for sequences (arrays / lists)
+    /// - parameter mappingStyle:  Set the style for mappings (dictionaries)
     public init(canonical: Bool = false, indent: Int = 0, width: Int = 0, allowUnicode: Bool = false,
                 lineBreak: Emitter.LineBreak = .ln, version: (major: Int, minor: Int)? = nil,
-                sortKeys: Bool = false, sequenceStyle: Node.Sequence.Style = .any) {
+                sortKeys: Bool = false, sequenceStyle: Node.Sequence.Style = .any,
+                mappingStyle: Node.Mapping.Style = .any) {
         self.canonical = canonical
         self.indent = indent
         self.width = width
@@ -409,6 +429,7 @@ extension Emitter.Options {
         self.version = version
         self.sortKeys = sortKeys
         self.sequenceStyle = sequenceStyle
+        self.mappingStyle = mappingStyle
     }
 }
 

--- a/Sources/Yams/Encoder.swift
+++ b/Sources/Yams/Encoder.swift
@@ -28,7 +28,7 @@ public class YAMLEncoder {
     /// - throws: `EncodingError` if something went wrong while encoding.
     public func encode<T: Swift.Encodable>(_ value: T, userInfo: [CodingUserInfoKey: Any] = [:]) throws -> String {
         do {
-            let encoder = _Encoder(userInfo: userInfo, sequenceStyle: options.sequenceStyle)
+            let encoder = _Encoder(userInfo: userInfo, sequenceStyle: options.sequenceStyle, mappingStyle: options.mappingStyle)
             var container = encoder.singleValueContainer()
             try container.encode(value)
             return try serialize(node: encoder.node, options: options)
@@ -47,10 +47,11 @@ public class YAMLEncoder {
 private class _Encoder: Swift.Encoder {
     var node: Node = .unused
 
-    init(userInfo: [CodingUserInfoKey: Any] = [:], codingPath: [CodingKey] = [], sequenceStyle: Node.Sequence.Style) {
+    init(userInfo: [CodingUserInfoKey: Any] = [:], codingPath: [CodingKey] = [], sequenceStyle: Node.Sequence.Style, mappingStyle: Node.Mapping.Style) {
         self.userInfo = userInfo
         self.codingPath = codingPath
         self.sequenceStyle = sequenceStyle
+        self.mappingStyle = mappingStyle
     }
 
     // MARK: - Swift.Encoder Methods
@@ -58,10 +59,11 @@ private class _Encoder: Swift.Encoder {
     let codingPath: [CodingKey]
     let userInfo: [CodingUserInfoKey: Any]
     let sequenceStyle: Node.Sequence.Style
+    let mappingStyle: Node.Mapping.Style
 
     func container<Key>(keyedBy type: Key.Type) -> KeyedEncodingContainer<Key> {
         if canEncodeNewValue {
-            node = [:]
+            node = Node([(Node, Node)](), .implicit, mappingStyle)
         } else {
             precondition(
                 node.isMapping,
@@ -119,13 +121,13 @@ private class _ReferencingEncoder: _Encoder {
     init(referencing encoder: _Encoder, key: CodingKey) {
         self.encoder = encoder
         reference = .mapping(key.stringValue)
-        super.init(userInfo: encoder.userInfo, codingPath: encoder.codingPath + [key], sequenceStyle: encoder.sequenceStyle)
+        super.init(userInfo: encoder.userInfo, codingPath: encoder.codingPath + [key], sequenceStyle: encoder.sequenceStyle, mappingStyle: encoder.mappingStyle)
     }
 
     init(referencing encoder: _Encoder, at index: Int) {
         self.encoder = encoder
         reference = .sequence(index)
-        super.init(userInfo: encoder.userInfo, codingPath: encoder.codingPath + [_YAMLCodingKey(index: index)], sequenceStyle: encoder.sequenceStyle)
+        super.init(userInfo: encoder.userInfo, codingPath: encoder.codingPath + [_YAMLCodingKey(index: index)], sequenceStyle: encoder.sequenceStyle, mappingStyle: encoder.mappingStyle)
     }
 
     deinit {

--- a/Sources/Yams/Encoder.swift
+++ b/Sources/Yams/Encoder.swift
@@ -28,7 +28,7 @@ public class YAMLEncoder {
     /// - throws: `EncodingError` if something went wrong while encoding.
     public func encode<T: Swift.Encodable>(_ value: T, userInfo: [CodingUserInfoKey: Any] = [:]) throws -> String {
         do {
-            let encoder = _Encoder(userInfo: userInfo)
+            let encoder = _Encoder(userInfo: userInfo, sequenceStyle: options.sequenceStyle)
             var container = encoder.singleValueContainer()
             try container.encode(value)
             return try serialize(node: encoder.node, options: options)
@@ -47,15 +47,17 @@ public class YAMLEncoder {
 private class _Encoder: Swift.Encoder {
     var node: Node = .unused
 
-    init(userInfo: [CodingUserInfoKey: Any] = [:], codingPath: [CodingKey] = []) {
+    init(userInfo: [CodingUserInfoKey: Any] = [:], codingPath: [CodingKey] = [], sequenceStyle: Node.Sequence.Style) {
         self.userInfo = userInfo
         self.codingPath = codingPath
+        self.sequenceStyle = sequenceStyle
     }
 
     // MARK: - Swift.Encoder Methods
 
     let codingPath: [CodingKey]
     let userInfo: [CodingUserInfoKey: Any]
+    let sequenceStyle: Node.Sequence.Style
 
     func container<Key>(keyedBy type: Key.Type) -> KeyedEncodingContainer<Key> {
         if canEncodeNewValue {
@@ -71,7 +73,7 @@ private class _Encoder: Swift.Encoder {
 
     func unkeyedContainer() -> UnkeyedEncodingContainer {
         if canEncodeNewValue {
-            node = []
+            node = Node([], .implicit, sequenceStyle)
         } else {
             precondition(
                 node.isSequence,
@@ -117,13 +119,13 @@ private class _ReferencingEncoder: _Encoder {
     init(referencing encoder: _Encoder, key: CodingKey) {
         self.encoder = encoder
         reference = .mapping(key.stringValue)
-        super.init(userInfo: encoder.userInfo, codingPath: encoder.codingPath + [key])
+        super.init(userInfo: encoder.userInfo, codingPath: encoder.codingPath + [key], sequenceStyle: encoder.sequenceStyle)
     }
 
     init(referencing encoder: _Encoder, at index: Int) {
         self.encoder = encoder
         reference = .sequence(index)
-        super.init(userInfo: encoder.userInfo, codingPath: encoder.codingPath + [_YAMLCodingKey(index: index)])
+        super.init(userInfo: encoder.userInfo, codingPath: encoder.codingPath + [_YAMLCodingKey(index: index)], sequenceStyle: encoder.sequenceStyle)
     }
 
     deinit {

--- a/Sources/Yams/Node.swift
+++ b/Sources/Yams/Node.swift
@@ -242,6 +242,10 @@ extension Node: ExpressibleByDictionaryLiteral {
     public init(dictionaryLiteral elements: (Node, Node)...) {
         self = Node(elements)
     }
+
+    public init(dictionaryLiteral elements: (Node, Node)..., style: Mapping.Style) {
+        self = Node(elements, .implicit, style)
+    }
 }
 
 extension Node: ExpressibleByFloatLiteral {

--- a/Sources/Yams/Node.swift
+++ b/Sources/Yams/Node.swift
@@ -232,6 +232,7 @@ extension Node: ExpressibleByArrayLiteral {
         self = .sequence(.init(elements))
     }
 
+    /// Create a `Node.sequence` from an array literal of `Node`s and a default `Style` to use for the array literal
     public init(arrayLiteral elements: Node..., style: Sequence.Style) {
         self = .sequence(.init(elements, .implicit, style))
     }
@@ -243,6 +244,7 @@ extension Node: ExpressibleByDictionaryLiteral {
         self = Node(elements)
     }
 
+    /// Create a `Node.mapping` from a dictionary literal of `Node`s and a default `Style` to use for the dictionary literal
     public init(dictionaryLiteral elements: (Node, Node)..., style: Mapping.Style) {
         self = Node(elements, .implicit, style)
     }

--- a/Sources/Yams/Node.swift
+++ b/Sources/Yams/Node.swift
@@ -231,6 +231,10 @@ extension Node: ExpressibleByArrayLiteral {
     public init(arrayLiteral elements: Node...) {
         self = .sequence(.init(elements))
     }
+
+    public init(arrayLiteral elements: Node..., style: Sequence.Style) {
+        self = .sequence(.init(elements, .implicit, style))
+    }
 }
 
 extension Node: ExpressibleByDictionaryLiteral {

--- a/Yams.podspec
+++ b/Yams.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name                      = 'Yams'
-  s.version                   = '4.0.6'
+  s.version                   = '4.0.7'
   s.summary                   = 'A sweet and swifty YAML parser.'
   s.homepage                  = 'https://github.com/jpsim/Yams'
   s.source                    = { :git => s.homepage + '.git', :tag => s.version }


### PR DESCRIPTION
## Summary:

This adds `sequenceStyle` and `mappingStyle` options to `Emitter.Options`, which allows those using `YAMLEncoder` to specify whether "sequences" and "mappings" use `block` style (the default style) or `flow` style.

Also, CHANGELOG.md was updated and Podspec version was bumped to 4.0.7.

No unit test coverage was added, as there isn't direct unit test coverage for `Emitter.Options`, however there are already tests around mapping and sequence styles in the `EmitterTests` class, so this should be sufficient.

_**Note:** "sequences" are arrays / lists, "mappings" are dictionaries_

## Strategy:

`sequenceStyle` and `mappingStyle` were added to `Emitter.Options`, and changes were cascaded down into `Emitter`, `Encoder`, and `Node` where necessary. The existing field `sortKeys` in `Emitter.Options` was used as a guide to see where both `sequenceStyle` and `mappingStyle` should be added in other places in the code. Otherwise, minimal code changes were made to gain the desired feature.

## Examples:

Given an example YAML file here:

```
structure:
  edges:
    e1:
    - n1
    - n2
    e2:
    - n1
    - n3
    e3:
    - n2
    - n3
  nodes:
  - n1
  - n2
  - n3
```

### `sequenceStyle`

Setting `sequenceStyle` to `.flow` now generates:

```
structure:
  edges:
    e1: [n1, n2]
    e2: [n1, n3]
    e3: [n2, n3]
  nodes: [n1, n2, n3]
```

Which can be more visually pleasing, readable, and compact in certain scenarios such as this one.

### `mappingStyle`

Setting `mappingStyle` to `.flow` now generates:

```
{structure: {edges: {e1: [n1, n2], e2: [n1, n3], e3: [n2, n3]}, nodes: [n1, n2, n3]}}
```

Which may not be as visually pleasing with larger YAML files, but still could be useful in certain scenarios, and having the option to configure `mappingStyle` does "match parity" with being able to configure `sequenceStyle`.

Also you might notice, setting `mappingStyle` to `.flow` also forces `sequenceStyle` to be `.flow`, but this is not an error as for "flow" style to be used correctly with mappings at the top level, it must be enforced recursively through each child. (Implying, child mappings and child sequences must also be "flow" style.)
