### PR TITLE
Add support for Musl (#429)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@
 
 ##### Enhancements
 
-* None.
+* Add support for Musl(Static Linux SDK).  
+  [arasan01](http://github.com/arasan01)
+  [#429](https://github.com/jpsim/Yams/issues/429)
 
 ##### Bug Fixes
 

--- a/Sources/Yams/Representer.swift
+++ b/Sources/Yams/Representer.swift
@@ -18,10 +18,14 @@ private let cpow: (_: Double, _: Double) -> Double = ucrt.pow
 import CoreFoundation
 import Bionic
 private let cpow: (_: Double, _: Double) -> Double = Bionic.pow
-#else
+#elseif canImport(Glibc)
 import CoreFoundation
 import Glibc
 private let cpow: (_: Double, _: Double) -> Double = Glibc.pow
+#elseif canImport(Musl)
+import CoreFoundation
+import Musl
+private let cpow: (_: Double, _: Double) -> Double = Musl.pow
 #endif
 
 public extension Node {


### PR DESCRIPTION
# Summary

Change import to allow a choice between Glibc and Musl.

related Issue: https://github.com/jpsim/Yams/issues/429
replacing musl pow: https://git.musl-libc.org/cgit/musl/tree/include/math.h

# Check

```sh
$ xcrun --toolchain org.swift.600202409171a swift --version
Apple Swift version 6.0.2-dev (LLVM 43d73cb0cc589f7, Swift aaa632cea622394)
Target: arm64-apple-macosx14.0

$ xcrun --toolchain org.swift.600202409171a swift build --swift-sdk x86_64-swift-linux-musl -c release
Building for production...
[3/3] Compiling Yams Constructor.swift
Build complete! (7.32s)

$ xcrun --toolchain org.swift.600202409171a swift build -c release
Building for production...
[9/9] Compiling Yams Constructor.swift
Build complete! (16.99s)
```
