### PR TITLE
Work around a conflict between the _float and _Builtin_float modules in Swift 6.3's Musl SDK

### DIFF
--- a/Sources/Yams/Representer.swift
+++ b/Sources/Yams/Representer.swift
@@ -7,6 +7,10 @@
 //
 
 import Foundation
+#if canImport(Musl)
+// Workaround for conflict between _float and _Builtin_float in Musl SDK with Swift 6.3
+import var _float.DBL_DECIMAL_DIG
+#endif
 
 public extension Node {
     /// Initialize a `Node` with a value of `NodeRepresentable`.


### PR DESCRIPTION
Without this fix, the Swift 6.3 Musl SDK yields the following error when building Yams:
```
/Yams/Sources/Yams/Representer.swift:339:45: error: ambiguous use of 'DBL_DECIMAL_DIG'
336 |         // Since `NumberFormatter` creates a string with insufficient precision for Decode,
337 |         // it uses with `String(format:...)`
338 |         let string = String(format: "%.*g", DBL_DECIMAL_DIG, self)
    |                                             `- error: ambiguous use of 'DBL_DECIMAL_DIG'
339 |         // "%*.g" does not use scientific notation if the exponent is less than –4.
340 |         // So fallback to using `NumberFormatter` if string does not uses scientific notation.

_float.DBL_DECIMAL_DIG:1:12: note: found this candidate in module '_float'
1 | public var DBL_DECIMAL_DIG: Int32 { get }
  |            `- note: found this candidate in module '_float'

_Builtin_float.DBL_DECIMAL_DIG:1:12: note: found this candidate in module '_Builtin_float'
1 | public var DBL_DECIMAL_DIG: Int32 { get }
  |            `- note: found this candidate in module '_Builtin_float'
```
This workaround explicitly pulls the `_float` module's version into the file's ambient namespace, resolving the ambiguity. This is presumably an upstream bug in Swift itself; I'll be filing an issue upstream next.