### PR TITLE
Use default repo names for bazel rules

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,4 +1,4 @@
-load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
+load("@rules_swift//swift:swift.bzl", "swift_library")
 
 cc_library(
     name = "CYaml",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -4,6 +4,6 @@ module(
     compatibility_level = 1,
 )
 
-bazel_dep(name = "platforms", version = "0.0.6")
-bazel_dep(name = "rules_apple", version = "2.0.0", dev_dependency = True, repo_name = "build_bazel_rules_apple")
-bazel_dep(name = "rules_swift", version = "1.5.1", repo_name = "build_bazel_rules_swift")
+bazel_dep(name = "platforms", version = "0.0.6", dev_dependency = True)
+bazel_dep(name = "rules_apple", version = "2.0.0", dev_dependency = True)
+bazel_dep(name = "rules_swift", version = "1.5.1")

--- a/Tests/BUILD
+++ b/Tests/BUILD
@@ -1,8 +1,8 @@
-load("@build_bazel_rules_apple//apple:macos.bzl", "macos_build_test")
-load("@build_bazel_rules_apple//apple:watchos.bzl", "watchos_build_test")
-load("@build_bazel_rules_apple//apple:tvos.bzl", "tvos_build_test")
-load("@build_bazel_rules_apple//apple:ios.bzl", "ios_build_test")
-load("@build_bazel_rules_swift//swift:swift.bzl", "swift_test")
+load("@rules_apple//apple:macos.bzl", "macos_build_test")
+load("@rules_apple//apple:watchos.bzl", "watchos_build_test")
+load("@rules_apple//apple:tvos.bzl", "tvos_build_test")
+load("@rules_apple//apple:ios.bzl", "ios_build_test")
+load("@rules_swift//swift:swift.bzl", "swift_test")
 
 config_setting(
     name = "linux",


### PR DESCRIPTION
No real difference in this but it's one less thing to override