### PR TITLE
Add bazel BCR configuration files

### DIFF
--- a/.bcr/metadata.template.json
+++ b/.bcr/metadata.template.json
@@ -1,0 +1,15 @@
+{
+    "homepage": "https://github.com/jpsim/Yams",
+    "maintainers": [
+        {
+            "email": "jp@jpsim.com",
+            "github": "jpsim",
+            "name": "JP Simard"
+        }
+    ],
+    "repository": [
+        "github:jpsim/Yams"
+    ],
+    "versions": [],
+    "yanked_versions": {}
+}

--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -1,6 +1,24 @@
+shell_commands: &shell_commands
+- "echo --- Downloading and extracting Swift $SWIFT_VERSION to $SWIFT_HOME"
+- "mkdir $SWIFT_HOME"
+- "curl https://download.swift.org/swift-${SWIFT_VERSION}-release/ubuntu2004/swift-${SWIFT_VERSION}-RELEASE/swift-${SWIFT_VERSION}-RELEASE-ubuntu20.04.tar.gz | tar xvz --strip-components=1 -C $SWIFT_HOME"
+
 tasks:
-  verify_targets:
-    name: Verify targets
+  verify_targets_linux:
+    name: Verify targets (Linux)
+    platform: ubuntu2004
+    environment:
+      CC: "clang"
+      SWIFT_VERSION: "5.7.2"
+      SWIFT_HOME: "$HOME/swift-$SWIFT_VERSION"
+      PATH: "$PATH:$SWIFT_HOME/usr/bin"
+    shell_commands: *shell_commands
+    build_flags:
+    - "--action_env=PATH"
+    test_targets:
+      - '@yams//Tests/...'
+  verify_targets_macos:
+    name: Verify targets (macOS)
     platform: macos
     test_targets:
       - '@yams//Tests/...'

--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -1,0 +1,9 @@
+tasks:
+  verify_targets:
+    name: Verify targets
+    platform: macos
+    build_targets:
+      - '@yams//:Yams'
+      - '@yams//Tests/...'
+    test_targets:
+      - '@yams//Tests/...'

--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -2,8 +2,5 @@ tasks:
   verify_targets:
     name: Verify targets
     platform: macos
-    build_targets:
-      - '@yams//:Yams'
-      - '@yams//Tests/...'
     test_targets:
       - '@yams//Tests/...'

--- a/.bcr/source.template.json
+++ b/.bcr/source.template.json
@@ -1,5 +1,5 @@
 {
     "url": "https://github.com/jpsim/Yams/archive/refs/tags/{TAG}.tar.gz",
     "integrity": "",
-    "strip_prefix": ""
+    "strip_prefix": "Yams-{TAG}"
 }

--- a/.bcr/source.template.json
+++ b/.bcr/source.template.json
@@ -1,0 +1,5 @@
+{
+    "url": "https://github.com/jpsim/Yams/archive/refs/tags/{TAG}.tar.gz",
+    "integrity": "",
+    "strip_prefix": ""
+}


### PR DESCRIPTION
Should allow https://github.com/apps/publish-to-bcr to push releases to BCR automatically.