### PR TITLE
Use `internal import` when possible

### DIFF
--- a/Sources/Yams/Emitter.swift
+++ b/Sources/Yams/Emitter.swift
@@ -6,6 +6,8 @@
 //  Copyright (c) 2016 Yams. All rights reserved.
 //
 
+// swiftlint:disable duplicate_imports
+
 #if SWIFT_PACKAGE
 #if compiler(>=6)
 internal import CYaml

--- a/Sources/Yams/Emitter.swift
+++ b/Sources/Yams/Emitter.swift
@@ -7,7 +7,11 @@
 //
 
 #if SWIFT_PACKAGE
+#if compiler(>=6)
+internal import CYaml
+#else
 @_implementationOnly import CYaml
+#endif
 #endif
 import Foundation
 

--- a/Sources/Yams/Parser.swift
+++ b/Sources/Yams/Parser.swift
@@ -9,7 +9,11 @@
 // swiftlint:disable file_length
 
 #if SWIFT_PACKAGE
+#if compiler(>=6)
+internal import CYaml
+#else
 @_implementationOnly import CYaml
+#endif
 #endif
 import Foundation
 

--- a/Sources/Yams/Parser.swift
+++ b/Sources/Yams/Parser.swift
@@ -7,6 +7,7 @@
 //
 
 // swiftlint:disable file_length
+// swiftlint:disable duplicate_imports
 
 #if SWIFT_PACKAGE
 #if compiler(>=6)

--- a/Sources/Yams/YamlError.swift
+++ b/Sources/Yams/YamlError.swift
@@ -6,6 +6,8 @@
 //  Copyright (c) 2016 Yams. All rights reserved.
 //
 
+// swiftlint:disable duplicate_imports
+
 #if SWIFT_PACKAGE
 #if compiler(>=6)
 internal import CYaml

--- a/Sources/Yams/YamlError.swift
+++ b/Sources/Yams/YamlError.swift
@@ -7,7 +7,11 @@
 //
 
 #if SWIFT_PACKAGE
+#if compiler(>=6)
+internal import CYaml
+#else
 @_implementationOnly import CYaml
+#endif
 #endif
 import Foundation
 


### PR DESCRIPTION
Addresses warnings around `@_implementationOnly import` statements when compiled with Xcode 16.3 / Swift 6.1