### PR TITLE
Add NumberFormatStrategy for Floating Points. Add option for decimal Encoding/Decoding

### DIFF
--- a/Sources/Yams/Emitter.swift
+++ b/Sources/Yams/Emitter.swift
@@ -257,7 +257,7 @@ public final class Emitter {
         public var floatMaximumSignificantDigits = 7
 
         public init(style: NumberFormatStyle = .scientific,
-                    doubleMaximumSignificantDigits: Int = 15, 
+                    doubleMaximumSignificantDigits: Int = 15,
                     floatMaximumSignificantDigits: Int = 7) {
             self.style = style
             self.doubleMaximumSignificantDigits = doubleMaximumSignificantDigits

--- a/Sources/Yams/Emitter.swift
+++ b/Sources/Yams/Emitter.swift
@@ -243,6 +243,28 @@ public final class Emitter {
         case crln
     }
 
+    /// Number format style to use when emitting YAML.
+    public enum NumberFormatStyle {
+        /// Use scientific notation.
+        case scientific
+        /// Use decimal notation.
+        case decimal
+    }
+
+    public struct NumberFormatStrategy {
+        public var style: NumberFormatStyle = .scientific
+        public var doubleMaximumSignificantDigits = 15
+        public var floatMaximumSignificantDigits = 7
+
+        public init(style: NumberFormatStyle = .scientific,
+                    doubleMaximumSignificantDigits: Int = 15, 
+                    floatMaximumSignificantDigits: Int = 7) {
+            self.style = style
+            self.doubleMaximumSignificantDigits = doubleMaximumSignificantDigits
+            self.floatMaximumSignificantDigits = floatMaximumSignificantDigits
+        }
+    }
+
     /// Retrieve this Emitter's binary output.
     public internal(set) var data = Data()
 
@@ -281,6 +303,9 @@ public final class Emitter {
         /// Redundancy aliasing strategy to use when encoding. Defaults to nil
         public var redundancyAliasingStrategy: RedundancyAliasingStrategy?
 
+        /// Set the number format strategy to use when emitting YAML.
+        public var numberFormatStrategy: NumberFormatStrategy = NumberFormatStrategy()
+
         /// Create `Emitter.Options` with the specified values.
         ///
         /// - parameter canonical:     Set if the output should be in the "canonical" format described in the YAML
@@ -297,6 +322,7 @@ public final class Emitter {
         /// - parameter mappingStyle:  Set the style for mappings (dictionaries)
         /// - parameter newLineScalarStyle: Set the style for newline-containing scalars
         /// - parameter redundancyAliasingStrategy: Set the strategy for identifying
+        /// - parameter numberFormatStrategy: Set the number format strategy to use when emitting YAML.
         /// redundant structures and automatically aliasing them
         public init(canonical: Bool = false, indent: Int = 0, width: Int = 0, allowUnicode: Bool = false,
                     lineBreak: Emitter.LineBreak = .ln,
@@ -306,7 +332,8 @@ public final class Emitter {
                     sortKeys: Bool = false, sequenceStyle: Node.Sequence.Style = .any,
                     mappingStyle: Node.Mapping.Style = .any,
                     newLineScalarStyle: Node.Scalar.Style = .any,
-                    redundancyAliasingStrategy: RedundancyAliasingStrategy? = nil) {
+                    redundancyAliasingStrategy: RedundancyAliasingStrategy? = nil,
+                    numberFormatStrategy: NumberFormatStrategy = NumberFormatStrategy()) {
             self.canonical = canonical
             self.indent = indent
             self.width = width
@@ -320,6 +347,7 @@ public final class Emitter {
             self.mappingStyle = mappingStyle
             self.newLineScalarStyle = newLineScalarStyle
             self.redundancyAliasingStrategy = redundancyAliasingStrategy
+            self.numberFormatStrategy = numberFormatStrategy
         }
     }
 

--- a/Sources/Yams/Emitter.swift
+++ b/Sources/Yams/Emitter.swift
@@ -243,26 +243,12 @@ public final class Emitter {
         case crln
     }
 
-    /// Number format style to use when emitting YAML.
-    public enum NumberFormatStyle {
+    /// Floating point number format style to use when emitting YAML.
+    public enum FloatingPointNumberFormatStrategy {
         /// Use scientific notation.
         case scientific
         /// Use decimal notation.
         case decimal
-    }
-
-    public struct NumberFormatStrategy {
-        public var style: NumberFormatStyle = .scientific
-        public var doubleMaximumSignificantDigits = 15
-        public var floatMaximumSignificantDigits = 7
-
-        public init(style: NumberFormatStyle = .scientific,
-                    doubleMaximumSignificantDigits: Int = 15,
-                    floatMaximumSignificantDigits: Int = 7) {
-            self.style = style
-            self.doubleMaximumSignificantDigits = doubleMaximumSignificantDigits
-            self.floatMaximumSignificantDigits = floatMaximumSignificantDigits
-        }
     }
 
     /// Retrieve this Emitter's binary output.
@@ -304,7 +290,7 @@ public final class Emitter {
         public var redundancyAliasingStrategy: RedundancyAliasingStrategy?
 
         /// Set the number format strategy to use when emitting YAML.
-        public var numberFormatStrategy: NumberFormatStrategy = NumberFormatStrategy()
+        public var floatingPointNumberFormatStrategy: FloatingPointNumberFormatStrategy = .scientific
 
         /// Create `Emitter.Options` with the specified values.
         ///
@@ -333,7 +319,7 @@ public final class Emitter {
                     mappingStyle: Node.Mapping.Style = .any,
                     newLineScalarStyle: Node.Scalar.Style = .any,
                     redundancyAliasingStrategy: RedundancyAliasingStrategy? = nil,
-                    numberFormatStrategy: NumberFormatStrategy = NumberFormatStrategy()) {
+                    floatingPointNumberFormatStrategy: FloatingPointNumberFormatStrategy = .scientific) {
             self.canonical = canonical
             self.indent = indent
             self.width = width
@@ -347,7 +333,7 @@ public final class Emitter {
             self.mappingStyle = mappingStyle
             self.newLineScalarStyle = newLineScalarStyle
             self.redundancyAliasingStrategy = redundancyAliasingStrategy
-            self.numberFormatStrategy = numberFormatStrategy
+            self.floatingPointNumberFormatStrategy = floatingPointNumberFormatStrategy
         }
     }
 
@@ -374,6 +360,7 @@ public final class Emitter {
     /// - parameter mappingStyle:  Set the style for mappings (dictionaries)
     /// - parameter newLineScalarStyle: Set the style for newline-containing scalars
     /// - parameter redundancyAliasingStrategy: Set the strategy for identifying redundant
+    /// - parameter numberFormatStrategy: Set the number format strategy to use when emitting YAML.
     /// structures and automatically aliasing them
     public init(canonical: Bool = false,
                 indent: Int = 0,
@@ -387,7 +374,8 @@ public final class Emitter {
                 sequenceStyle: Node.Sequence.Style = .any,
                 mappingStyle: Node.Mapping.Style = .any,
                 newLineScalarStyle: Node.Scalar.Style = .any,
-                redundancyAliasingStrategy: RedundancyAliasingStrategy? = nil) {
+                redundancyAliasingStrategy: RedundancyAliasingStrategy? = nil,
+                floatingPointNumberFormatStrategy: FloatingPointNumberFormatStrategy = .scientific) {
         options = Options(canonical: canonical,
                           indent: indent,
                           width: width,
@@ -400,7 +388,8 @@ public final class Emitter {
                           sequenceStyle: sequenceStyle,
                           mappingStyle: mappingStyle,
                           newLineScalarStyle: newLineScalarStyle,
-                          redundancyAliasingStrategy: redundancyAliasingStrategy)
+                          redundancyAliasingStrategy: redundancyAliasingStrategy,
+                          floatingPointNumberFormatStrategy: floatingPointNumberFormatStrategy)
         // configure emitter
         yaml_emitter_initialize(&emitter)
         yaml_emitter_set_output(&self.emitter, { pointer, buffer, size in

--- a/Sources/Yams/Emitter.swift
+++ b/Sources/Yams/Emitter.swift
@@ -308,7 +308,7 @@ public final class Emitter {
         /// - parameter mappingStyle:  Set the style for mappings (dictionaries)
         /// - parameter newLineScalarStyle: Set the style for newline-containing scalars
         /// - parameter redundancyAliasingStrategy: Set the strategy for identifying
-        /// - parameter numberFormatStrategy: Set the number format strategy to use when emitting YAML.
+        /// - parameter floatingPointNumberFormatStrategy: Set the number format strategy to use when emitting YAML.
         /// redundant structures and automatically aliasing them
         public init(canonical: Bool = false, indent: Int = 0, width: Int = 0, allowUnicode: Bool = false,
                     lineBreak: Emitter.LineBreak = .ln,
@@ -360,7 +360,7 @@ public final class Emitter {
     /// - parameter mappingStyle:  Set the style for mappings (dictionaries)
     /// - parameter newLineScalarStyle: Set the style for newline-containing scalars
     /// - parameter redundancyAliasingStrategy: Set the strategy for identifying redundant
-    /// - parameter numberFormatStrategy: Set the number format strategy to use when emitting YAML.
+    /// - parameter floatingPointNumberFormatStrategy: Set the number format strategy to use when emitting YAML.
     /// structures and automatically aliasing them
     public init(canonical: Bool = false,
                 indent: Int = 0,

--- a/Sources/Yams/Encoder.swift
+++ b/Sources/Yams/Encoder.swift
@@ -56,12 +56,14 @@ public class YAMLEncoder {
 private class _Encoder: Swift.Encoder {
     var node: Node = .unused
 
-    init(userInfo: [CodingUserInfoKey: Any] = [:], 
-        codingPath: [CodingKey] = [], 
+    init(
+        userInfo: [CodingUserInfoKey: Any] = [:],
+        codingPath: [CodingKey] = [],
         sequenceStyle: Node.Sequence.Style,
-        mappingStyle: Node.Mapping.Style, 
+        mappingStyle: Node.Mapping.Style,
         newlineScalarStyle: Node.Scalar.Style,
-        numberFormatStrategy: Emitter.NumberFormatStrategy) {
+        numberFormatStrategy: Emitter.NumberFormatStrategy
+    ) {
         self.userInfo = userInfo
         self.codingPath = codingPath
         self.sequenceStyle = sequenceStyle

--- a/Sources/Yams/Encoder.swift
+++ b/Sources/Yams/Encoder.swift
@@ -237,7 +237,11 @@ extension _Encoder: SingleValueEncodingContainer {
 
     private func encode(yamlEncodable encodable: YAMLEncodable) throws {
         func encodeNode() {
-            node = encodable.box(options: options)
+            if let optionEncodable = encodable as? YAMLEncodableWithOptions {
+                node = optionEncodable.box(options: options)
+            } else {
+                node = encodable.box()
+            }
             if let stringValue = encodable as? (any StringProtocol), stringValue.contains("\n") {
                 node.scalar?.style = options.newLineScalarStyle
             }

--- a/Sources/Yams/Representer.swift
+++ b/Sources/Yams/Representer.swift
@@ -313,7 +313,7 @@ extension Float: YAMLEncodable {
 private extension FloatingPoint where Self: CVarArg {
     func formattedStringForCodable(numberFormatStyle: Emitter.NumberFormatStyle,
                                    formatter: NumberFormatter) -> String {
-        if numberFormatStyle == .decimal {
+        if numberFormatStyle == .decimal && self != .greatestFiniteMagnitude && self != -.greatestFiniteMagnitude {
             formatter.numberStyle = .decimal
             return formatter.string(for: self)!
         }

--- a/Sources/Yams/Representer.swift
+++ b/Sources/Yams/Representer.swift
@@ -294,7 +294,7 @@ extension Double: YAMLEncodable {
     /// Returns this value wrapped in a `Node.scalar`.
     public func box(numberFormatStrategy: Emitter.NumberFormatStrategy) -> Node {
         encodableFloatingPointFormatter.maximumSignificantDigits = numberFormatStrategy.doubleMaximumSignificantDigits
-        let formattedString = formattedStringForCodable(numberFormatStyle: numberFormatStrategy.style, 
+        let formattedString = formattedStringForCodable(numberFormatStyle: numberFormatStrategy.style,
                                                                 formatter: encodableFloatingPointFormatter)
         return Node(formattedString, Tag(.float))
     }
@@ -304,15 +304,15 @@ extension Float: YAMLEncodable {
     /// Returns this value wrapped in a `Node.scalar`.
     public func box(numberFormatStrategy: Emitter.NumberFormatStrategy) -> Node {
         encodableFloatingPointFormatter.maximumSignificantDigits = numberFormatStrategy.floatMaximumSignificantDigits
-        let formattedString = formattedStringForCodable(numberFormatStyle: numberFormatStrategy.style, 
+        let formattedString = formattedStringForCodable(numberFormatStyle: numberFormatStrategy.style,
                                                                 formatter: encodableFloatingPointFormatter)
         return Node(formattedString, Tag(.float))
     }
 }
 
 private extension FloatingPoint where Self: CVarArg {
-    func formattedStringForCodable(numberFormatStyle: Emitter.NumberFormatStyle, 
-                                formatter: NumberFormatter) -> String {
+    func formattedStringForCodable(numberFormatStyle: Emitter.NumberFormatStyle,
+                                   formatter: NumberFormatter) -> String {
         if numberFormatStyle == .decimal {
             formatter.numberStyle = .decimal
             return formatter.string(for: self)!
@@ -330,7 +330,7 @@ private extension FloatingPoint where Self: CVarArg {
     }
 }
 
-extension Emitter.NumberFormatStrategy {
+private extension Emitter.NumberFormatStrategy {
     var numberFormatStyle: NumberFormatter.Style {
         switch self.style {
         case .scientific:

--- a/Sources/Yams/Representer.swift
+++ b/Sources/Yams/Representer.swift
@@ -62,40 +62,40 @@ private func represent(_ value: Any) throws -> Node {
 /// Type is representable as `Node.scalar`.
 public protocol ScalarRepresentable: NodeRepresentable {
     /// This value's `Node.scalar` representation.
-    func represented(options: Emitter.Options) -> Node.Scalar
+    func represented() -> Node.Scalar
 }
 
 extension ScalarRepresentable {
     /// This value's `Node.scalar` representation.
     public func represented() throws -> Node {
-        return .scalar(represented(options: .init()))
+        return .scalar(represented())
     }
 }
 
 extension NSNull: ScalarRepresentable {
     /// This value's `Node.scalar` representation.
-    public func represented(options: Emitter.Options) -> Node.Scalar {
+    public func represented() -> Node.Scalar {
         return .init("null", Tag(.null))
     }
 }
 
 extension Bool: ScalarRepresentable {
     /// This value's `Node.scalar` representation.
-    public func represented(options: Emitter.Options) -> Node.Scalar {
+    public func represented() -> Node.Scalar {
         return .init(self ? "true" : "false", Tag(.bool))
     }
 }
 
 extension Data: ScalarRepresentable {
     /// This value's `Node.scalar` representation.
-    public func represented(options: Emitter.Options) -> Node.Scalar {
+    public func represented() -> Node.Scalar {
         return .init(base64EncodedString(), Tag(.binary))
     }
 }
 
 extension Date: ScalarRepresentable {
     /// This value's `Node.scalar` representation.
-    public func represented(options: Emitter.Options) -> Node.Scalar {
+    public func represented() -> Node.Scalar {
         return .init(iso8601String, Tag(.timestamp))
     }
 
@@ -157,25 +157,15 @@ private let iso8601WithoutZFormatter: DateFormatter = {
 
 extension Double: ScalarRepresentable {
     /// This value's `Node.scalar` representation.
-    public func represented(options: Emitter.Options) -> Node.Scalar {
-        let formattedString: String = formattedStringForCodable(
-            value: self,
-            floatingPointNumberFormatStrategy: options.floatingPointNumberFormatStrategy,
-            formatter: doubleFormatter
-        )
-        return .init(formattedString.replacingOccurrences(of: "+-", with: "-"), Tag(.float))
+    public func represented() -> Node.Scalar {
+        return .init(doubleFormatter.string(for: self)!.replacingOccurrences(of: "+-", with: "-"), Tag(.float))
     }
 }
 
 extension Float: ScalarRepresentable {
     /// This value's `Node.scalar` representation.
-    public func represented(options: Emitter.Options) -> Node.Scalar {
-        let formattedString: String = formattedStringForCodable(
-            value: self,
-            floatingPointNumberFormatStrategy: options.floatingPointNumberFormatStrategy,
-            formatter: floatFormatter
-        )
-        return .init(formattedString.replacingOccurrences(of: "+-", with: "-"), Tag(.float))
+    public func represented() -> Node.Scalar {
+        return .init(floatFormatter.string(for: self)!.replacingOccurrences(of: "+-", with: "-"), Tag(.float))
     }
 }
 
@@ -200,7 +190,7 @@ private let floatFormatter = numberFormatter(with: 7)
 
 extension BinaryInteger {
     /// This value's `Node.scalar` representation.
-    public func represented(options: Emitter.Options) -> Node.Scalar {
+    public func represented() -> Node.Scalar {
         return .init(String(describing: self), Tag(.int))
     }
 }
@@ -230,21 +220,21 @@ extension Optional: NodeRepresentable {
 
 extension Decimal: ScalarRepresentable {
     /// This value's `Node.scalar` representation.
-    public func represented(options: Emitter.Options) -> Node.Scalar {
+    public func represented() -> Node.Scalar {
         return .init(description)
     }
 }
 
 extension URL: ScalarRepresentable {
     /// This value's `Node.scalar` representation.
-    public func represented(options: Emitter.Options) -> Node.Scalar {
+    public func represented() -> Node.Scalar {
         return .init(absoluteString)
     }
 }
 
 extension String: ScalarRepresentable {
     /// This value's `Node.scalar` representation.
-    public func represented(options: Emitter.Options) -> Node.Scalar {
+    public func represented() -> Node.Scalar {
         let scalar = Node.Scalar(self)
         return scalar.resolvedTag.name == .str ? scalar : .init(self, Tag(.str), .singleQuoted)
     }
@@ -252,7 +242,7 @@ extension String: ScalarRepresentable {
 
 extension UUID: ScalarRepresentable {
     /// This value's `Node.scalar` representation.
-    public func represented(options: Emitter.Options) -> Node.Scalar {
+    public func represented() -> Node.Scalar {
         return .init(uuidString)
     }
 }
@@ -262,13 +252,13 @@ extension UUID: ScalarRepresentable {
 /// Types conforming to this protocol can be encoded by `YamlEncoder`.
 public protocol YAMLEncodable: Encodable {
     /// Returns this value wrapped in a `Node`.
-    func box(options: Emitter.Options) -> Node
+    func box() -> Node
 }
 
 extension YAMLEncodable where Self: ScalarRepresentable {
     /// Returns this value wrapped in a `Node.scalar`.
-    public func box(options: Emitter.Options) -> Node {
-        return .scalar(represented(options: options))
+    public func box() -> Node {
+        return .scalar(represented())
     }
 }
 
@@ -291,15 +281,24 @@ extension UUID: YAMLEncodable {}
 
 extension Date: YAMLEncodable {
     /// Returns this value wrapped in a `Node.scalar`.
-    public func box(options: Emitter.Options) -> Node {
+    public func box() -> Node {
         return Node(iso8601StringWithFullNanosecond, Tag(.timestamp))
     }
 }
 
-extension Double: YAMLEncodable {
+/// Internal customization point for built-in values whose encoding depends on emitter options.
+protocol YAMLEncodableWithOptions: YAMLEncodable {
+    func box(options: Emitter.Options) -> Node
+}
+
+extension Double: YAMLEncodable, YAMLEncodableWithOptions {
     /// Returns this value wrapped in a `Node.scalar`.
-    public func box(options: Emitter.Options) -> Node {
-        let formattedString: String = formattedStringForCodable(
+    public func box() -> Node {
+        return Node(formattedStringForCodable, Tag(.float))
+    }
+
+    func box(options: Emitter.Options) -> Node {
+        let formattedString: String = formatFloatingPoint(
             value: self,
             floatingPointNumberFormatStrategy: options.floatingPointNumberFormatStrategy,
             formatter: doubleFormatter
@@ -308,10 +307,14 @@ extension Double: YAMLEncodable {
     }
 }
 
-extension Float: YAMLEncodable {
+extension Float: YAMLEncodable, YAMLEncodableWithOptions {
     /// Returns this value wrapped in a `Node.scalar`.
-    public func box(options: Emitter.Options) -> Node {
-        let formattedString: String = formattedStringForCodable(
+    public func box() -> Node {
+        return Node(formattedStringForCodable, Tag(.float))
+    }
+
+    func box(options: Emitter.Options) -> Node {
+        let formattedString: String = formatFloatingPoint(
             value: self,
             floatingPointNumberFormatStrategy: options.floatingPointNumberFormatStrategy,
             formatter: floatFormatter
@@ -320,22 +323,30 @@ extension Float: YAMLEncodable {
     }
 }
 
-private func formattedStringForCodable<T: FloatingPoint & CustomStringConvertible & CVarArg>(
+private extension FloatingPoint where Self: CustomStringConvertible & CVarArg {
+    var formattedStringForCodable: String {
+        formatFloatingPoint(
+            value: self,
+            floatingPointNumberFormatStrategy: .scientific,
+            formatter: doubleFormatter
+        )
+    }
+}
+
+private func formatFloatingPoint<T: FloatingPoint & CustomStringConvertible & CVarArg>(
     value: T,
     floatingPointNumberFormatStrategy: Emitter.FloatingPointNumberFormatStrategy,
     formatter: NumberFormatter
 ) -> String {
     if floatingPointNumberFormatStrategy == .decimal {
-        switch value {
-        case .infinity:
-            return ".inf"
-        case -.infinity:
-            return "-.inf"
-        case .nan:
+        if value.isNaN {
             return ".nan"
-        default:
-            return value.description
+        } else if value == .infinity {
+            return ".inf"
+        } else if value == -.infinity {
+            return "-.inf"
         }
+        return value.description
     }
 
     // Since `NumberFormatter` creates a string with insufficient precision for Decode,
@@ -344,7 +355,6 @@ private func formattedStringForCodable<T: FloatingPoint & CustomStringConvertibl
     // "%*.g" does not use scientific notation if the exponent is less than –4.
     // So fallback to using `NumberFormatter` if string does not uses scientific notation.
     guard string.lazy.suffix(5).contains("e") else {
-        formatter.numberStyle = .scientific
         return formatter.string(for: value)!.replacingOccurrences(of: "+-", with: "-")
     }
     return string

--- a/Tests/YamsTests/EncoderTests.swift
+++ b/Tests/YamsTests/EncoderTests.swift
@@ -35,6 +35,31 @@ final class EncoderTests: XCTestCase, @unchecked Sendable { // swiftlint:disable
         _testRoundTrip(of: Timestamp(3141592653), expectedYAML: "3.141592653e+9\n")
     }
 
+    func testEncodingTopLevelSingleValueStructDecimalDouble() {
+        _testRoundTrip(of: Double(3.141592653), 
+                        with: YAMLEncoder.Options(numberFormatStrategy: .init(style: .decimal)), 
+                        expectedYAML: "3.141592653\n")
+    }
+
+
+    func testDecimalDoubleStyle() throws {
+        _testRoundTrip(of: Double(6.8), 
+                        with: YAMLEncoder.Options(numberFormatStrategy: .init(style: .decimal)), 
+                        expectedYAML: "6.8\n")
+    }
+
+    func testDecimalFloatStyle() throws {
+        _testRoundTrip(of: Float(6.8), 
+                        with: YAMLEncoder.Options(numberFormatStrategy: .init(style: .decimal)), 
+                        expectedYAML: "6.8\n")
+    }
+
+    func testMinimumFractionDigits() throws {
+        _testRoundTrip(of: Double(6.0),
+                    with: YAMLEncoder.Options(numberFormatStrategy: .init(style: .decimal, doubleMaximumSignificantDigits: 1)),
+                    expectedYAML: "6\n")
+    }
+
     func testEncodingTopLevelSingleValueClass() {
         _testRoundTrip(of: Counter(), expectedYAML: "0\n")
     }

--- a/Tests/YamsTests/EncoderTests.swift
+++ b/Tests/YamsTests/EncoderTests.swift
@@ -59,6 +59,24 @@ final class EncoderTests: XCTestCase, @unchecked Sendable { // swiftlint:disable
                     expectedYAML: "6\n")
     }
 
+    func testDecimalDoubleGreatestFiniteMagnitude() throws {
+        _testRoundTrip(of: Double.greatestFiniteMagnitude,
+                        with: YAMLEncoder.Options(numberFormatStrategy: .init(style: .decimal)),
+                        expectedYAML: "1.7976931348623157e+308\n")
+    }
+
+    func testDecimalDoubleNegativeGreatestFiniteMagnitude() throws {
+        _testRoundTrip(of: -Double.greatestFiniteMagnitude,
+                        with: YAMLEncoder.Options(numberFormatStrategy: .init(style: .decimal)),
+                        expectedYAML: "-1.7976931348623157e+308\n")
+    }
+
+    func testDecimalFloatGreatestFiniteMagnitude() throws {
+        _testRoundTrip(of: Float.greatestFiniteMagnitude,
+                        with: YAMLEncoder.Options(numberFormatStrategy: .init(style: .decimal)),
+                        expectedYAML: "3.4028234663852886e+38\n")
+    }
+
     func testEncodingTopLevelSingleValueClass() {
         _testRoundTrip(of: Counter(), expectedYAML: "0\n")
     }

--- a/Tests/YamsTests/EncoderTests.swift
+++ b/Tests/YamsTests/EncoderTests.swift
@@ -36,21 +36,20 @@ final class EncoderTests: XCTestCase, @unchecked Sendable { // swiftlint:disable
     }
 
     func testEncodingTopLevelSingleValueStructDecimalDouble() {
-        _testRoundTrip(of: Double(3.141592653), 
-                        with: YAMLEncoder.Options(numberFormatStrategy: .init(style: .decimal)), 
+        _testRoundTrip(of: Double(3.141592653),
+                        with: YAMLEncoder.Options(numberFormatStrategy: .init(style: .decimal)),
                         expectedYAML: "3.141592653\n")
     }
 
-
     func testDecimalDoubleStyle() throws {
-        _testRoundTrip(of: Double(6.8), 
-                        with: YAMLEncoder.Options(numberFormatStrategy: .init(style: .decimal)), 
+        _testRoundTrip(of: Double(6.8),
+                        with: YAMLEncoder.Options(numberFormatStrategy: .init(style: .decimal)),
                         expectedYAML: "6.8\n")
     }
 
     func testDecimalFloatStyle() throws {
-        _testRoundTrip(of: Float(6.8), 
-                        with: YAMLEncoder.Options(numberFormatStrategy: .init(style: .decimal)), 
+        _testRoundTrip(of: Float(6.8),
+                        with: YAMLEncoder.Options(numberFormatStrategy: .init(style: .decimal)),
                         expectedYAML: "6.8\n")
     }
 

--- a/Tests/YamsTests/EncoderTests.swift
+++ b/Tests/YamsTests/EncoderTests.swift
@@ -37,44 +37,56 @@ final class EncoderTests: XCTestCase, @unchecked Sendable { // swiftlint:disable
 
     func testEncodingTopLevelSingleValueStructDecimalDouble() {
         _testRoundTrip(of: Double(3.141592653),
-                        with: YAMLEncoder.Options(numberFormatStrategy: .init(style: .decimal)),
+                        with: YAMLEncoder.Options(floatingPointNumberFormatStrategy: .decimal),
                         expectedYAML: "3.141592653\n")
     }
 
     func testDecimalDoubleStyle() throws {
         _testRoundTrip(of: Double(6.8),
-                        with: YAMLEncoder.Options(numberFormatStrategy: .init(style: .decimal)),
+                        with: YAMLEncoder.Options(floatingPointNumberFormatStrategy: .decimal),
                         expectedYAML: "6.8\n")
     }
 
     func testDecimalFloatStyle() throws {
         _testRoundTrip(of: Float(6.8),
-                        with: YAMLEncoder.Options(numberFormatStrategy: .init(style: .decimal)),
+                        with: YAMLEncoder.Options(floatingPointNumberFormatStrategy: .decimal),
                         expectedYAML: "6.8\n")
     }
 
     func testMinimumFractionDigits() throws {
         _testRoundTrip(of: Double(6.0),
-                    with: YAMLEncoder.Options(numberFormatStrategy: .init(style: .decimal, doubleMaximumSignificantDigits: 1)),
-                    expectedYAML: "6\n")
+                    with: YAMLEncoder.Options(floatingPointNumberFormatStrategy: .decimal),
+                    expectedYAML: "6.0\n")
     }
 
     func testDecimalDoubleGreatestFiniteMagnitude() throws {
         _testRoundTrip(of: Double.greatestFiniteMagnitude,
-                        with: YAMLEncoder.Options(numberFormatStrategy: .init(style: .decimal)),
+                        with: YAMLEncoder.Options(floatingPointNumberFormatStrategy: .decimal),
                         expectedYAML: "1.7976931348623157e+308\n")
     }
 
     func testDecimalDoubleNegativeGreatestFiniteMagnitude() throws {
         _testRoundTrip(of: -Double.greatestFiniteMagnitude,
-                        with: YAMLEncoder.Options(numberFormatStrategy: .init(style: .decimal)),
+                        with: YAMLEncoder.Options(floatingPointNumberFormatStrategy: .decimal),
                         expectedYAML: "-1.7976931348623157e+308\n")
     }
 
     func testDecimalFloatGreatestFiniteMagnitude() throws {
         _testRoundTrip(of: Float.greatestFiniteMagnitude,
-                        with: YAMLEncoder.Options(numberFormatStrategy: .init(style: .decimal)),
-                        expectedYAML: "3.4028234663852886e+38\n")
+                        with: YAMLEncoder.Options(floatingPointNumberFormatStrategy: .decimal),
+                        expectedYAML: "3.4028235e+38\n")
+    }
+
+    func testDecimalDoubleNegativeInfinite() throws {
+        _testRoundTrip(of: -Double.infinity,
+                        with: YAMLEncoder.Options(floatingPointNumberFormatStrategy: .decimal),
+                        expectedYAML: "-.inf\n")
+    }
+
+    func testDecimalDoublePositiveInfinite() throws {
+        _testRoundTrip(of: Double.infinity,
+                        with: YAMLEncoder.Options(floatingPointNumberFormatStrategy: .decimal),
+                        expectedYAML: ".inf\n")
     }
 
     func testEncodingTopLevelSingleValueClass() {
@@ -520,6 +532,20 @@ where T: Codable, T: Equatable {
 }
 
 // MARK: - Helper Global Functions
+
+private func numberDecimalFormatter(with significantDigits: Int = 7) -> NumberFormatter {
+    let formatter = NumberFormatter()
+    formatter.locale = Locale(identifier: "en_US")
+    formatter.numberStyle = .decimal
+    formatter.usesSignificantDigits = true
+    formatter.maximumSignificantDigits = significantDigits
+    formatter.positiveInfinitySymbol = ".inf"
+    formatter.negativeInfinitySymbol = "-.inf"
+    formatter.notANumberSymbol = ".nan"
+    formatter.exponentSymbol = "e+"
+    return formatter
+}
+
 public func expectEqual<T: Equatable>(
     _ expected: T, _ actual: T,
     _ message: @autoclosure () -> String = "",

--- a/Tests/YamsTests/EncoderTests.swift
+++ b/Tests/YamsTests/EncoderTests.swift
@@ -14,6 +14,14 @@ import Yams
 
 /// Tests are copied from https://github.com/apple/swift/blob/main/test/stdlib/TestJSONEncoder.swift
 final class EncoderTests: XCTestCase, @unchecked Sendable { // swiftlint:disable:this type_body_length
+    private struct CustomScalar: ScalarRepresentable, YAMLEncodable {
+        let value: String
+
+        func represented() -> Node.Scalar {
+            return Node.Scalar(value)
+        }
+    }
+
     // MARK: - Encoding Top-Level Empty Types
     func testEncodingTopLevelEmptyStruct() {
         let empty = EmptyStruct()
@@ -39,6 +47,11 @@ final class EncoderTests: XCTestCase, @unchecked Sendable { // swiftlint:disable
         _testRoundTrip(of: Double(3.141592653),
                         with: YAMLEncoder.Options(floatingPointNumberFormatStrategy: .decimal),
                         expectedYAML: "3.141592653\n")
+    }
+
+    func testExistingScalarRepresentableConformanceStillEncodes() {
+        XCTAssertEqual(try Node(CustomScalar(value: "custom")), "custom")
+        XCTAssertEqual(try YAMLEncoder().encode(CustomScalar(value: "custom")), "custom\n")
     }
 
     func testDecimalDoubleStyle() throws {
@@ -87,6 +100,12 @@ final class EncoderTests: XCTestCase, @unchecked Sendable { // swiftlint:disable
         _testRoundTrip(of: Double.infinity,
                         with: YAMLEncoder.Options(floatingPointNumberFormatStrategy: .decimal),
                         expectedYAML: ".inf\n")
+    }
+
+    func testDecimalDoubleNaN() throws {
+        let encoder = YAMLEncoder()
+        encoder.options.floatingPointNumberFormatStrategy = .decimal
+        XCTAssertEqual(try encoder.encode(Double.nan), ".nan\n")
     }
 
     func testEncodingTopLevelSingleValueClass() {


### PR DESCRIPTION
Closes https://github.com/jpsim/Yams/issues/279

I modified PR by [zeionara](https://github.com/zeionara) - https://github.com/jpsim/Yams/pull/374

For my project https://github.com/AdaEngine/AdaEngine needs a human readable Floating Points values and I want to fix exponential values in yaml files.

I've add a tests for Float and Double, and I hope we merge this request. 

Thank you for your project!