### PR TITLE
Remove rules_cc dependency

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,4 +1,3 @@
-load("@rules_cc//cc:defs.bzl", "cc_library")
 load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
 
 cc_library(


### PR DESCRIPTION
The previous plan to move the cc rules into this repo have been stalled. Having this load requires downstream users to include that repo that is just a shim to the main repo in the cc_library case.