### PR TITLE
Enable library evolution to support Swift 6.1

### DIFF
--- a/Sources/Yams/Emitter.swift
+++ b/Sources/Yams/Emitter.swift
@@ -7,7 +7,11 @@
 //
 
 #if SWIFT_PACKAGE
+#if compiler(>=6)
+internal import CYaml
+#else
 @_implementationOnly import CYaml
+#endif
 #endif
 import Foundation
 

--- a/Sources/Yams/Parser.swift
+++ b/Sources/Yams/Parser.swift
@@ -9,7 +9,11 @@
 // swiftlint:disable file_length
 
 #if SWIFT_PACKAGE
+#if compiler(>=6)
+internal import CYaml
+#else
 @_implementationOnly import CYaml
+#endif
 #endif
 import Foundation
 

--- a/Sources/Yams/YamlError.swift
+++ b/Sources/Yams/YamlError.swift
@@ -7,7 +7,11 @@
 //
 
 #if SWIFT_PACKAGE
+#if compiler(>=6)
+internal import CYaml
+#else
 @_implementationOnly import CYaml
+#endif
 #endif
 import Foundation
 


### PR DESCRIPTION
Xcode 16.3/Swift 6.1 now treat usages of `@_implementationOnly` as errors unless library evolution is enabled. 

Updates _BUILD_ and fixes an issue with unsupported scoped imports in module interfaces.