### PR TITLE
Update BCR presubmit to only build, not test

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -14,11 +14,11 @@ tasks:
       PATH: "$PATH:$SWIFT_HOME/usr/bin"
     shell_commands: *shell_commands
     build_flags:
-    - "--action_env=PATH"
-    test_targets:
-      - '@yams//Tests/...'
+      - "--action_env=PATH"
+    build_targets:
+      - '@yams//:Yams'
   verify_targets_macos:
     name: Verify targets (macOS)
     platform: macos
-    test_targets:
-      - '@yams//Tests/...'
+    build_targets:
+      - '@yams//:Yams'


### PR DESCRIPTION
Based on discussion in the PR: https://github.com/bazelbuild/bazel-central-registry/pull/367