### PR TITLE
Do not detect C++ toolchain

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -5,3 +5,5 @@ tasks:
     bazel: 7.x
     build_targets:
       - '@yams//:Yams'
+    build_flags:
+      - "--repo_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1"


### PR DESCRIPTION
This was necessary in the [previous Bazel release](https://github.com/bazelbuild/bazel-central-registry/pull/2404). So I guess this should be part of the template.