### PR TITLE
Adjust changelog for recent changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ##### Breaking
 
+* None.
+
+##### Enhancements
+
+* None.
+
+##### Bug Fixes
+
 * Change how empty strings are decoded into nullable properties.
   `key: ""` previously decoded into
   `struct Value: Codable { let key: String? }` as `Value(key: nil)`
@@ -11,13 +19,9 @@
   [Liam Nichols](https://github.com/liamnichols)
   [#301](https://github.com/jpsim/Yams/issues/301)
 
-##### Enhancements
-
-* None.
-
-##### Bug Fixes
-
-* None.
+* Fix parsing of unquoted URLs into Strings.  
+  [Honza Dvorsky](https://github.com/czechboy0)
+  [#337](https://github.com/jpsim/Yams/issues/337)
 
 ## 5.0.6
 


### PR DESCRIPTION
Technically, the two bug fixes could also be breaking changes in the sense that if consumers are relying on the previously buggy behavior, they'll now break with these fixes, but I think it's low-risk enough to avoid bumping the major version number.