### PR TITLE
Modify CYaml header includes for Swift C++ compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 ## Main
 
+##### Breaking
+
+* None.
+
+##### Enhancements
+
+* Increase compatibility with Swift C++ clients.  
+  [John Fairhurst](https://github.com/johnfairh)
+
+##### Bug Fixes
+
+* None
+
 ## 6.2.0
 
 ##### Breaking

--- a/Sources/CYaml/include/yaml.h
+++ b/Sources/CYaml/include/yaml.h
@@ -11,13 +11,13 @@
 #ifndef YAML_H
 #define YAML_H
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
  * @defgroup export Export Definitions


### PR DESCRIPTION
Moving a large Swift-C++ project to Xcode 26 / macOS 15 / arm  I hit this error in Xcode about CYaml/yaml.h:

<img width="1007" height="147" alt="Screenshot 2025-11-06 at 12 28 35" src="https://github.com/user-attachments/assets/f60ecd10-3922-4fdf-ae9d-4025f58a0f30" />

I found [this forum post](https://forums.swift.org/t/import-of-c-module-appears-within-extern-c-language-linkage-specification/65606/3) from one of the Apple Swift-C++ developers, made the suggested change, and my projects built again.