### PR TITLE
Yams: make `CYaml` private to Yams

### DIFF
--- a/Sources/CYaml/CMakeLists.txt
+++ b/Sources/CYaml/CMakeLists.txt
@@ -1,27 +1,17 @@
 
-add_library(CYaml
+add_library(CYaml STATIC
   src/api.c
   src/emitter.c
   src/parser.c
   src/reader.c
   src/scanner.c
   src/writer.c)
-if(NOT BUILD_SHARED_LIBS)
-  target_compile_definitions(CYaml PRIVATE
-    YAML_DECLARE_STATIC)
-endif()
-target_compile_definitions(CYaml PRIVATE
-  YAML_DECLARE_EXPORT)
+target_compile_definitions(CYaml PUBLIC
+  $<$<COMPILE_LANGUAGE:C>:YAML_DECLARE_STATIC>)
 target_include_directories(CYaml PUBLIC
-  include)
+  $<$<COMPILE_LANGUAGE:C>:${CMAKE_CURRENT_SOURCE_DIR}/include>)
+target_compile_options(CYaml PUBLIC
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -DYAML_DECLARE_STATIC>"
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -I${CMAKE_CURRENT_SOURCE_DIR}/include>")
 
 set_property(GLOBAL APPEND PROPERTY YAMS_EXPORTS CYaml)
-install(TARGETS CYaml
-  EXPORT YamsExports
-  RUNTIME DESTINATION bin
-  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
-install(FILES
-  include/module.modulemap
-  include/yaml.h
-  DESTINATION include/cyaml)

--- a/Sources/Yams/CMakeLists.txt
+++ b/Sources/Yams/CMakeLists.txt
@@ -25,7 +25,6 @@ target_link_libraries(Yams PRIVATE
   $<$<NOT:$<PLATFORM_ID:Darwin>>:dispatch>
   $<$<NOT:$<PLATFORM_ID:Darwin>>:Foundation>)
 set_target_properties(Yams PROPERTIES
-  INTERFACE_COMPILE_OPTIONS "SHELL:-Xcc -I$<TARGET_PROPERTY:CYaml,INCLUDE_DIRECTORIES>"
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
 
 set_property(GLOBAL APPEND PROPERTY YAMS_EXPORTS Yams)

--- a/Sources/Yams/Emitter.swift
+++ b/Sources/Yams/Emitter.swift
@@ -7,7 +7,7 @@
 //
 
 #if SWIFT_PACKAGE
-import CYaml
+@_implementationOnly import CYaml
 #endif
 import Foundation
 

--- a/Sources/Yams/Parser.swift
+++ b/Sources/Yams/Parser.swift
@@ -7,7 +7,7 @@
 //
 
 #if SWIFT_PACKAGE
-import CYaml
+@_implementationOnly import CYaml
 #endif
 import Foundation
 

--- a/Sources/Yams/YamlError.swift
+++ b/Sources/Yams/YamlError.swift
@@ -7,8 +7,9 @@
 //
 
 #if SWIFT_PACKAGE
-import CYaml
+@_implementationOnly import CYaml
 #endif
+import Foundation
 
 /// Errors thrown by Yams APIs.
 public enum YamlError: Error {


### PR DESCRIPTION
This changes how `CYaml` is built and used within Yams.  As there are no
interfaces from `CYaml` being directly exposed, we can statically link
the library.  However, this still would cause a problem as the `CYaml`
import would be serialized into the module requiring that the module is
available when building anything which consumes `Yams`.  To avoid that,
change the `import CYaml` instances to `@_implementationOnly`.  This
allows for `CYaml` to not be required at the consumer site.

While in the area of the CMake build system, clean up some of the build
system to use language specific options.  This is required to avoid the
de-duplication of the options across languages and enables linking
`CYaml` statically into the library.  Note that on Windows static
linking of *Swift* libraries is not yet properly supported and this does
not enable that nor use that - it is statically linking *C* content.

This now allows building Yams dynamically as a single library target.
On Windows, this is a negligible space savings of ~16KiB.