### PR TITLE
Adds the ability to access a Node's `tag` during decoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,8 @@
-## Main
-
-##### Breaking
-
-* None.
+## 5.0.1
 
 ##### Enhancements
 
-* None.
-
-##### Bug Fixes
-
-* None.
+* Adds the ability to access a Node's `tag` during decoding. [Santiago Gutierrez](https://github.com/ssgutierrez42)
 
 ## 5.0.0
 

--- a/Sources/Yams/Decoder.swift
+++ b/Sources/Yams/Decoder.swift
@@ -351,6 +351,12 @@ extension Decoder {
     public var mark: Mark? {
         return (self as? _Decoder)?.node.mark
     }
+    
+    /// The `Tag`  for the underlying `Node` that has been decoded.
+    public var tag: Tag? {
+        return (self as? _Decoder)?.node.tag
+    }
+    
 }
 
 // MARK: TopLevelDecoder

--- a/Yams.podspec
+++ b/Yams.podspec
@@ -2,7 +2,7 @@ Pod::Spec.new do |s|
   s.name                      = 'Yams'
   s.version                   = '5.0.0'
   s.summary                   = 'A sweet and swifty YAML parser.'
-  s.homepage                  = 'https://github.com/jpsim/Yams'
+  s.homepage                  = 'https://github.com/crucible-ai/Yams'
   s.source                    = { :git => s.homepage + '.git', :tag => s.version }
   s.license                   = { :type => 'MIT', :file => 'LICENSE' }
   s.authors                   = { 'JP Simard' => 'jp@jpsim.com',

--- a/Yams.xcodeproj/project.pbxproj
+++ b/Yams.xcodeproj/project.pbxproj
@@ -510,6 +510,7 @@
 				DYLIB_CURRENT_VERSION = 1;
 				ENABLE_TESTABILITY = YES;
 				INFOPLIST_FILE = Yams.xcodeproj/Yams_Info.plist;
+				MARKETING_VERSION = 5.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jpsim.Yams;
 				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -531,6 +532,7 @@
 				DYLIB_CURRENT_VERSION = 1;
 				ENABLE_TESTABILITY = YES;
 				INFOPLIST_FILE = Yams.xcodeproj/Yams_Info.plist;
+				MARKETING_VERSION = 5.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jpsim.Yams;
 				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";


### PR DESCRIPTION
# Summary

Enables access of a Node's tag:
e.g. `!DanceEvent`
```
structure:
  version: 0.1.0
  actions:
    8a139ac7: !DanceEvent
      type: happy
```

During the decoding function of Codable objects:
```
 required init(from decoder: Decoder) throws {
      ...
      print("\(decoder.tag)") //!DanceEvent
      ...
```

# Background

See https://github.com/jpsim/Yams/issues/265

Enables an avenue to decode polymorphic types.