### PR TITLE
Use an aspect hint instead of the `swift_module` tag

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -41,7 +41,7 @@ jobs:
   Linux:
     strategy:
       matrix:
-        tag: ['5.7', '5.8', '5.9', '5.10']
+        tag: ['6.0', '6.1', '6.2']
     runs-on: ubuntu-latest
     container:
       image: swift:${{ matrix.tag }}-focal

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -41,7 +41,7 @@ jobs:
   Linux:
     strategy:
       matrix:
-        tag: ['6.0', '6.1', '6.2']
+        tag: ['6.0', '6.1']
     runs-on: ubuntu-latest
     container:
       image: swift:${{ matrix.tag }}-focal

--- a/BUILD
+++ b/BUILD
@@ -7,11 +7,11 @@ cc_library(
         "Sources/CYaml/src/*.h",
     ]),
     hdrs = ["Sources/CYaml/include/yaml.h"],
+    aspect_hints = ["@build_bazel_rules_swift//swift:auto_module"],
     # Requires because of https://github.com/bazelbuild/bazel/pull/10143 otherwise host transition builds fail
     copts = ["-fPIC"],
     includes = ["Sources/CYaml/include"],
     linkstatic = True,
-    tags = ["swift_module"],
     visibility = ["//Tests:__subpackages__"],
 )
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -13,4 +13,4 @@ bazel_dep(
 )
 
 bazel_dep(name = "platforms", version = "0.0.9", dev_dependency = True)
-bazel_dep(name = "rules_apple", version = "3.5.1", dev_dependency = True)
+bazel_dep(name = "rules_apple", version = "4.1.2", dev_dependency = True)

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -5,7 +5,12 @@ module(
 )
 
 bazel_dep(name = "apple_support", version = "1.15.1")
-bazel_dep(name = "rules_swift", version = "1.18.0", repo_name = "build_bazel_rules_swift", max_compatibility_level = 3)
+bazel_dep(
+    name = "rules_swift",
+    version = "2.9.0",
+    repo_name = "build_bazel_rules_swift",
+    max_compatibility_level = 3,
+)
 
 bazel_dep(name = "platforms", version = "0.0.9", dev_dependency = True)
 bazel_dep(name = "rules_apple", version = "3.5.1", dev_dependency = True)


### PR DESCRIPTION
This is needed when using rules_swift 2.x+, otherwise inputs aren’t properly tracked and RBE doesn’t work.