### PR TITLE
[CI] Update nightly CI job to use an actively maintained image

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -30,5 +30,6 @@ jobs:
       image: swiftlang/swift:nightly
     steps:
       - uses: actions/checkout@v3
+      - run: swift --version
       - run: YAMS_DEFAULT_ENCODING=UTF16 swift test --parallel
       - run: YAMS_DEFAULT_ENCODING=UTF8 swift test --parallel

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -27,7 +27,7 @@ jobs:
   Nightly:
     runs-on: ubuntu-latest
     container:
-      image: norionomura/swift:nightly
+      image: swiftlang/swift:nightly
     steps:
       - uses: actions/checkout@v3
       - run: YAMS_DEFAULT_ENCODING=UTF16 swift test --parallel


### PR DESCRIPTION
The last update to `norionomura/swift:nightly` was in July 2021: https://hub.docker.com/r/norionomura/swift/tags?page=1&name=nightly

The `swiftlang/swift:nightly` appears to still be actively maintained and the last push was just a few hours ago: https://hub.docker.com/r/swiftlang/swift/tags?page=1&name=nightly