### PR TITLE
Build CYaml as PIC explicitly to link it agaist libYams.so

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -55,3 +55,20 @@ jobs:
       - run: cmake --build build
       - run: cmake --build build --target install
       - run: file /usr/local/lib/swift/macosx/libYams.dylib | grep "Mach-O 64-bit dynamically linked shared library x86_64"
+
+  CMake_Linux:
+    strategy:
+      matrix:
+        tag: ['5.6-focal', '5.6-bionic']
+    runs-on: ubuntu-latest
+    container:
+      image: swift:${{ matrix.tag }}
+    steps:
+      - uses: actions/checkout@v2
+      - run: apt-get update && apt-get install ninja-build curl
+      - run: curl -L https://github.com/Kitware/CMake/releases/download/v3.23.1/cmake-3.23.1-linux-x86_64.tar.gz | tar xz --strip-components=1 -C /usr
+      - run: swift -version
+      - run: rm -rf build
+      - run: cmake -B build -G Ninja -S . -DCMAKE_BUILD_TYPE=Release
+      - run: cmake --build build
+      - run: cmake --build build --target install

--- a/Sources/CYaml/CMakeLists.txt
+++ b/Sources/CYaml/CMakeLists.txt
@@ -13,5 +13,6 @@ target_include_directories(CYaml PUBLIC
 target_compile_options(CYaml PUBLIC
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -DYAML_DECLARE_STATIC>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -I${CMAKE_CURRENT_SOURCE_DIR}/include>")
+set_property(TARGET CYaml PROPERTY POSITION_INDEPENDENT_CODE ON)
 
 set_property(GLOBAL APPEND PROPERTY YAMS_EXPORTS CYaml)


### PR DESCRIPTION
CYaml has been a private dependency of libYams.so and linked statically
against it since 2a93d740efde7caa4bc1e74c4e3c91361c12167b.
Therefore, CYaml should be built as PIC, but it wasn't.

Since gas 2.31 (Ubuntu 20.04), which includes implicit promotion of
non-PIC reloc (R_X86_64_PC32) to PIC reloc (R_X86_64_PLT32)[^1], this
issue is not revealed. However gas older than 2.31 (Ubuntu 18.04), this
PIC-ness mismatch causes linking failure with the following output:

```
/usr/bin/ld.gold: error: lib/libCYaml.a(api.c.o): requires dynamic R_X86_64_PC32 reloc against 'yaml_realloc' which may overflow at runtime; recompile with -fPIC
/usr/bin/ld.gold: error: lib/libCYaml.a(scanner.c.o): requires dynamic R_X86_64_PC32 reloc against 'yaml_parser_fetch_more_tokens' which may overflow at runtime; recompile with -fPIC
```

This patch fixes the PIC-ness mismatch by enabling
`POSITION_INDEPENDENT_CODE` explicitly, and adds CI job to check cmake
build system works on Ubuntu 18.04.

[^1]: https://sourceware.org/git/gitweb.cgi?p=binutils-gdb.git;h=bd7ab16b4537788ad53521c45469a1bdae84ad4a