### PR TITLE
build: pass `YAML_DEFINE_STATIC` to the CInterop

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,8 @@ let package = Package(
         .target(
             name: "Yams",
             dependencies: ["CYaml"],
-            exclude: ["CMakeLists.txt"]
+            exclude: ["CMakeLists.txt"],
+            cSettings: [.define("YAML_DECLARE_STATIC")]
         ),
         .testTarget(
             name: "YamsTests",


### PR DESCRIPTION
While we would now build CYaml statically, we would fail to indicate to clang the library was meant to be used statically and not dynamically. This cleans up some linker warnings when building SPM.