### PR TITLE
Improve test CI setup

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -30,26 +30,8 @@ jobs:
     runs-on: macos-12
     steps:
       - uses: actions/checkout@v3
-      - name: MacOS build test
-        if: always()
-        run: bazelisk test //Tests:macOSBuildTest
-        shell: bash
-      - name: WatchOS build test
-        if: always()
-        run: bazelisk test //Tests:watchOSBuildTest
-        shell: bash
-      - name: iOS build test
-        if: always()
-        run: bazelisk test //Tests:iOSBuildTest
-        shell: bash
-      - name: tvOS build test
-        if: always()
-        run: bazelisk test //Tests:tvOSBuildTest
-        shell: bash
-      - name: Yams tests
-        if: always()
-        run: bazelisk test //Tests:UnitTests
-        shell: bash
+      - name: Apple tests
+        run: bazelisk test //Tests/...
   Linux:
     strategy:
       matrix:
@@ -61,4 +43,4 @@ jobs:
       - uses: actions/checkout@v3
       - uses: bazelbuild/setup-bazelisk@v2
       - name: Yams tests
-        run: bazel test --test_output=all //Tests:UnitTests
+        run: bazel test --test_output=all //Tests/...

--- a/Tests/BUILD
+++ b/Tests/BUILD
@@ -32,6 +32,7 @@ swift_test(
 macos_build_test(
     name = "macOSBuildTest",
     minimum_os_version = "10.9",
+    target_compatible_with = ["@platforms//os:macos"],
     targets = [
         "//:Yams",
         "//:CYaml",
@@ -41,6 +42,7 @@ macos_build_test(
 watchos_build_test(
     name = "watchOSBuildTest",
     minimum_os_version = "2.0",
+    target_compatible_with = ["@platforms//os:macos"],
     targets = [
         "//:Yams",
         "//:CYaml",
@@ -50,6 +52,7 @@ watchos_build_test(
 tvos_build_test(
     name = "tvOSBuildTest",
     minimum_os_version = "9.0",
+    target_compatible_with = ["@platforms//os:macos"],
     targets = [
         "//:Yams",
         "//:CYaml",
@@ -59,6 +62,7 @@ tvos_build_test(
 ios_build_test(
     name = "iOSBuildTest",
     minimum_os_version = "8.0",
+    target_compatible_with = ["@platforms//os:macos"],
     targets = [
         "//:Yams",
         "//:CYaml",


### PR DESCRIPTION
This runs all macOS tests at once to improve performance, and makes it easier to run tests on Linux without having to single out the compatible targets