### PR TITLE
Allow decoding from a Node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
 
 ##### Enhancements
 
-* None.
+* Allow decoding from an existing Node.  
+  [Rob Napier](https://github.com/rnapier)
 
 ##### Bug Fixes
 

--- a/Sources/Yams/Decoder.swift
+++ b/Sources/Yams/Decoder.swift
@@ -18,6 +18,23 @@ public class YAMLDecoder {
         self.encoding = encoding
     }
 
+    /// Decode a `Decodable` type from a given `Node` and optional user info mapping.
+    ///
+    /// - parameter type:    `Decodable` type to decode.
+    /// - parameter node:     YAML Node to decode.
+    /// - parameter userInfo: Additional key/values which can be used when looking up keys to decode.
+    ///
+    /// - returns: Returns the decoded type `T`.
+    ///
+    /// - throws: `DecodingError` or `YamlError` if something went wrong while decoding.
+    public func decode<T>(_ type: T.Type = T.self,
+                          from node: Node,
+                          userInfo: [CodingUserInfoKey: Any] = [:]) throws -> T where T: Swift.Decodable {
+        let decoder = _Decoder(referencing: node, userInfo: userInfo)
+        let container = try decoder.singleValueContainer()
+        return try container.decode(type)
+    }
+
     /// Decode a `Decodable` type from a given `String` and optional user info mapping.
     ///
     /// - parameter type:    `Decodable` type to decode.
@@ -32,9 +49,7 @@ public class YAMLDecoder {
                           userInfo: [CodingUserInfoKey: Any] = [:]) throws -> T where T: Swift.Decodable {
         do {
             let node = try Parser(yaml: yaml, resolver: Resolver([.merge]), encoding: encoding).singleRoot() ?? ""
-            let decoder = _Decoder(referencing: node, userInfo: userInfo)
-            let container = try decoder.singleValueContainer()
-            return try container.decode(type)
+            return try self.decode(type, from: node, userInfo: userInfo)
         } catch let error as DecodingError {
             throw error
         } catch {

--- a/Tests/YamsTests/NodeDecoderTests.swift
+++ b/Tests/YamsTests/NodeDecoderTests.swift
@@ -1,0 +1,36 @@
+//
+//  NodeDecoderTests.swift
+//  
+//
+//  Created by Rob Napier on 6/3/23.
+//
+
+import XCTest
+import Yams
+
+final class NodeDecoderTests: XCTestCase {
+    func testMultiLevelPartialDecode() throws {
+        let yaml = """
+        ---
+        topLevel:
+          secondLevel:
+            desired:
+              name: My Name
+              age: 123
+        """
+
+        struct Desired: Decodable {
+            var name: String
+            var age: Int
+        }
+
+        let node = try Yams.compose(yaml: yaml)!
+
+        let desiredNode = try XCTUnwrap(node["topLevel"]?["secondLevel"]?["desired"])
+
+        let desired = try YAMLDecoder().decode(Desired.self, from: desiredNode)
+
+        XCTAssertEqual(desired.name, "My Name")
+        XCTAssertEqual(desired.age, 123)
+    }
+}


### PR DESCRIPTION
This permits decoding the entire document into a Node, and then extracting Decodable types from parts of the document without creating a structure for the entire thing.