### PR TITLE
Migrate BCR publishing to reusable workflow

### DIFF
--- a/.bcr/source.template.json
+++ b/.bcr/source.template.json
@@ -1,5 +1,5 @@
 {
-    "url": "https://github.com/jpsim/Yams/archive/refs/tags/{TAG}.tar.gz",
+    "url": "https://github.com/jpsim/Yams/releases/download/{TAG}/Yams-{TAG}.tar.gz",
     "integrity": "",
     "strip_prefix": "Yams-{TAG}"
 }

--- a/.github/workflows/publish-to-bcr.yml
+++ b/.github/workflows/publish-to-bcr.yml
@@ -1,0 +1,28 @@
+name: Publish to BCR
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: The release tag to publish to BCR
+        required: true
+        type: string
+
+concurrency:
+  group: publish-to-bcr-${{ github.event.release.tag_name || inputs.tag_name }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    uses: bazel-contrib/publish-to-bcr/.github/workflows/publish.yaml@v1.2.0
+    with:
+      tag_name: ${{ github.event.release.tag_name || inputs.tag_name }}
+      registry_fork: jpsim/bazel-central-registry
+      attest: false
+      download_default_release_artifacts: false
+    permissions:
+      contents: write
+    secrets:
+      publish_token: ${{ secrets.BCR_PUBLISH_TOKEN }}


### PR DESCRIPTION
The Publish to BCR GitHub App is being discontinued after June 30,
2026. Add the reusable workflow entry point and point the BCR source
template at the uploaded release tarball format used by existing BCR
submissions.
