### PR TITLE
Fix parsing of unquoted URLs

### DIFF
--- a/Sources/Yams/Constructor.swift
+++ b/Sources/Yams/Constructor.swift
@@ -530,8 +530,11 @@ public protocol SexagesimalConvertible: ExpressibleByIntegerLiteral {
 }
 
 private extension SexagesimalConvertible {
-    init(sexagesimal value: String) {
-        self = value.sexagesimal()
+    init?(sexagesimal value: String) {
+        guard let value = value.sexagesimal() as Self? else {
+            return nil
+        }
+        self = value
     }
 }
 
@@ -575,7 +578,7 @@ extension Int64: SexagesimalConvertible {}
 extension UInt64: SexagesimalConvertible {}
 
 private extension String {
-    func sexagesimal<T>() -> T where T: SexagesimalConvertible {
+    func sexagesimal<T>() -> T? where T: SexagesimalConvertible {
         assert(contains(":"))
         var scalar = self
 
@@ -589,7 +592,12 @@ private extension String {
         } else {
             sign = 1
         }
-        let digits = scalar.components(separatedBy: ":").compactMap(T.create).reversed()
+        let components = scalar.components(separatedBy: ":")
+        let mappedComponents = components.compactMap(T.create)
+        guard mappedComponents.count == components.count else {
+            return nil
+        }
+        let digits = mappedComponents.reversed()
         let (_, value) = digits.reduce((1, 0) as (T, T)) { baseAndValue, digit in
             let value = baseAndValue.1 + (digit * baseAndValue.0)
             let base = baseAndValue.0 * 60

--- a/Tests/YamsTests/ConstructorTests.swift
+++ b/Tests/YamsTests/ConstructorTests.swift
@@ -515,6 +515,13 @@ class ConstructorTests: XCTestCase { // swiftlint:disable:this type_body_length
         XCTAssertEqual(nodes[1]["link with"]?[1]?["="], "library2.dll")
         XCTAssertEqual(nodes[1]["link with"]?[1]?["version"], "2.3")
     }
+
+    func testStrictParsingSexagesimal() throws {
+        XCTAssertEqual(Int.construct(from: .init("12:34:56")), 45296)
+        XCTAssertEqual(Double.construct(from: .init("12:34:56.789")), 45296.789)
+        XCTAssertNil(Int.construct(from: .init("http://example.com")))
+        XCTAssertNil(Double.construct(from: .init("http://example.com")))
+    }
 }
 
 extension ConstructorTests {


### PR DESCRIPTION
## Summary

I believe this fixes https://github.com/jpsim/Yams/issues/337, which I also just hit.

The problem is that trying to parse an int _succeeded_ for the unquoted string `http://example.com` (parsed as the number `0`), which caused issues when using an "AnyCodable" approach.

This PR makes the parsing stricter, so that a URL like above does not successfully parse as an int, and allows "AnyCodable" wrappers to only successfully parse the value as a string.

## Test Plan

Added a unit test both for the positive and negative cases.
