### PR TITLE
Use aspect hint for CYaml in Bazel

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -7,11 +7,11 @@ cc_library(
         "Sources/CYaml/src/*.h",
     ]),
     hdrs = ["Sources/CYaml/include/yaml.h"],
+    aspect_hints = ["@build_bazel_rules_swift//swift:auto_module"],
     # Requires because of https://github.com/bazelbuild/bazel/pull/10143 otherwise host transition builds fail
     copts = ["-fPIC"],
     includes = ["Sources/CYaml/include"],
     linkstatic = True,
-    tags = ["swift_module"],
     visibility = ["//Tests:__subpackages__"],
 )
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -5,7 +5,7 @@ module(
 )
 
 bazel_dep(name = "apple_support", version = "1.15.1")
-bazel_dep(name = "rules_swift", version = "1.18.0", repo_name = "build_bazel_rules_swift", max_compatibility_level = 2)
+bazel_dep(name = "rules_swift", version = "2.0.0", repo_name = "build_bazel_rules_swift")
 
 bazel_dep(name = "platforms", version = "0.0.9", dev_dependency = True)
-bazel_dep(name = "rules_apple", version = "3.5.1", dev_dependency = True)
+bazel_dep(name = "rules_apple", version = "3.6.0", dev_dependency = True)


### PR DESCRIPTION
rules_swift 2.0 requires using the `aspect_hints` attribute to specify interop between `cc_library` and `swift_library`. This change adds the `aspect_hints` attribute to the `cc_library` rule for CYaml. It increases the minimum supported rules_swift version to 2.0