### PR TITLE
Refresh CI runner and toolchain matrix

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -35,7 +35,7 @@ jobs:
   macOS:
     runs-on: macos-14
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
       - name: Apple tests
         run: bazelisk test //Tests/...
   Linux:
@@ -46,7 +46,7 @@ jobs:
     container:
       image: swift:${{ matrix.tag }}-focal
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
       - uses: bazelbuild/setup-bazelisk@v3
       - name: Yams tests
         run: bazel test --test_output=all //Tests:UnitTests

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -30,12 +30,16 @@ jobs:
     name: macOS with Xcode ${{ matrix.xcode_version }}
     strategy:
       matrix:
-        xcode_version: ['15.0', '15.4']
-    runs-on: macos-14
+        include:
+          - runner: macos-14
+            xcode_version: '15.4'
+          - runner: macos-26
+            xcode_version: '26.5'
+    runs-on: ${{ matrix.runner }}
     env:
       DEVELOPER_DIR: /Applications/Xcode_${{ matrix.xcode_version }}.app
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
       - run: sudo chown runner:admin /usr/local
       - run: |
           # macOS GHA runners have an issue with the version of cmake installed by defaut from the pinned tap
@@ -55,7 +59,7 @@ jobs:
       - run: cmake -B build -G Ninja -S . -DCMAKE_BUILD_TYPE=Release
       - run: cmake --build build
       - run: cmake --build build --target install
-      - run: file /usr/local/lib/swift/macosx/libYams.dylib | grep "Mach-O 64-bit dynamically linked shared library arm64"
+      - run: file /usr/local/lib/swift/macosx/libYams.dylib | grep "Mach-O 64-bit dynamically linked shared library"
 
   CMake_Linux:
     name: Linux with Swift ${{ matrix.tag }}
@@ -66,7 +70,7 @@ jobs:
     container:
       image: swift:${{ matrix.tag }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
       - run: apt-get update && apt-get install -y ninja-build curl
       - run: curl -L https://github.com/Kitware/CMake/releases/download/v3.23.1/cmake-3.23.1-linux-x86_64.tar.gz | tar xz --strip-components=1 -C /usr
       - run: swift -version

--- a/.github/workflows/jazzy.yml
+++ b/.github/workflows/jazzy.yml
@@ -31,13 +31,13 @@ jobs:
     env:
       DEVELOPER_DIR: /Applications/Xcode_15.4.app
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
       - name: Install SourceKitten
         run: brew install sourcekitten
       - run: swift build
       - name: Generate documentation json
         run: sourcekitten doc --spm --module-name Yams > yams.json
-      - uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby@v1.310.0
         with:
           ruby-version: 3.3.3
           bundler-cache: true
@@ -51,7 +51,7 @@ jobs:
             exit 1
           fi
       - name: Upload Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: API Docs
           path: docs

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -33,7 +33,7 @@ jobs:
     container:
       image: swiftlang/swift:nightly
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
       - run: swift --version
       - run: YAMS_DEFAULT_ENCODING=UTF16 swift test --parallel
       - run: YAMS_DEFAULT_ENCODING=UTF8 swift test --parallel

--- a/.github/workflows/swiftlint.yml
+++ b/.github/workflows/swiftlint.yml
@@ -17,6 +17,6 @@ jobs:
     container:
       image: ghcr.io/realm/swiftlint:0.54.0
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
       - name: SwiftLint
         run: swiftlint lint --strict

--- a/.github/workflows/swiftlint_analyze.yml
+++ b/.github/workflows/swiftlint_analyze.yml
@@ -27,7 +27,7 @@ jobs:
     env:
       DEVELOPER_DIR: /Applications/Xcode_15.4.app
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
       - name: Generate xcodebuild.log
         run: xcodebuild -sdk macosx -scheme Yams -project Yams.xcodeproj clean build-for-testing > xcodebuild.log
         shell: bash

--- a/.github/workflows/swiftpm.yml
+++ b/.github/workflows/swiftpm.yml
@@ -28,20 +28,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  Xcode_Ventura:
-    name: macOS 13 with Xcode ${{ matrix.xcode_version }}
-    strategy:
-      matrix:
-        xcode_version: ['14.3', '15.0']
-    runs-on: macos-13
-    env:
-      DEVELOPER_DIR: /Applications/Xcode_${{ matrix.xcode_version }}.app
-    steps:
-      - uses: actions/checkout@v4
-      - run: swift -version
-      - run: YAMS_DEFAULT_ENCODING=UTF16 swift test --parallel
-      - run: YAMS_DEFAULT_ENCODING=UTF8 swift test --parallel
-
   Xcode_Sonoma:
     name: macOS 14 with Xcode ${{ matrix.xcode_version }}
     strategy:
@@ -51,7 +37,7 @@ jobs:
     env:
       DEVELOPER_DIR: /Applications/Xcode_${{ matrix.xcode_version }}.app
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
       - run: swift -version
       - run: YAMS_DEFAULT_ENCODING=UTF16 swift test --parallel
       - run: YAMS_DEFAULT_ENCODING=UTF8 swift test --parallel
@@ -69,35 +55,39 @@ jobs:
     name: macOS 15 with Xcode ${{ matrix.xcode_version }}
     strategy:
       matrix:
-        xcode_version: ['16.0', '16.2', '16.3']
+        xcode_version: ['16.4']
     runs-on: macos-15
     env:
       DEVELOPER_DIR: /Applications/Xcode_${{ matrix.xcode_version }}.app
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
       - run: swift -version
       - run: YAMS_DEFAULT_ENCODING=UTF16 swift test --parallel
       - run: YAMS_DEFAULT_ENCODING=UTF8 swift test --parallel
-      - name: Code Coverage
-        if: matrix.xcode_version == '16.0'
-        run: |
-          swift test --enable-code-coverage
-          xcrun llvm-cov export -format="lcov" .build/debug/YamsPackageTests.xctest/Contents/MacOS/YamsPackageTests -instr-profile .build/debug/codecov/default.profdata > coverage.lcov
-          if [[ -n "${CODECOV_TOKEN}" ]]; then
-            bash <(curl -s https://codecov.io/bash) -f coverage.lcov
-          fi
-        env: { 'CODECOV_TOKEN': '${{ secrets.CODECOV_TOKEN }}' }
 
+  Xcode_Tahoe:
+    name: macOS 26 with Xcode ${{ matrix.xcode_version }}
+    strategy:
+      matrix:
+        xcode_version: ['26.5']
+    runs-on: macos-26
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_${{ matrix.xcode_version }}.app
+    steps:
+      - uses: actions/checkout@v6.0.2
+      - run: swift -version
+      - run: YAMS_DEFAULT_ENCODING=UTF16 swift test --parallel
+      - run: YAMS_DEFAULT_ENCODING=UTF8 swift test --parallel
   Linux:
     name: Linux with Swift ${{ matrix.tag }}
     strategy:
       matrix:
-        tag: ['5.7', '5.8', '5.9', '5.10', '6.0', '6.1']
+        tag: ['5.7', '5.8', '5.9', '5.10', '6.0', '6.1', '6.3.2']
     runs-on: ubuntu-latest
     container:
       image: swift:${{ matrix.tag }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
       - run: YAMS_DEFAULT_ENCODING=UTF16 swift test --parallel
       - run: YAMS_DEFAULT_ENCODING=UTF8 swift test --parallel
 
@@ -106,10 +96,10 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        swift_version: ['6.1', '6.2']
+        swift_version: ['6.2', '6.3.2']
     steps:
-      - uses: actions/checkout@v4
-      - uses: SwiftyLab/setup-swift@4bbb093f8c68d1dee1caa8b67c681a3f8fe70a91
+      - uses: actions/checkout@v6.0.2
+      - uses: SwiftyLab/setup-swift@v1.14.0
         with:
           swift-version: ${{ matrix.swift_version }}
       - name: Build
@@ -120,14 +110,14 @@ jobs:
     name: Android with Swift ${{ matrix.tag }}
     strategy:
       matrix:
-        tag: ['6.0.3']
+        tag: ['6.3.2']
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: skiptools/swift-android-action@v2
+      - uses: actions/checkout@v6.0.2
+      - uses: skiptools/swift-android-action@v2.9.4
         with:
           swift-version: ${{ matrix.tag }}
+          android-api-level: 35
           # needed for tests that use fixturesDirectory
           copy-files: Tests
           test-env: TEST_WORKSPACE=1
-

--- a/.github/workflows/xcodebuild.yml
+++ b/.github/workflows/xcodebuild.yml
@@ -24,39 +24,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  xcodebuild_Ventura:
-    name: macOS 13 with Xcode ${{ matrix.xcode_version }}
-    strategy:
-      matrix:
-        xcode_version: ['14.3', '15.0']
-        xcode_flags: ['-scheme Yams -project Yams.xcodeproj']
-    runs-on: macos-13
-    env:
-      DEVELOPER_DIR: /Applications/Xcode_${{ matrix.xcode_version }}.app
-    steps:
-      - uses: actions/checkout@v4
-      - run: xcodebuild -version
-      - name: macOS with UTF16
-        if: always()
-        run: set -o pipefail && YAMS_DEFAULT_ENCODING=UTF16 xcodebuild ${{ matrix.xcode_flags }} test | xcbeautify --renderer github-actions
-        shell: bash
-      - name: macOS with UTF8
-        if: always()
-        run: set -o pipefail && YAMS_DEFAULT_ENCODING=UTF8 xcodebuild ${{ matrix.xcode_flags }} test | xcbeautify --renderer github-actions
-        shell: bash
-      - name: iPhone Simulator
-        if: always()
-        run: set -o pipefail && xcodebuild ${{ matrix.xcode_flags }} test -sdk iphonesimulator -destination "name=iPhone 8" | xcbeautify --renderer github-actions
-        shell: bash
-      - name: Apple TV Simulator
-        if: always()
-        run: set -o pipefail && xcodebuild ${{ matrix.xcode_flags }} test -sdk appletvsimulator -destination "name=Apple TV 4K (2nd generation)" | xcbeautify --renderer github-actions
-        shell: bash
-      - name: watchOS Simulator
-        if: always()
-        run: set -o pipefail && xcodebuild ${{ matrix.xcode_flags }} build -sdk watchsimulator | xcbeautify --renderer github-actions
-        shell: bash
-
   xcodebuild_Sonoma:
     name: macOS 14 with Xcode ${{ matrix.xcode_version }}
     strategy:
@@ -67,7 +34,7 @@ jobs:
     env:
       DEVELOPER_DIR: /Applications/Xcode_${{ matrix.xcode_version }}.app
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
       - run: xcodebuild -version
       - name: macOS with UTF16
         if: always()
@@ -97,13 +64,13 @@ jobs:
     name: macOS 15 with Xcode ${{ matrix.xcode_version }}
     strategy:
       matrix:
-        xcode_version: ['16.0', '16.2', '16.3']
+        xcode_version: ['16.4']
         xcode_flags: ['-scheme Yams -project Yams.xcodeproj']
     runs-on: macos-15
     env:
       DEVELOPER_DIR: /Applications/Xcode_${{ matrix.xcode_version }}.app
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
       - run: xcodebuild -version
       - name: macOS with UTF16
         if: always()


### PR DESCRIPTION
`macos-13` no longer receives GitHub-hosted runners, which leaves
those jobs queued indefinitely. Drop that obsolete lane and collapse
the macOS matrix to the still-supported Xcode versions that provide
old and current coverage.

Update the Android smoke test from `Swift 6.0.3` to `Swift 6.3.2`
and run it on Android API 35. The previous job built successfully but
failed when the emulator linker tried to launch the test executable.

Add `Swift 6.3.2` to Linux and Windows SwiftPM coverage so CI
exercises the current stable Swift toolchain without adding another
heavy macOS simulator lane.

Add Xcode `26.5` coverage through a SwiftPM `macos-26` lane and a
CMake `macos-26` lane. Keep xcodebuild on established simulator
coverage until the newer runner proves stable.

Refresh action pins for checkout, Windows Swift setup, Android Swift,
Ruby setup, and artifact upload to current released tags.

Remove low-value duplicate jobs, including extra Xcode point-release
lanes, duplicate SwiftPM coverage, the older Windows Swift lane, and
the redundant CMake macOS Xcode lane.
