### PR TITLE
Don't decode explicit strings as bools, regardless of content

### DIFF
--- a/Sources/Yams/Constructor.swift
+++ b/Sources/Yams/Constructor.swift
@@ -139,6 +139,9 @@ extension Bool: ScalarConstructible {
     ///
     /// - returns: An instance of `Bool`, if one was successfully extracted from the scalar.
     public static func construct(from scalar: Node.Scalar) -> Bool? {
+        if scalar.tag.name == .str {
+            return nil
+        }
         switch scalar.string.lowercased() {
         case "true", "yes", "on":
             return true

--- a/Tests/YamsTests/NodeDecoderTests.swift
+++ b/Tests/YamsTests/NodeDecoderTests.swift
@@ -33,4 +33,64 @@ final class NodeDecoderTests: XCTestCase {
         XCTAssertEqual(desired.name, "My Name")
         XCTAssertEqual(desired.age, 123)
     }
+
+    func testDecodeBools() throws {
+        let yaml = """
+        ---
+        topLevel:
+          unquotedBool: true
+          explicitBool: !!bool true
+          explicitStringNotBool: !!str true
+          singleQuotedStringNotBool: 'true'
+          doubleQuotedStringNotBool: "true"
+        """
+
+        struct TopLevel: Decodable {
+            var unquotedBool: BoolOrString
+            var explicitBool: BoolOrString
+            var explicitStringNotBool: BoolOrString
+            var singleQuotedStringNotBool: BoolOrString
+            var doubleQuotedStringNotBool: BoolOrString
+        }
+
+        let node = try Yams.compose(yaml: yaml)!
+
+        let desiredNode = try XCTUnwrap(node["topLevel"])
+
+        let desired = try YAMLDecoder().decode(TopLevel.self, from: desiredNode)
+
+        XCTAssertEqual(desired.unquotedBool, true)
+        XCTAssertEqual(desired.explicitBool, true)
+        XCTAssertEqual(desired.explicitStringNotBool, "true")
+        XCTAssertEqual(desired.singleQuotedStringNotBool, "true")
+        XCTAssertEqual(desired.doubleQuotedStringNotBool, "true")
+    }
+}
+
+enum BoolOrString: Equatable {
+    case bool(Bool)
+    case string(String)
+}
+
+extension BoolOrString: Decodable {
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if let bool = try? container.decode(Bool.self) {
+            self = .bool(bool)
+        } else {
+            self = .string(try container.decode(String.self))
+        }
+    }
+}
+
+extension BoolOrString: ExpressibleByStringLiteral {
+    init(stringLiteral value: String) {
+        self = .string(value)
+    }
+}
+
+extension BoolOrString: ExpressibleByBooleanLiteral {
+    init(booleanLiteral value: Bool) {
+        self = .bool(value)
+    }
 }

--- a/Tests/YamsTests/NodeDecoderTests.swift
+++ b/Tests/YamsTests/NodeDecoderTests.swift
@@ -59,11 +59,11 @@ final class NodeDecoderTests: XCTestCase {
 
         let desired = try YAMLDecoder().decode(TopLevel.self, from: desiredNode)
 
-        XCTAssertEqual(desired.unquotedBool, true)
-        XCTAssertEqual(desired.explicitBool, true)
-        XCTAssertEqual(desired.explicitStringNotBool, "true")
-        XCTAssertEqual(desired.singleQuotedStringNotBool, "true")
-        XCTAssertEqual(desired.doubleQuotedStringNotBool, "true")
+        XCTAssertEqual(desired.unquotedBool, .bool(true))
+        XCTAssertEqual(desired.explicitBool, .bool(true))
+        XCTAssertEqual(desired.explicitStringNotBool, .string("true"))
+        XCTAssertEqual(desired.singleQuotedStringNotBool, .string("true"))
+        XCTAssertEqual(desired.doubleQuotedStringNotBool, .string("true"))
     }
 }
 
@@ -80,17 +80,5 @@ extension BoolOrString: Decodable {
         } else {
             self = .string(try container.decode(String.self))
         }
-    }
-}
-
-extension BoolOrString: ExpressibleByStringLiteral {
-    init(stringLiteral value: String) {
-        self = .string(value)
-    }
-}
-
-extension BoolOrString: ExpressibleByBooleanLiteral {
-    init(booleanLiteral value: Bool) {
-        self = .bool(value)
     }
 }


### PR DESCRIPTION
## Summary

A scalar with the text `true`, for example, can be decoded as a Bool today - that's expected.

However, when using a YAMLDecoder, the scalars `!!str true`, `"true"`, and `'true'` also successfully decode as Bools - that's unexpected, especially with Decodable implementations often trying multiple different types to decode as, and use the first one that works.

The suggested change checks the scalar's tag property, and if it's explicitly marked as a string, doesn't allow creating a Bool value from it.

This fixes AnyCodable-style decoding of YAML values, which in turn affects correctness of round-tripping YAML through Yams and back into YAML.

## Test Plan

Added unit tests, verified they failed before this change and pass with the change.
