### PR TITLE
build: use static linking for `CYaml`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
         .target(
             name: "CYaml",
             exclude: ["CMakeLists.txt"],
-            cSettings: [.define("YAML_DECLARE_EXPORT")]
+            cSettings: [.define("YAML_DECLARE_STATIC")]
         ),
         .target(
             name: "Yams",


### PR DESCRIPTION
When building with SPM, the library will be built for static linking rather than dynamic linking.  Use the `YAML_DECLARE_STATIC` to control this behaviour.  Unlike CMake, we do not have fine-grained control over the artifact linkage.