### PR TITLE
Use builtin `pow`

### DIFF
--- a/Sources/Yams/Representer.swift
+++ b/Sources/Yams/Representer.swift
@@ -8,22 +8,6 @@
 
 import Foundation
 
-#if os(iOS) || os(macOS) || os(watchOS) || os(tvOS) || os(visionOS)
-import Darwin
-private let cpow: (_: Double, _: Double) -> Double = Darwin.pow
-#elseif os(Windows)
-import ucrt
-private let cpow: (_: Double, _: Double) -> Double = ucrt.pow
-#elseif canImport(Bionic)
-import CoreFoundation
-import Bionic
-private let cpow: (_: Double, _: Double) -> Double = Bionic.pow
-#else
-import CoreFoundation
-import Glibc
-private let cpow: (_: Double, _: Double) -> Double = Glibc.pow
-#endif
-
 public extension Node {
     /// Initialize a `Node` with a value of `NodeRepresentable`.
     ///
@@ -143,9 +127,7 @@ private extension TimeInterval {
         var integral = 0.0
         let fractional = modf(self, &integral)
 
-        // TODO(TF-1203): Can't use `pow` free function due to
-        // https://bugs.swift.org/browse/TF-1203.
-        let radix = cpow(10.0, Double(precision))
+        let radix = pow(10.0, Double(precision))
 
         let rounded = Int((fractional * radix).rounded())
         let quotient = rounded / Int(radix)


### PR DESCRIPTION
- Removes dependency on libc and the platform-specific `pow` function. This allows Linux builds using non-Glibc (like Musl) to build without error.
- `pow` should now be available in [Swift's standard library](https://github.com/swiftlang/swift/pull/23140/files) for all platforms and distributions.
- This workaround was originally added to support the Swift for Tensorflow (#281), but that project has now been archived so support is no longer required here.
- Resolves #429 
- Closes #430