### PR TITLE
Fix `YAMLDecoder`'s handling when decoding empty strings into optional types

### DIFF
--- a/Sources/Yams/Constructor.swift
+++ b/Sources/Yams/Constructor.swift
@@ -396,6 +396,10 @@ extension NSNull/*: ScalarConstructible*/ {
     ///
     /// - returns: An instance of `NSNull`, if one was successfully extracted from the scalar.
     public static func construct(from scalar: Node.Scalar) -> NSNull? {
+        // When constructing from a Scalar, only plain style scalars should be recognized.
+        // For example #"key: 'null'"# or #"key: ''"# should not be considered as null.
+        guard case .plain = scalar.style else { return nil }
+
         switch scalar.string {
         case "", "~", "null", "Null", "NULL":
             return NSNull()

--- a/Tests/YamsTests/ConstructorTests.swift
+++ b/Tests/YamsTests/ConstructorTests.swift
@@ -210,14 +210,16 @@ class ConstructorTests: XCTestCase { // swiftlint:disable:this type_body_length
             english: null
             ~: null key
             ---
-            # This sequence has five
-            # entries, two have values.
+            # This sequence has seven
+            # entries, four have values.
             sparse:
               - ~
               - 2nd entry
               -
               - 4th entry
               - Null
+              - 'null'
+              - ''
 
             """
         let objects = Array(try Yams.load_all(yaml: example))
@@ -234,7 +236,9 @@ class ConstructorTests: XCTestCase { // swiftlint:disable:this type_body_length
                     "2nd entry",
                     NSNull(),
                     "4th entry",
-                    NSNull()
+                    NSNull(),
+                    "null",
+                    ""
                 ]
             ]
         ]

--- a/Tests/YamsTests/NodeTests.swift
+++ b/Tests/YamsTests/NodeTests.swift
@@ -59,7 +59,7 @@ class NodeTests: XCTestCase {
         let scalarFloat: Node = "1.0"
         XCTAssertEqual(scalarFloat.float, 1.0)
 
-        let scalarNull: Node = "null"
+        let scalarNull = Node("null", .implicit, .plain)
         XCTAssertEqual(scalarNull.null, NSNull())
 
         let scalarInt: Node = "1"

--- a/Tests/YamsTests/TopLevelDecoderTests.swift
+++ b/Tests/YamsTests/TopLevelDecoderTests.swift
@@ -35,14 +35,14 @@ class TopLevelDecoderTests: XCTestCase {
 
     func testDecodeOptionalTypes() throws {
         let yaml = """
-        A: ''
-        B:
-        C: null
-        D: ~
-        E: ""
+        AAA: ''
+        BBB:
+        CCC: null
+        DDD: ~
+        EEE: ""
         json: {
-          "F": "",
-          "G": "null"
+          "FFF": "",
+          "GGG": "null"
         }
         array:
         - one
@@ -54,28 +54,28 @@ class TopLevelDecoderTests: XCTestCase {
 
         struct Container: Codable, Equatable {
             struct JSON: Codable, Equatable {
-                var F: String?
-                var G: String?
+                var FFF: String?
+                var GGG: String?
             }
 
-            var A: String?
-            var B: String?
-            var C: Int?
-            var D: String?
-            var E: String?
+            var AAA: String?
+            var BBB: String?
+            var CCC: Int?
+            var DDD: String?
+            var EEE: String?
             var json: JSON
             var array: [String?]
         }
 
         let container = try YAMLDecoder().decode(Container.self, from: yaml)
 
-        XCTAssertEqual(container.A, "")
-        XCTAssertEqual(container.B, nil)
-        XCTAssertEqual(container.C, nil)
-        XCTAssertEqual(container.D, nil)
-        XCTAssertEqual(container.E, "")
-        XCTAssertEqual(container.json.F, "")
-        XCTAssertEqual(container.json.G, "null")
+        XCTAssertEqual(container.AAA, "")
+        XCTAssertEqual(container.BBB, nil)
+        XCTAssertEqual(container.CCC, nil)
+        XCTAssertEqual(container.DDD, nil)
+        XCTAssertEqual(container.EEE, "")
+        XCTAssertEqual(container.json.FFF, "")
+        XCTAssertEqual(container.json.GGG, "null")
         XCTAssertEqual(container.array, ["one", "", nil, "null", "~"])
     }
 }

--- a/Tests/YamsTests/TopLevelDecoderTests.swift
+++ b/Tests/YamsTests/TopLevelDecoderTests.swift
@@ -32,5 +32,51 @@ class TopLevelDecoderTests: XCTestCase {
             )
         XCTAssertEqual(foo?.name, "Bird")
     }
+
+    func testDecodeOptionalTypes() throws {
+        let yaml = """
+        A: ''
+        B:
+        C: null
+        D: ~
+        E: ""
+        json: {
+          "F": "",
+          "G": "null"
+        }
+        array:
+        - one
+        - ''
+        - null
+        - 'null'
+        - '~'
+        """
+
+        struct Container: Codable, Equatable {
+            struct JSON: Codable, Equatable {
+                var F: String?
+                var G: String?
+            }
+
+            var A: String?
+            var B: String?
+            var C: Int?
+            var D: String?
+            var E: String?
+            var json: JSON
+            var array: [String?]
+        }
+
+        let container = try YAMLDecoder().decode(Container.self, from: yaml)
+
+        XCTAssertEqual(container.A, "")
+        XCTAssertEqual(container.B, nil)
+        XCTAssertEqual(container.C, nil)
+        XCTAssertEqual(container.D, nil)
+        XCTAssertEqual(container.E, "")
+        XCTAssertEqual(container.json.F, "")
+        XCTAssertEqual(container.json.G, "null")
+        XCTAssertEqual(container.array, ["one", "", nil, "null", "~"])
+    }
 }
 #endif


### PR DESCRIPTION
# Background

I was checking the feasibility of using `YAMLDecoder` to decode a simple JSON file instead of having to switch between `JSONDecoder`, but I noticed a discrepancy in a really simple example:

```swift
let json = """
    {
      "access": ""
    }
    """

struct Container: Decodable {
    let access: String?
}

let decoded = try YAMLDecoder().decode(Container.self, from: json)
XCTAssertEqual(decoded.access, "") // failed: ("nil") is not equal to ("Optional("")")
```

This was odd, because the problem does not surface when using `Yams.load(yaml:)`:

```swift
let json = """
    {
      "access": ""
    }
    """

let decoded = try XCTUnwrap(try Yams.load(yaml: json) as? NSDictionary)
XCTAssertEqual(decoded, ["access": ""]) // success
```

It was then where I discovered #301. 

# Description

> **Disclaimer:** This is my first time ever looking at this codebase, so I likely will have missed something 🙏 

Following the hints from @JensAyton, I could see in `NSNull.construct(from:)` that we weren't factoring in the `style` of the input scalar, which meant that technically this method would treat `'null'` or `''` as null. This however never seemed to surface as an issue when using `Yams.load(yaml:)` since the calling methods would perform additional checks on things like the node tag. `_Decoder.decodeNil()` on the other hand does not. 

While I could have implemented a fix in `_Decoder.decodeNil()`, I felt that it might be more appropriate to put it in `NSNull.construct(from:)`, which I did here.

In addition to the fix, I added extra test coverage to reproduce the issue and I also had to make one small adjustment to `NodeTests` due to this change.. I'll add a comment inline.

Finally, I also want to reiterate another comment from @JensAyton: 

> However, I’m leery of making a PR with this change since it may impact existing code with unfortunate dependencies on the current behaviour.

I feel the same way. I'd very much appreciate thorough eyes on this. I've added what I think is appropriate test coverage, but if you think I need to do more, or if there is a better approach to fix this, please let me know 🙏 